### PR TITLE
design fixes

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -255,6 +255,7 @@ cursor div {
 
     top: -85px !important;
     left: -34px !important;
+    padding-bottom: 0 !important;
 }
 
 cursor img {
@@ -285,3 +286,13 @@ cursor div:after {
     left: 43%;
 }
 
+
+editinfo > div.editInfoMarker {
+    width: 3px;
+    border-radius: 0;
+    box-shadow: 0 0 0 #fff;
+}
+
+editinfo > div.editInfoMarker:hover {
+    box-shadow: 0 0 1px rgba(0, 0, 0, 1);
+}


### PR DESCRIPTION
remove too much buttom padding
Old: 
![with-padding](https://f.cloud.github.com/assets/245432/1155711/9f40b744-1f75-11e3-89b2-6895d962870a.png)
New: 
![without-padding](https://f.cloud.github.com/assets/245432/1155712/a0d291a4-1f75-11e3-9b3d-879852e45851.png)

make line editor indicators unugly (no border radius)
![new-line-markers](https://f.cloud.github.com/assets/245432/1155721/d17f3122-1f75-11e3-8178-3fbdadf7293f.png)

That are just dirty fixes, because the styles are applied by the JS code (it would be great if this is could be moved to CSS rules only - separation of concerns, easier to fix design issues without diving into code, etc.)

Feel free to move those changes, whereever you want.

@jancborchardt Opinion?
