### PR TITLE
Sync with webodf 379ba3bfff4a7d736109f48c8ab72ea649a77918

### DIFF
--- a/js/3rdparty/webodf/dojo-amalgamation.js
+++ b/js/3rdparty/webodf/dojo-amalgamation.js
@@ -661,7 +661,7 @@ a;this._set("title",a)},postCreate:function(){this.inherited(arguments);this.con
 "-"+c];j.replace(this.domNode,a,this._currentOrientClass||"");this._currentOrientClass=a},focus:function(){this._getFocusItems(this.containerNode);g.focus(this._firstFocusItem)},onOpen:function(a){this.orient(this.domNode,a.aroundCorner,a.corner);var b=a.aroundNodePos;if("M"==a.corner.charAt(0)&&"M"==a.aroundCorner.charAt(0))this.connectorNode.style.top=b.y+(b.h-this.connectorNode.offsetHeight>>1)-a.y+"px",this.connectorNode.style.left="";else if("M"==a.corner.charAt(1)&&"M"==a.aroundCorner.charAt(1))this.connectorNode.style.left=
 b.x+(b.w-this.connectorNode.offsetWidth>>1)-a.x+"px";this._onShow()},onClose:function(){this.onHide()},_onKey:function(a){var b=a.target;a.charOrCode===l.TAB&&this._getFocusItems(this.containerNode);var c=this._firstFocusItem==this._lastFocusItem;a.charOrCode==l.ESCAPE?(this.defer("onCancel"),i.stop(a)):b==this._firstFocusItem&&a.shiftKey&&a.charOrCode===l.TAB?(c||g.focus(this._lastFocusItem),i.stop(a)):b==this._lastFocusItem&&a.charOrCode===l.TAB&&!a.shiftKey?(c||g.focus(this._firstFocusItem),i.stop(a)):
 a.charOrCode===l.TAB&&a.stopPropagation()}})})},"url:dijit/templates/TooltipDialog.html":'<div role="presentation" tabIndex="-1">\n\t<div class="dijitTooltipContainer" role="presentation">\n\t\t<div class ="dijitTooltipContents dijitTooltipFocusNode" data-dojo-attach-point="containerNode" role="dialog"></div>\n\t</div>\n\t<div class="dijitTooltipConnector" role="presentation" data-dojo-attach-point="connectorNode"></div>\n</div>\n',"*now":function(e){e(['dojo/i18n!*preload*dojo/nls/dojo*["ar","ca","cs","da","de","el","en-gb","en-us","es-es","fi-fi","fr-fr","he-il","hu","it-it","ja-jp","ko-kr","nl-nl","nb","pl","pt-br","pt-pt","ru","sk","sl","sv","th","tr","zh-tw","zh-cn","ROOT"]'])}}});
-// START OF nls/dojobundle.js
+// START OF dojobundle.js
 /* START OF NLS BUNDLE ENTRY [dojo-deps/dist/dijit/_editor/nls/FontChoice.js] */
 //>>built
 define("dijit/_editor/nls/FontChoice",{root:{fontSize:"Size",fontName:"Font",formatBlock:"Format",serif:"serif","sans-serif":"sans-serif",monospace:"monospace",cursive:"cursive",fantasy:"fantasy",noFormat:"None",p:"Paragraph",h1:"Heading",h2:"Subheading",h3:"Sub-subheading",pre:"Pre-formatted",1:"xx-small",2:"x-small",3:"small",4:"medium",5:"large",6:"x-large",7:"xx-large"},zh:!0,"zh-tw":!0,tr:!0,th:!0,sv:!0,sl:!0,sk:!0,ru:!0,ro:!0,pt:!0,"pt-pt":!0,pl:!0,nl:!0,nb:!0,ko:!0,kk:!0,ja:!0,it:!0,hu:!0,
@@ -1706,6 +1706,6 @@ define("dojox/widget/nls/ru/FilePicker",{name:"\u0418\u043c\u044f",path:"\u041f\
 define("dojox/widget/nls/ru/Wizard",{next:"\u0414\u0430\u043b\u0435\u0435",previous:"\u041d\u0430\u0437\u0430\u0434",done:"\u0413\u043e\u0442\u043e\u0432\u043e"});
 /* END OF NLS BUNDLE ENTRY [dojo-deps/dist/dojox/widget/nls/ru/Wizard.js] */
 
-// END OF nls/dojobundle.js
+// END OF dojobundle.js
 
 (function(){var e=this.require;e({cache:{}});!e.async&&e(["dojo"]);e.boot&&e.apply(null,e.boot)})();

--- a/js/3rdparty/webodf/editor/MemberListView.js
+++ b/js/3rdparty/webodf/editor/MemberListView.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define,runtime */

--- a/js/3rdparty/webodf/editor/nls/de/myResources.js
+++ b/js/3rdparty/webodf/editor/nls/de/myResources.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 define({

--- a/js/3rdparty/webodf/editor/nls/myResources.js
+++ b/js/3rdparty/webodf/editor/nls/myResources.js
@@ -9,6 +9,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -29,7 +32,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 define({
     root: {
@@ -91,7 +94,8 @@ define({
         color: "Color",
         text: "Text",
         background: "Background",
-        defaultStyle: "Default Style"
+        defaultStyle: "Default Style",
+        insertImage: "Insert Image"
     },
 
     de: true,

--- a/js/3rdparty/webodf/editor/nls/ru/myResources.js
+++ b/js/3rdparty/webodf/editor/nls/ru/myResources.js
@@ -9,6 +9,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -29,7 +32,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 define({
     file: 'досье',

--- a/js/3rdparty/webodf/editor/server/ServerFactory.js
+++ b/js/3rdparty/webodf/editor/server/ServerFactory.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global ops, SessionList*/
@@ -38,7 +41,7 @@
 /**
  * @interface
  */
-ServerFactory = function Server() {"use strict"; };
+function ServerFactory() {"use strict"; };
 
 /**
  * @return {!ops.Server}

--- a/js/3rdparty/webodf/editor/server/owncloud/ServerFactory.js
+++ b/js/3rdparty/webodf/editor/server/owncloud/ServerFactory.js
@@ -3,34 +3,24 @@
  * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ * This file is part of WebODF.
  *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * As a special exception to the AGPL, any HTML file which merely makes function
- * calls to this code, and for that purpose includes it by reference shall be
- * deemed a separate work for copyright law purposes. In addition, the copyright
- * holders of this code give you permission to combine this code with free
- * software libraries that are released under the GNU LGPL. You may copy and
- * distribute such a system following the terms of the GNU AGPL for this code
- * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * This license applies to this entire compilation.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  * @licend
+ *
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define, require, OC*/

--- a/js/3rdparty/webodf/editor/server/pullbox/MemberModel.js
+++ b/js/3rdparty/webodf/editor/server/pullbox/MemberModel.js
@@ -3,34 +3,24 @@
  * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ * This file is part of WebODF.
  *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * As a special exception to the AGPL, any HTML file which merely makes function
- * calls to this code, and for that purpose includes it by reference shall be
- * deemed a separate work for copyright law purposes. In addition, the copyright
- * holders of this code give you permission to combine this code with free
- * software libraries that are released under the GNU LGPL. You may copy and
- * distribute such a system following the terms of the GNU AGPL for this code
- * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * This license applies to this entire compilation.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  * @licend
+ *
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global runtime, ops*/

--- a/js/3rdparty/webodf/editor/server/pullbox/Server.js
+++ b/js/3rdparty/webodf/editor/server/pullbox/Server.js
@@ -3,34 +3,24 @@
  * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ * This file is part of WebODF.
  *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * As a special exception to the AGPL, any HTML file which merely makes function
- * calls to this code, and for that purpose includes it by reference shall be
- * deemed a separate work for copyright law purposes. In addition, the copyright
- * holders of this code give you permission to combine this code with free
- * software libraries that are released under the GNU LGPL. You may copy and
- * distribute such a system following the terms of the GNU AGPL for this code
- * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * This license applies to this entire compilation.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  * @licend
+ *
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global XMLHttpRequest, runtime, core, ops*/

--- a/js/3rdparty/webodf/editor/server/pullbox/ServerFactory.js
+++ b/js/3rdparty/webodf/editor/server/pullbox/ServerFactory.js
@@ -3,34 +3,24 @@
  * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ * This file is part of WebODF.
  *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * As a special exception to the AGPL, any HTML file which merely makes function
- * calls to this code, and for that purpose includes it by reference shall be
- * deemed a separate work for copyright law purposes. In addition, the copyright
- * holders of this code give you permission to combine this code with free
- * software libraries that are released under the GNU LGPL. You may copy and
- * distribute such a system following the terms of the GNU AGPL for this code
- * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * This license applies to this entire compilation.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  * @licend
+ *
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define, document, require, runtime, ops */

--- a/js/3rdparty/webodf/editor/server/pullbox/SessionList.js
+++ b/js/3rdparty/webodf/editor/server/pullbox/SessionList.js
@@ -3,34 +3,24 @@
  * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
  *
  * @licstart
- * The JavaScript code in this page is free software: you can redistribute it
- * and/or modify it under the terms of the GNU Affero General Public License
- * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.  The code is distributed
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ * This file is part of WebODF.
  *
- * As additional permission under GNU AGPL version 3 section 7, you
- * may distribute non-source (e.g., minimized or compacted) forms of
- * that code without the copy of the GNU GPL normally required by
- * section 4, provided you include this license notice and a URL
- * through which recipients can access the Corresponding Source.
+ * WebODF is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License (GNU AGPL)
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
  *
- * As a special exception to the AGPL, any HTML file which merely makes function
- * calls to this code, and for that purpose includes it by reference shall be
- * deemed a separate work for copyright law purposes. In addition, the copyright
- * holders of this code give you permission to combine this code with free
- * software libraries that are released under the GNU LGPL. You may copy and
- * distribute such a system following the terms of the GNU AGPL for this code
- * and the LGPL for the libraries. If you modify this code, you may extend this
- * exception to your version of the code, but you are not obligated to do so.
- * If you do not wish to do so, delete this exception statement from your
- * version.
+ * WebODF is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- * This license applies to this entire compilation.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  * @licend
+ *
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define, ops, runtime */

--- a/js/3rdparty/webodf/editor/widgets/annotation.js
+++ b/js/3rdparty/webodf/editor/widgets/annotation.js
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ *
+ * @licstart
+ * The JavaScript code in this page is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.  The code is distributed
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As additional permission under GNU AGPL version 3 section 7, you
+ * may distribute non-source (e.g., minimized or compacted) forms of
+ * that code without the copy of the GNU GPL normally required by
+ * section 4, provided you include this license notice and a URL
+ * through which recipients can access the Corresponding Source.
+ *
+ * As a special exception to the AGPL, any HTML file which merely makes function
+ * calls to this code, and for that purpose includes it by reference shall be
+ * deemed a separate work for copyright law purposes. In addition, the copyright
+ * holders of this code give you permission to combine this code with free
+ * software libraries that are released under the GNU LGPL. You may copy and
+ * distribute such a system following the terms of the GNU AGPL for this code
+ * and the LGPL for the libraries. If you modify this code, you may extend this
+ * exception to your version of the code, but you are not obligated to do so.
+ * If you do not wish to do so, delete this exception statement from your
+ * version.
+ *
+ * This license applies to this entire compilation.
+ * @licend
+ * @source: http://www.webodf.org/
+ * @source: https://github.com/kogmbh/WebODF/
+ */
+
+/*global define, require */
+
+define("webodf/editor/widgets/annotation", [
+    "dijit/form/Button"],
+
+    function (Button) {
+        "use strict";
+
+        var AnnotationControl = function (callback) {
+            var self = this,
+                widget = {},
+                addAnnotationButton,
+                annotationManager;
+
+
+            addAnnotationButton = new Button({
+                label: runtime.tr('Annotate'),
+                disabled: true,
+                showLabel: false,
+                iconClass: 'dijitIconBookmark',
+                onClick: function () {
+                    if (annotationManager) {
+                        annotationManager.addAnnotation();
+                        self.onToolDone();
+                    }
+                }
+            });
+
+            widget.children = [addAnnotationButton];
+            widget.startup = function () {
+                widget.children.forEach(function (element) {
+                    element.startup();
+                });
+            };
+
+            widget.placeAt = function (container) {
+                widget.children.forEach(function (element) {
+                    element.placeAt(container);
+                });
+                return widget;
+            };
+
+            function onAnnotatableChanged(isAnnotatable) {
+                addAnnotationButton.setAttribute('disabled', !isAnnotatable);
+            }
+
+            this.setEditorSession = function (session) {
+                if (annotationManager) {
+                    annotationManager.unsubscribe(gui.AnnotationManager.annotatableChanged, onAnnotatableChanged);
+                }
+                annotationManager = session && session.sessionController.getAnnotationManager();
+                if (annotationManager) {
+                    annotationManager.subscribe(gui.AnnotationManager.annotatableChanged, onAnnotatableChanged);
+                }
+                onAnnotatableChanged(annotationManager && annotationManager.isAnnotatable());
+            };
+
+            this.onToolDone = function () {};
+
+            callback(widget);
+        };
+
+        return AnnotationControl;
+    }
+);

--- a/js/3rdparty/webodf/editor/widgets/dialogWidgets/alignmentPane.html
+++ b/js/3rdparty/webodf/editor/widgets/dialogWidgets/alignmentPane.html
@@ -4,22 +4,22 @@
 		<body>
             <div data-dojo-type="dijit/form/Form" id="alignmentPaneForm" data-dojo-id="alignmentPaneForm">
 
-				<h3 text-i18n="options">Options</h3>
+				<h3 text-i18n="Options">Options</h3>
 
 			    <input type="radio" data-dojo-type="dijit/form/RadioButton" name="textAlign" id="radioLeft" checked value="left"/>
-			    <label text-i18n="left" for="radioLeft">Left</label> <br/>
+			    <label text-i18n="Left" for="radioLeft"></label> <br/>
 			    <input type="radio" data-dojo-type="dijit/form/RadioButton" name="textAlign" id="radioCenter" value="center"/>
-			    <label text-i18n="center" for="radioCenter">Center</label> <br/>
+			    <label text-i18n="Center" for="radioCenter"></label> <br/>
 			    <input type="radio" data-dojo-type="dijit/form/RadioButton" name="textAlign" id="radioRight" value="right"/>
-			    <label text-i18n="right" for="radioRight">Right</label> <br/>
+			    <label text-i18n="Right" for="radioRight"></label> <br/>
 			    <input type="radio" data-dojo-type="dijit/form/RadioButton" name="textAlign" id="radioJustified" value="justify"/>
-			    <label text-i18n="justified" for="radioJustified">Justified</label> <br/>
+			    <label text-i18n="Justified" for="radioJustified"></label> <br/>
 				
-				<h3><span text-i18n="spacing">Spacing</span> <small>(mm)</small></h3>
+				<h3><span text-i18n="Spacing"></span> <small>(mm)</small></h3>
 
 				<div style = "margin-top: 10px;">
 					<div style = "float: right; margin-right: 200px;">
-						<label text-i18n="top" for="topMargin">Top</label>
+						<label text-i18n="Top" for="topMargin"></label>
 						<input data-dojo-type="dijit/form/NumberSpinner" id="topMargin"
 					    value="0"
 					    data-dojo-props="smallDelta:1, constraints:{min:0,max:100}"
@@ -28,7 +28,7 @@
 					</div>
                     <br><br>
 					<div style = "float: left;">
-						<label text-i18n="left" for="leftMargin">Left</label>
+						<label text-i18n="Left" for="leftMargin"></label>
 						<input data-dojo-type="dijit/form/NumberSpinner" id="leftMargin"
 					    value="0"
 					    data-dojo-props="smallDelta:1, constraints:{min:0,max:100}"
@@ -36,7 +36,7 @@
 					    />
 					</div>
 					<div style = "float: right; margin-right: 50px;">
-					    <label text-i18n="right" for="rightMargin">Right</label>
+					    <label text-i18n="Right" for="rightMargin"></label>
 						<input data-dojo-type="dijit/form/NumberSpinner" id="rightMargin"
 					    value="0"
 					    data-dojo-props="smallDelta:1, constraints:{min:0,max:100}"
@@ -45,7 +45,7 @@
 					</div>
 					<br/><br>
 					<div style = "float: right; margin-right: 200px;">
-						<label text-i18n="bottom" for="bottomMargin">Bottom</label>
+						<label text-i18n="Bottom" for="bottomMargin"></label>
 						<input data-dojo-type="dijit/form/NumberSpinner" id="bottomMargin"
 					    value="0"
 					    data-dojo-props="smallDelta:1, constraints:{min:0,max:100}"

--- a/js/3rdparty/webodf/editor/widgets/dialogWidgets/alignmentPane.js
+++ b/js/3rdparty/webodf/editor/widgets/dialogWidgets/alignmentPane.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,10 +33,10 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global runtime,core,define,require,document,dijit */
+/*global runtime,core,define,require,dijit */
 
 runtime.loadClass("core.CSSUnits");
 
@@ -103,13 +106,13 @@ define("webodf/editor/widgets/dialogWidgets/alignmentPane", [], function () {
                 runtime.assert(editorBase, "webodf/editor path not defined in dojoConfig");
                 ready(function () {
                     contentPane = new ContentPane({
-                        title: document.translator("alignment"),
+                        title: runtime.tr("Alignment"),
                         href: editorBase+"/widgets/dialogWidgets/alignmentPane.html",
                         preload: true
                     });
                     contentPane.onLoad = function () {
                         form = dijit.byId('alignmentPaneForm');
-                        document.translateContent(form.domNode);
+                        runtime.translateContent(form.domNode);
                     };
                     return cb();
                 });

--- a/js/3rdparty/webodf/editor/widgets/dialogWidgets/fontEffectsPane.html
+++ b/js/3rdparty/webodf/editor/widgets/dialogWidgets/fontEffectsPane.html
@@ -4,23 +4,23 @@
 		<body>
             <div data-dojo-type="dijit/form/Form" id="fontEffectsPaneForm" data-dojo-id="fontEffectsPaneForm">
 
-				<h3 text-i18n="style">Style</h3>
+				<h3 text-i18n="Style"></h3>
 
 			    <input data-dojo-type="dijit/form/CheckBox" name="textStyle" id="radioBold" value="bold"/>
-			    <label text-i18n="bold" for="radioBold">Bold</label> <br/>
+			    <label text-i18n="Bold" for="radioBold"></label> <br/>
 			    <input data-dojo-type="dijit/form/CheckBox" name="textStyle" id="radioItalic" value="italic"/>
-			    <label text-i18n="italic" for="radioItalic">Italic</label> <br/>
+			    <label text-i18n="Italic" for="radioItalic"></label> <br/>
 			    <input data-dojo-type="dijit/form/CheckBox" name="textStyle" id="radioUnderline" value="underline"/>
-			    <label text-i18n="underline" for="radioUnderline">Underline</label> <br/>
+			    <label text-i18n="Underline" for="radioUnderline"></label> <br/>
 
-			    <h3 text-i18n="font">Font</h3>
+			    <h3 text-i18n="Font"></h3>
                 <br>
 			    <div id = 'fontPicker' class="labeledSelect" style = "float: left;">
-                    <label text-i18n="family" for="fontName">Family:</label>
+                    <label text-i18n="Family" for="fontName"></label>
                 </div>
 
             	<div style = "float: left; margin-left: 30px;">
-					<label for="fontSize"><span text-i18n="size">Size</span> (pt) </label>
+					<label for="fontSize"><span text-i18n="Size"></span> (pt) </label>
 					<input data-dojo-type="dijit/form/NumberSpinner" id="fontSize"
 				    value="12"
 				    data-dojo-props="smallDelta:1, constraints:{min:6,max:96}"
@@ -29,13 +29,11 @@
 				</div>
 				<br /><br />
 
-				<h3 text-i18n="color">Color</h3>
+				<h3 text-i18n="Color"></h3>
                 <br>
                 <input data-dojo-type="dijit/form/TextBox" name = "color" id = "textColorTB" style="display: none;"/>
                 <div data-dojo-type="dijit/form/DropDownButton">
-				    <span><span text-i18n="text" id = "textColor">
-                        Text
-				    </span></span>
+				    <span><span text-i18n="Text" id = "textColor"></span></span>
 				    <div data-dojo-type="dijit/TooltipDialog">
                         <div data-dojo-type="dojox.widget.ColorPicker" id="textColorPicker"></div>
 				    </div>
@@ -43,9 +41,7 @@
 
                 <input data-dojo-type="dijit/form/TextBox" name = "backgroundColor" id = "backgroundColorTB" style="display: none;"/>
 				<div data-dojo-type="dijit/form/DropDownButton">
-				    <span><span text-i18n="background" id = "backgroundColor">
-                        Background
-				    </span></span>
+				    <span><span text-i18n="Background" id = "backgroundColor"></span></span>
 				    <div data-dojo-type="dijit/TooltipDialog">
                         <div data-dojo-type="dojox.widget.ColorPicker" id="backgroundColorPicker"></div>
 					</div>

--- a/js/3rdparty/webodf/editor/widgets/dialogWidgets/fontEffectsPane.js
+++ b/js/3rdparty/webodf/editor/widgets/dialogWidgets/fontEffectsPane.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global runtime,define,require,document,dijit */
@@ -123,13 +126,12 @@ define("webodf/editor/widgets/dialogWidgets/fontEffectsPane", [], function () {
                 "dojox/widget/ColorPicker",
                 "webodf/editor/widgets/fontPicker"
             ], function (dojo, ready, domConstruct, ContentPane, ColorPicker, FontPicker) {
-                var translator = document.translator,
-                    editorBase = dojo.config && dojo.config.paths &&
+                var editorBase = dojo.config && dojo.config.paths &&
                             dojo.config.paths['webodf/editor'];
                 runtime.assert(editorBase, "webodf/editor path not defined in dojoConfig");
                 ready(function () {
                     contentPane = new ContentPane({
-                        title: translator("fontEffects"),
+                        title: runtime.tr("Font Effects"),
                         href: editorBase+"/widgets/dialogWidgets/fontEffectsPane.html",
                         preload: true
                     });
@@ -139,7 +141,7 @@ define("webodf/editor/widgets/dialogWidgets/fontEffectsPane", [], function () {
                             backgroundColorTB = dijit.byId('backgroundColorTB');
 
                         form = dijit.byId('fontEffectsPaneForm');
-                        document.translateContent(form.domNode);
+                        runtime.translateContent(form.domNode);
 
                         preview = document.getElementById('previewText');
                         textColorPicker = dijit.byId('textColorPicker');

--- a/js/3rdparty/webodf/editor/widgets/fontPicker.js
+++ b/js/3rdparty/webodf/editor/widgets/fontPicker.js
@@ -9,6 +9,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -29,7 +32,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 /*global define,require,document */
 define("webodf/editor/widgets/fontPicker", [

--- a/js/3rdparty/webodf/editor/widgets/imageInserter.js
+++ b/js/3rdparty/webodf/editor/widgets/imageInserter.js
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ *
+ * @licstart
+ * The JavaScript code in this page is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.  The code is distributed
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As additional permission under GNU AGPL version 3 section 7, you
+ * may distribute non-source (e.g., minimized or compacted) forms of
+ * that code without the copy of the GNU GPL normally required by
+ * section 4, provided you include this license notice and a URL
+ * through which recipients can access the Corresponding Source.
+ *
+ * As a special exception to the AGPL, any HTML file which merely makes function
+ * calls to this code, and for that purpose includes it by reference shall be
+ * deemed a separate work for copyright law purposes. In addition, the copyright
+ * holders of this code give you permission to combine this code with free
+ * software libraries that are released under the GNU LGPL. You may copy and
+ * distribute such a system following the terms of the GNU AGPL for this code
+ * and the LGPL for the libraries. If you modify this code, you may extend this
+ * exception to your version of the code, but you are not obligated to do so.
+ * If you do not wish to do so, delete this exception statement from your
+ * version.
+ *
+ * This license applies to this entire compilation.
+ * @licend
+ * @source: http://www.webodf.org/
+ * @source: https://github.com/kogmbh/WebODF/
+ */
+
+/*global define,require,document,Image,FileReader,window,runtime,ops */
+
+define("webodf/editor/widgets/imageInserter", [
+    "dijit/form/Button",
+    "webodf/editor/EditorSession"],
+
+    function (Button, EditorSession) {
+        "use strict";
+
+        var ImageInserter = function (callback) {
+            var self = this,
+                widget = {},
+                insertImageButton,
+                editorSession,
+                fileLoader;
+
+
+            /**
+             * @param {!string} content  as datauri
+             * @param {!string} mimetype
+             * @return {undefined}
+             */
+            function insertImageOnceLoaded(mimetype, content) {
+                var hiddenImage = new Image();
+
+                hiddenImage.style.position = "absolute";
+                hiddenImage.style.left = "-99999px";
+                document.body.appendChild(hiddenImage);
+                hiddenImage.onload = function () {
+                    // remove the data:image/jpg;base64, bit
+                    content = content.substring(content.indexOf(",") + 1);
+                    if (editorSession) {
+                        editorSession.insertImage(mimetype, content, hiddenImage.width, hiddenImage.height);
+                    }
+                    // clean up
+                    document.body.removeChild(hiddenImage);
+                    self.onToolDone();
+                };
+                hiddenImage.src = content;
+            }
+
+            function fileSelectHandler(evt) {
+                var file, files, reader;
+                files = (evt.target && evt.target.files) || (evt.dataTransfer && evt.dataTransfer.files);
+                if (files && files.length === 1) {
+                    file = files[0];
+                    reader = new FileReader();
+                    reader.onloadend = function () {
+                        if (reader.readyState === 2) {
+                            insertImageOnceLoaded(file.type, reader.result);
+                        } else {
+                            runtime.log("Image could not be loaded");
+                            self.onToolDone();
+                        }
+                    };
+                    reader.readAsDataURL(file);
+                }
+            }
+
+            function createFileLoader() {
+                var form = document.createElement("form"),
+                    input = document.createElement("input");
+                form.appendChild(input);
+                form.id = "imageForm";
+                form.style.display = "none";
+                input.id = "imageLoader";
+                input.setAttribute("type", "file");
+                input.setAttribute("accept", "image/*");
+                input.addEventListener("change", fileSelectHandler, false);
+                document.body.appendChild(form);
+                return {input: input, form: form};
+            }
+
+            insertImageButton = new Button({
+                label: runtime.tr("Insert Image"),
+                disabled: true,
+                showLabel: false,
+                iconClass: "dijitEditorIcon dijitEditorIconInsertImage",
+                onClick: function () {
+                    if (!fileLoader) {
+                        fileLoader = createFileLoader();
+                    }
+                    fileLoader.form.reset();
+                    fileLoader.input.click();
+                }
+            });
+
+            widget.children = [insertImageButton];
+            widget.startup = function () {
+                widget.children.forEach(function (element) {
+                    element.startup();
+                });
+            };
+
+            widget.placeAt = function (container) {
+                widget.children.forEach(function (element) {
+                    element.placeAt(container);
+                });
+                return widget;
+            };
+
+            function handleCursorMoved(cursor) {
+                var disabled = cursor.getSelectionType() === ops.OdtCursor.RegionSelection;
+                // LO/AOO pops up the picture/frame option dialog if image is selected when pressing the button
+                // Since we only support inline images, disable the button for now.
+                insertImageButton.setAttribute('disabled', disabled);
+            }
+
+            this.setEditorSession = function (session) {
+                if (editorSession) {
+                    editorSession.unsubscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
+                editorSession = session;
+                if (editorSession) {
+                    editorSession.subscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
+                widget.children.forEach(function (element) {
+                    element.setAttribute("disabled", !session);
+                });
+            };
+
+            this.onToolDone = function () {};
+
+            callback(widget);
+        };
+
+        return ImageInserter;
+    });

--- a/js/3rdparty/webodf/editor/widgets/paragraphAlignment.js
+++ b/js/3rdparty/webodf/editor/widgets/paragraphAlignment.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,20 +33,22 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global define,require,document */
+/*global define,require,ops,gui */
 
 define("webodf/editor/widgets/paragraphAlignment", [
     "dijit/form/ToggleButton",
-    "dijit/form/Button"],
+    "dijit/form/Button",
+    "webodf/editor/EditorSession"],
 
-    function (ToggleButton, Button) {
+    function (ToggleButton, Button, EditorSession) {
         "use strict";
 
         var ParagraphAlignment = function (callback) {
             var self = this,
+                editorSession,
                 widget = {},
                 directParagraphStyler,
                 justifyLeft,
@@ -54,7 +59,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
                 outdent;
 
             justifyLeft = new ToggleButton({
-                label: document.translator('justifyLeft'),
+                label: runtime.tr('Align Left'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -66,7 +71,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
             });
 
             justifyCenter = new ToggleButton({
-                label: document.translator('justifyCenter'),
+                label: runtime.tr('Center'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -78,7 +83,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
             });
 
             justifyRight = new ToggleButton({
-                label: document.translator('justifyRight'),
+                label: runtime.tr('Align Right'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -90,7 +95,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
             });
 
             justifyFull = new ToggleButton({
-                label: document.translator('justifyFull'),
+                label: runtime.tr('Justify'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -102,7 +107,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
             });
 
             outdent = new Button({
-                label: document.translator('outdent'),
+                label: runtime.tr('Decrease Indent'),
                 disabled: true,
                 showLabel: false,
                 iconClass: "dijitEditorIcon dijitEditorIconOutdent",
@@ -113,7 +118,7 @@ define("webodf/editor/widgets/paragraphAlignment", [
             });
 
             indent = new Button({
-                label: document.translator('indent'),
+                label: runtime.tr('Increase Indent'),
                 disabled: true,
                 showLabel: false,
                 iconClass: "dijitEditorIcon dijitEditorIconIndent",
@@ -161,7 +166,14 @@ define("webodf/editor/widgets/paragraphAlignment", [
                 });
             }
 
-            this.setEditorSession = function(session) {
+            function handleCursorMoved(cursor) {
+                var disabled = cursor.getSelectionType() === ops.OdtCursor.RegionSelection;
+                widget.children.forEach(function (element) {
+                    element.setAttribute('disabled', disabled);
+                });
+            }
+
+            this.setEditorSession = function (session) {
                 if (directParagraphStyler) {
                     directParagraphStyler.unsubscribe(gui.DirectParagraphStyler.paragraphStylingChanged, updateStyleButtons);
                 }
@@ -178,6 +190,14 @@ define("webodf/editor/widgets/paragraphAlignment", [
                     isAlignedRight:     directParagraphStyler ? directParagraphStyler.isAlignedRight() :     false,
                     isAlignedJustified: directParagraphStyler ? directParagraphStyler.isAlignedJustified() : false
                 });
+
+                if (editorSession) {
+                    editorSession.unsubscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
+                editorSession = session;
+                if (editorSession) {
+                    editorSession.subscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
             };
 
             this.onToolDone = function () {};

--- a/js/3rdparty/webodf/editor/widgets/paragraphStyles.js
+++ b/js/3rdparty/webodf/editor/widgets/paragraphStyles.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define,require */
@@ -38,7 +41,7 @@
 define("webodf/editor/widgets/paragraphStyles",
        ["webodf/editor/EditorSession"],
 
-   function (EditorSession) {
+    function (EditorSession) {
     "use strict";
     /**
      * @constructor
@@ -47,7 +50,6 @@ define("webodf/editor/widgets/paragraphStyles",
         var self = this,
             editorSession,
             select,
-            translator = document.translator,
             defaultStyleUIId = ":default";
 
         this.widget = function () {
@@ -90,7 +92,7 @@ define("webodf/editor/widgets/paragraphStyles",
 
             // Populate the Default Style always 
             selectionList = [{
-                label: translator("defaultStyle"),
+                label: runtime.tr("Default Style"),
                 value: defaultStyleUIId
             }];
             availableStyles = editorSession ? editorSession.getAvailableParagraphStyles() : [];
@@ -166,15 +168,24 @@ define("webodf/editor/widgets/paragraphStyles",
             });
         }
 
+        function handleCursorMoved(cursor) {
+            var disabled = cursor.getSelectionType() === ops.OdtCursor.RegionSelection;
+            if (select) {
+                select.setAttribute('disabled', disabled);
+            }
+        }
+
         this.setEditorSession = function(session) {
             if (editorSession) {
                 editorSession.unsubscribe(EditorSession.signalCommonStyleCreated, addStyle);
                 editorSession.unsubscribe(EditorSession.signalCommonStyleDeleted, removeStyle);
+                editorSession.unsubscribe(EditorSession.signalCursorMoved, handleCursorMoved);
             }
             editorSession = session;
             if (editorSession) {
                 editorSession.subscribe(EditorSession.signalCommonStyleCreated, addStyle);
                 editorSession.subscribe(EditorSession.signalCommonStyleDeleted, removeStyle);
+                editorSession.subscribe(EditorSession.signalCursorMoved, handleCursorMoved);
                 populateStyles();
             }
         };

--- a/js/3rdparty/webodf/editor/widgets/paragraphStylesDialog.js
+++ b/js/3rdparty/webodf/editor/widgets/paragraphStylesDialog.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,10 +33,10 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global define,require,document,dojo,dijit */
+/*global define,require,dojo,dijit */
 
 define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
     "use strict";
@@ -54,7 +57,7 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                 "dijit/form/DropDownButton",
                 "dijit/form/RadioButton"], function (Dialog, TooltipDialog, popup, TabContainer, ContentPane, Button, DropDownButton, RadioButton) {
                 var i,
-                    translator = document.translator,
+                    tr = runtime.tr,
                     tabContainer,
                     flowPane,
                     numberingPane,
@@ -179,17 +182,17 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                 }
                 // Dialog
                 dialog = new Dialog({
-                    title: translator("paragraphStyles")
+                    title: tr("Paragraph Styles")
                 });
 
                 cloneTooltip = new TooltipDialog({
                     content:
-                        '<h2 style="margin: 0;">'+translator("cloneThisStyle")+'</h2><br/>' +
-                        '<label for="name">'+translator("newName_C")+'</label> <input data-dojo-type="dijit/form/TextBox" id="name" name="name"><br/><br/>',
+                        '<h2 style="margin: 0;">'+tr("Clone this Style")+'</h2><br/>' +
+                        '<label for="name">'+tr("New Name:")+'</label> <input data-dojo-type="dijit/form/TextBox" id="name" name="name"><br/><br/>',
                     style: "width: 300px;"
                 });
                 cloneButton = new Button({
-                    label: translator("create"),
+                    label: tr("Create"),
                     onClick: function () {
                         cloneStyle(stylePicker.value(), cloneTooltip.get('value').name);
                         cloneTooltip.reset();
@@ -198,7 +201,7 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                 });
                 cloneTooltip.addChild(cloneButton);
                 cloneDropDown = new DropDownButton({
-                    label: translator("clone"),
+                    label: tr("Clone"),
                     showLabel: false,
                     iconClass: 'dijitEditorIcon dijitEditorIconCopy',
                     dropDown: cloneTooltip,
@@ -207,7 +210,7 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                 dialog.addChild(cloneDropDown, 1);
 
                 deleteButton = new Button({
-                    label: translator("delete"),
+                    label: tr("Delete"),
                     showLabel: false,
                     iconClass: 'dijitEditorIcon dijitEditorIconDelete',
                     style: "float: right; margin-bottom: 5px;",
@@ -227,11 +230,11 @@ define("webodf/editor/widgets/paragraphStylesDialog", [], function () {
                     "class": "dijitDialogPaneActionBar"
                 });
                 okButton = new dijit.form.Button({
-                    label: translator("ok"),
+                    label: tr("OK"),
                     onClick: accept
                 }).placeAt(actionBar);
                 cancelButton = new dijit.form.Button({
-                    label: translator("cancel"),
+                    label: tr("Cancel"),
                     onClick: cancel
                 }).placeAt(actionBar);
                 dialog.domNode.appendChild(actionBar);

--- a/js/3rdparty/webodf/editor/widgets/simpleStyles.js
+++ b/js/3rdparty/webodf/editor/widgets/simpleStyles.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,21 +33,23 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global define,require,document */
+/*global define,require,gui,ops */
 
 define("webodf/editor/widgets/simpleStyles", [
     "webodf/editor/widgets/fontPicker",
     "dijit/form/ToggleButton",
-    "dijit/form/NumberSpinner"],
+    "dijit/form/NumberSpinner",
+    "webodf/editor/EditorSession"],
 
-    function (FontPicker, ToggleButton, NumberSpinner) {
+    function (FontPicker, ToggleButton, NumberSpinner, EditorSession) {
         "use strict";
 
         var SimpleStyles = function(callback) {
             var self = this,
+                editorSession,
                 widget = {},
                 directTextStyler,
                 boldButton,
@@ -56,7 +61,7 @@ define("webodf/editor/widgets/simpleStyles", [
                 fontPickerWidget;
 
             boldButton = new ToggleButton({
-                label: document.translator('bold'),
+                label: runtime.tr('Bold'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -68,7 +73,7 @@ define("webodf/editor/widgets/simpleStyles", [
             });
 
             italicButton = new ToggleButton({
-                label: document.translator('italic'),
+                label: runtime.tr('Italic'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -80,7 +85,7 @@ define("webodf/editor/widgets/simpleStyles", [
             });
 
             underlineButton = new ToggleButton({
-                label: document.translator('underline'),
+                label: runtime.tr('Underline'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -92,7 +97,7 @@ define("webodf/editor/widgets/simpleStyles", [
             });
 
             strikethroughButton = new ToggleButton({
-                label: document.translator('strikethrough'),
+                label: runtime.tr('Strikethrough'),
                 disabled: true,
                 showLabel: false,
                 checked: false,
@@ -104,7 +109,7 @@ define("webodf/editor/widgets/simpleStyles", [
             });
 
             fontSizeSpinner = new NumberSpinner({
-                label: document.translator('size'),
+                label: runtime.tr('Size'),
                 disabled: true,
                 showLabel: false,
                 value: 12,
@@ -170,6 +175,13 @@ define("webodf/editor/widgets/simpleStyles", [
                 });
             }
 
+            function handleCursorMoved(cursor) {
+                var disabled = cursor.getSelectionType() === ops.OdtCursor.RegionSelection;
+                widget.children.forEach(function (element) {
+                    element.setAttribute('disabled', disabled);
+                });
+            }
+
             this.setEditorSession = function(session) {
                 if (directTextStyler) {
                     directTextStyler.unsubscribe(gui.DirectTextStyler.textStylingChanged, updateStyleButtons);
@@ -190,6 +202,14 @@ define("webodf/editor/widgets/simpleStyles", [
                     fontSize: directTextStyler ? directTextStyler.fontSize() : undefined,
                     fontName: directTextStyler ? directTextStyler.fontName() : undefined
                 });
+
+                if (editorSession) {
+                    editorSession.unsubscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
+                editorSession = session;
+                if (editorSession) {
+                    editorSession.subscribe(EditorSession.signalCursorMoved, handleCursorMoved);
+                }
             };
 
             this.onToolDone = function () {};

--- a/js/3rdparty/webodf/editor/widgets/toolbarWidgets/currentStyle.js
+++ b/js/3rdparty/webodf/editor/widgets/toolbarWidgets/currentStyle.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,7 +33,7 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
 /*global define, require */

--- a/js/3rdparty/webodf/editor/widgets/undoRedoMenu.js
+++ b/js/3rdparty/webodf/editor/widgets/undoRedoMenu.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,10 +33,10 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global define,require,document */
+/*global define,require*/
 
 define("webodf/editor/widgets/undoRedoMenu",
     ["webodf/editor/EditorSession"],
@@ -51,7 +54,7 @@ define("webodf/editor/widgets/undoRedoMenu",
                     var widget = {};
 
                     undoButton = new Button({
-                        label: document.translator('undo'),
+                        label: runtime.tr('Undo'),
                         showLabel: false,
                         disabled: true, // TODO: get current session state
                         iconClass: "dijitEditorIcon dijitEditorIconUndo",
@@ -63,7 +66,7 @@ define("webodf/editor/widgets/undoRedoMenu",
                     });
 
                     redoButton = new Button({
-                        label: document.translator('redo'),
+                        label: runtime.tr('Redo'),
                         showLabel: false,
                         disabled: true, // TODO: get current session state
                         iconClass: "dijitEditorIcon dijitEditorIconRedo",

--- a/js/3rdparty/webodf/editor/widgets/zoomSlider.js
+++ b/js/3rdparty/webodf/editor/widgets/zoomSlider.js
@@ -10,6 +10,9 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
  *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this code.  If not, see <http://www.gnu.org/licenses/>.
+ *
  * As additional permission under GNU AGPL version 3 section 7, you
  * may distribute non-source (e.g., minimized or compacted) forms of
  * that code without the copy of the GNU GPL normally required by
@@ -30,10 +33,10 @@
  * This license applies to this entire compilation.
  * @licend
  * @source: http://www.webodf.org/
- * @source: http://gitorious.org/webodf/webodf/
+ * @source: https://github.com/kogmbh/WebODF/
  */
 
-/*global define,require,document */
+/*global define,require*/
 
 define("webodf/editor/widgets/zoomSlider", [], function () {
     "use strict";

--- a/js/3rdparty/webodf/webodf-debug.js
+++ b/js/3rdparty/webodf/webodf-debug.js
@@ -11,6 +11,9 @@
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -31,7 +34,7 @@
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 var core = {};
 var gui = {};
@@ -948,7 +951,7 @@ var runtime = function() {
         }
         code = null;
         dir = dircontents[dir];
-        if(dir && dir.indexOf && dir.indexOf(path) !== -1) {
+        if(dir && (dir.indexOf && dir.indexOf(path) !== -1)) {
           return dirs[i] + "/" + path
         }
       }
@@ -986,6 +989,24 @@ var runtime = function() {
     }
     cache[classpath] = true
   }
+})();
+(function() {
+  var translator = function() {
+  };
+  function tr(original) {
+    var result = translator(original);
+    if(!result || String(typeof result) !== "string") {
+      return original
+    }
+    return result
+  }
+  runtime.getTranslator = function() {
+    return translator
+  };
+  runtime.setTranslator = function(translatorFunction) {
+    translator = translatorFunction
+  };
+  runtime.tr = tr
 })();
 (function(args) {
   if(args) {
@@ -1538,14 +1559,14 @@ core.RawDeflate = function() {
     }
     do {
       matchp = cur_match;
-      if(zip_window[matchp + best_len] !== scan_end || zip_window[matchp + best_len - 1] !== scan_end1 || zip_window[matchp] !== zip_window[scanp] || zip_window[++matchp] !== zip_window[scanp + 1]) {
+      if(zip_window[matchp + best_len] !== scan_end || (zip_window[matchp + best_len - 1] !== scan_end1 || (zip_window[matchp] !== zip_window[scanp] || zip_window[++matchp] !== zip_window[scanp + 1]))) {
         continue
       }
       scanp += 2;
       matchp++;
       do {
         ++scanp
-      }while(zip_window[scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && zip_window[++scanp] === zip_window[++matchp] && scanp < strendp);
+      }while(zip_window[scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && (zip_window[++scanp] === zip_window[++matchp] && scanp < strendp))))))));
       len = zip_MAX_MATCH - (strendp - scanp);
       scanp = strendp - zip_MAX_MATCH;
       if(len > best_len) {
@@ -2044,7 +2065,7 @@ core.RawDeflate = function() {
       zip_prev_length = zip_match_length;
       zip_prev_match = zip_match_start;
       zip_match_length = zip_MIN_MATCH - 1;
-      if(zip_hash_head !== zip_NIL && zip_prev_length < zip_max_lazy_match && zip_strstart - zip_hash_head <= zip_MAX_DIST) {
+      if(zip_hash_head !== zip_NIL && (zip_prev_length < zip_max_lazy_match && zip_strstart - zip_hash_head <= zip_MAX_DIST)) {
         zip_match_length = zip_longest_match(zip_hash_head);
         if(zip_match_length > zip_lookahead) {
           zip_match_length = zip_lookahead
@@ -2939,6 +2960,9 @@ core.RawInflate = function RawInflate() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -2959,7 +2983,7 @@ core.RawInflate = function RawInflate() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 core.LoopWatchDog = function LoopWatchDog(timeout, maxChecks) {
   var startTime = Date.now(), checks = 0;
@@ -3023,6 +3047,9 @@ core.Utils = function Utils() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -3043,184 +3070,237 @@ core.Utils = function Utils() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-core.DomUtils = function DomUtils() {
-  function findStablePoint(container, offset) {
-    if(offset < container.childNodes.length) {
-      container = container.childNodes[offset];
-      offset = 0;
-      while(container.firstChild) {
-        container = container.firstChild
-      }
-    }else {
-      while(container.lastChild) {
-        container = container.lastChild;
-        offset = container.nodeType === Node.TEXT_NODE ? container.textContent.length : container.childNodes.length
-      }
+(function() {
+  var rangeClientRectsBug;
+  function rangeClientRectsUntransformedBug(document) {
+    var range, directBoundingRect, rangeBoundingRect, testContainer, testElement;
+    if(rangeClientRectsBug === undefined) {
+      testContainer = document.createElement("div");
+      testContainer.style.position = "absolute";
+      testContainer.style.left = "-99999px";
+      testContainer.style.transform = "scale(2)";
+      testContainer.style["-webkit-transform"] = "scale(2)";
+      testElement = document.createElement("div");
+      testElement.style.width = "10px";
+      testElement.style.height = "10px";
+      testContainer.appendChild(testElement);
+      document.body.appendChild(testContainer);
+      range = testElement.ownerDocument.createRange();
+      directBoundingRect = testElement.getBoundingClientRect();
+      range.selectNode(testElement);
+      rangeBoundingRect = range.getBoundingClientRect();
+      rangeClientRectsBug = directBoundingRect.height !== rangeBoundingRect.height;
+      range.detach();
+      document.body.removeChild(testContainer)
     }
-    return{container:container, offset:offset}
+    return rangeClientRectsBug
   }
-  function splitBoundaries(range) {
-    var modifiedNodes = [], end, splitStart;
-    if(range.startContainer.nodeType === Node.TEXT_NODE || range.endContainer.nodeType === Node.TEXT_NODE) {
-      end = findStablePoint(range.endContainer, range.endOffset);
-      range.setEnd(end.container, end.offset);
-      if(range.endOffset !== 0 && range.endContainer.nodeType === Node.TEXT_NODE && range.endOffset !== range.endContainer.length) {
-        modifiedNodes.push(range.endContainer.splitText(range.endOffset));
-        modifiedNodes.push(range.endContainer)
-      }
-      if(range.startOffset !== 0 && range.startContainer.nodeType === Node.TEXT_NODE && range.startOffset !== range.startContainer.length) {
-        splitStart = range.startContainer.splitText(range.startOffset);
-        modifiedNodes.push(range.startContainer);
-        modifiedNodes.push(splitStart);
-        range.setStart(splitStart, 0)
-      }
-    }
-    return modifiedNodes
-  }
-  this.splitBoundaries = splitBoundaries;
-  function containsRange(container, insideRange) {
-    return container.compareBoundaryPoints(container.START_TO_START, insideRange) <= 0 && container.compareBoundaryPoints(container.END_TO_END, insideRange) >= 0
-  }
-  this.containsRange = containsRange;
-  function rangesIntersect(range1, range2) {
-    return range1.compareBoundaryPoints(range1.END_TO_START, range2) <= 0 && range1.compareBoundaryPoints(range1.START_TO_END, range2) >= 0
-  }
-  this.rangesIntersect = rangesIntersect;
-  function getNodesInRange(range, nodeFilter) {
-    var document = range.startContainer.ownerDocument, elements = [], root = (range.commonAncestorContainer), n, treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ALL, nodeFilter, false);
-    treeWalker.currentNode = range.startContainer;
-    n = range.startContainer;
-    while(n) {
-      if(nodeFilter(n) === NodeFilter.FILTER_ACCEPT) {
-        elements.push(n)
-      }else {
-        if(nodeFilter(n) === NodeFilter.FILTER_REJECT) {
-          break
-        }
-      }
-      n = n.parentNode
-    }
-    elements.reverse();
-    n = treeWalker.nextNode();
-    while(n) {
-      elements.push(n);
-      n = treeWalker.nextNode()
-    }
-    return elements
-  }
-  this.getNodesInRange = getNodesInRange;
-  function mergeTextNodes(node, nextNode) {
-    var mergedNode = null;
-    if(node.nodeType === Node.TEXT_NODE) {
-      if(node.length === 0) {
-        node.parentNode.removeChild(node);
-        if(nextNode.nodeType === Node.TEXT_NODE) {
-          mergedNode = nextNode
+  core.DomUtils = function DomUtils() {
+    function findStablePoint(container, offset) {
+      if(offset < container.childNodes.length) {
+        container = container.childNodes[offset];
+        offset = 0;
+        while(container.firstChild) {
+          container = container.firstChild
         }
       }else {
-        if(nextNode.nodeType === Node.TEXT_NODE) {
-          node.appendData(nextNode.data);
-          nextNode.parentNode.removeChild(nextNode)
+        while(container.lastChild) {
+          container = container.lastChild;
+          offset = container.nodeType === Node.TEXT_NODE ? container.textContent.length : container.childNodes.length
         }
-        mergedNode = node
       }
+      return{container:container, offset:offset}
     }
-    return mergedNode
-  }
-  function normalizeTextNodes(node) {
-    if(node && node.nextSibling) {
-      node = mergeTextNodes(node, node.nextSibling)
+    function splitBoundaries(range) {
+      var modifiedNodes = [], end, splitStart;
+      if(range.startContainer.nodeType === Node.TEXT_NODE || range.endContainer.nodeType === Node.TEXT_NODE) {
+        end = findStablePoint(range.endContainer, range.endOffset);
+        range.setEnd(end.container, end.offset);
+        if(range.endOffset !== 0 && (range.endContainer.nodeType === Node.TEXT_NODE && range.endOffset !== range.endContainer.length)) {
+          modifiedNodes.push(range.endContainer.splitText(range.endOffset));
+          modifiedNodes.push(range.endContainer)
+        }
+        if(range.startOffset !== 0 && (range.startContainer.nodeType === Node.TEXT_NODE && range.startOffset !== range.startContainer.length)) {
+          splitStart = range.startContainer.splitText(range.startOffset);
+          modifiedNodes.push(range.startContainer);
+          modifiedNodes.push(splitStart);
+          range.setStart(splitStart, 0)
+        }
+      }
+      return modifiedNodes
     }
-    if(node && node.previousSibling) {
-      mergeTextNodes(node.previousSibling, node)
+    this.splitBoundaries = splitBoundaries;
+    function containsRange(container, insideRange) {
+      return container.compareBoundaryPoints(container.START_TO_START, insideRange) <= 0 && container.compareBoundaryPoints(container.END_TO_END, insideRange) >= 0
     }
-  }
-  this.normalizeTextNodes = normalizeTextNodes;
-  function rangeContainsNode(limits, node) {
-    var range = node.ownerDocument.createRange(), nodeLength = node.nodeType === Node.TEXT_NODE ? node.length : node.childNodes.length, result;
-    range.setStart(limits.startContainer, limits.startOffset);
-    range.setEnd(limits.endContainer, limits.endOffset);
-    result = range.comparePoint(node, 0) === 0 && range.comparePoint(node, nodeLength) === 0;
-    range.detach();
-    return result
-  }
-  this.rangeContainsNode = rangeContainsNode;
-  function mergeIntoParent(targetNode) {
-    var parent = targetNode.parentNode;
-    while(targetNode.firstChild) {
-      parent.insertBefore(targetNode.firstChild, targetNode)
+    this.containsRange = containsRange;
+    function rangesIntersect(range1, range2) {
+      return range1.compareBoundaryPoints(range1.END_TO_START, range2) <= 0 && range1.compareBoundaryPoints(range1.START_TO_END, range2) >= 0
     }
-    parent.removeChild(targetNode);
-    return parent
-  }
-  this.mergeIntoParent = mergeIntoParent;
-  function getElementsByTagNameNS(node, namespace, tagName) {
-    return Array.prototype.slice.call(node.getElementsByTagNameNS(namespace, tagName))
-  }
-  this.getElementsByTagNameNS = getElementsByTagNameNS;
-  function rangeIntersectsNode(range, node) {
-    var nodeLength = node.nodeType === Node.TEXT_NODE ? node.length : node.childNodes.length;
-    return range.comparePoint(node, 0) <= 0 && range.comparePoint(node, nodeLength) >= 0
-  }
-  this.rangeIntersectsNode = rangeIntersectsNode;
-  function containsNode(parent, descendant) {
-    return parent === descendant || parent.contains(descendant)
-  }
-  this.containsNode = containsNode;
-  function getPositionInContainingNode(node, container) {
-    var offset = 0, n;
-    while(node.parentNode !== container) {
-      runtime.assert(node.parentNode !== null, "parent is null");
-      node = (node.parentNode)
-    }
-    n = container.firstChild;
-    while(n !== node) {
-      offset += 1;
-      n = n.nextSibling
-    }
-    return offset
-  }
-  function comparePoints(c1, o1, c2, o2) {
-    if(c1 === c2) {
-      return o2 - o1
-    }
-    var comparison = c1.compareDocumentPosition(c2);
-    if(comparison === 2) {
-      comparison = -1
-    }else {
-      if(comparison === 4) {
-        comparison = 1
-      }else {
-        if(comparison === 10) {
-          o1 = getPositionInContainingNode(c1, c2);
-          comparison = o1 < o2 ? 1 : -1
+    this.rangesIntersect = rangesIntersect;
+    function getNodesInRange(range, nodeFilter) {
+      var document = range.startContainer.ownerDocument, elements = [], root = (range.commonAncestorContainer), n, filterResult, treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ALL, nodeFilter, false);
+      treeWalker.currentNode = range.startContainer;
+      n = range.startContainer;
+      while(n) {
+        filterResult = nodeFilter(n);
+        if(filterResult === NodeFilter.FILTER_ACCEPT) {
+          elements.push(n)
         }else {
-          o2 = getPositionInContainingNode(c2, c1);
-          comparison = o2 < o1 ? -1 : 1
+          if(filterResult === NodeFilter.FILTER_REJECT) {
+            break
+          }
+        }
+        n = n.parentNode
+      }
+      elements.reverse();
+      n = treeWalker.nextNode();
+      while(n) {
+        elements.push(n);
+        n = treeWalker.nextNode()
+      }
+      return elements
+    }
+    this.getNodesInRange = getNodesInRange;
+    function mergeTextNodes(node, nextNode) {
+      var mergedNode = null;
+      if(node.nodeType === Node.TEXT_NODE) {
+        if(node.length === 0) {
+          node.parentNode.removeChild(node);
+          if(nextNode.nodeType === Node.TEXT_NODE) {
+            mergedNode = nextNode
+          }
+        }else {
+          if(nextNode.nodeType === Node.TEXT_NODE) {
+            node.appendData(nextNode.data);
+            nextNode.parentNode.removeChild(nextNode)
+          }
+          mergedNode = node
         }
       }
+      return mergedNode
     }
-    return comparison
-  }
-  this.comparePoints = comparePoints;
-  function containsNodeForBrokenWebKit(parent, descendant) {
-    return parent === descendant || Boolean(parent.compareDocumentPosition(descendant) & Node.DOCUMENT_POSITION_CONTAINED_BY)
-  }
-  function init(self) {
-    var window = runtime.getWindow(), appVersion, webKitOrSafari;
-    if(window === null) {
-      return
+    function normalizeTextNodes(node) {
+      if(node && node.nextSibling) {
+        node = mergeTextNodes(node, node.nextSibling)
+      }
+      if(node && node.previousSibling) {
+        mergeTextNodes(node.previousSibling, node)
+      }
     }
-    appVersion = window.navigator.appVersion.toLowerCase();
-    webKitOrSafari = appVersion.indexOf("chrome") === -1 && (appVersion.indexOf("applewebkit") !== -1 || appVersion.indexOf("safari") !== -1);
-    if(webKitOrSafari) {
-      self.containsNode = containsNodeForBrokenWebKit
+    this.normalizeTextNodes = normalizeTextNodes;
+    function rangeContainsNode(limits, node) {
+      var range = node.ownerDocument.createRange(), nodeLength = node.nodeType === Node.TEXT_NODE ? node.length : node.childNodes.length, result;
+      range.setStart(limits.startContainer, limits.startOffset);
+      range.setEnd(limits.endContainer, limits.endOffset);
+      result = range.comparePoint(node, 0) === 0 && range.comparePoint(node, nodeLength) === 0;
+      range.detach();
+      return result
     }
-  }
-  init(this)
-};
+    this.rangeContainsNode = rangeContainsNode;
+    function mergeIntoParent(targetNode) {
+      var parent = targetNode.parentNode;
+      while(targetNode.firstChild) {
+        parent.insertBefore(targetNode.firstChild, targetNode)
+      }
+      parent.removeChild(targetNode);
+      return parent
+    }
+    this.mergeIntoParent = mergeIntoParent;
+    function removeUnwantedNodes(targetNode, shouldRemove) {
+      var parent = targetNode.parentNode, node = targetNode.firstChild, next;
+      while(node) {
+        next = node.nextSibling;
+        removeUnwantedNodes(node, shouldRemove);
+        node = next
+      }
+      if(shouldRemove(targetNode)) {
+        parent = mergeIntoParent(targetNode)
+      }
+      return parent
+    }
+    this.removeUnwantedNodes = removeUnwantedNodes;
+    function getElementsByTagNameNS(node, namespace, tagName) {
+      return Array.prototype.slice.call(node.getElementsByTagNameNS(namespace, tagName))
+    }
+    this.getElementsByTagNameNS = getElementsByTagNameNS;
+    function rangeIntersectsNode(range, node) {
+      var nodeLength = node.nodeType === Node.TEXT_NODE ? node.length : node.childNodes.length;
+      return range.comparePoint(node, 0) <= 0 && range.comparePoint(node, nodeLength) >= 0
+    }
+    this.rangeIntersectsNode = rangeIntersectsNode;
+    function containsNode(parent, descendant) {
+      return parent === descendant || parent.contains(descendant)
+    }
+    this.containsNode = containsNode;
+    function getPositionInContainingNode(node, container) {
+      var offset = 0, n;
+      while(node.parentNode !== container) {
+        runtime.assert(node.parentNode !== null, "parent is null");
+        node = (node.parentNode)
+      }
+      n = container.firstChild;
+      while(n !== node) {
+        offset += 1;
+        n = n.nextSibling
+      }
+      return offset
+    }
+    function comparePoints(c1, o1, c2, o2) {
+      if(c1 === c2) {
+        return o2 - o1
+      }
+      var comparison = c1.compareDocumentPosition(c2);
+      if(comparison === 2) {
+        comparison = -1
+      }else {
+        if(comparison === 4) {
+          comparison = 1
+        }else {
+          if(comparison === 10) {
+            o1 = getPositionInContainingNode(c1, c2);
+            comparison = o1 < o2 ? 1 : -1
+          }else {
+            o2 = getPositionInContainingNode(c2, c1);
+            comparison = o2 < o1 ? -1 : 1
+          }
+        }
+      }
+      return comparison
+    }
+    this.comparePoints = comparePoints;
+    function containsNodeForBrokenWebKit(parent, descendant) {
+      return parent === descendant || Boolean(parent.compareDocumentPosition(descendant) & Node.DOCUMENT_POSITION_CONTAINED_BY)
+    }
+    this.areRangeRectanglesTransformed = function(document) {
+      return!rangeClientRectsUntransformedBug(document)
+    };
+    function adaptRangeDifferenceToZoomLevel(inputNumber, zoomLevel) {
+      var window = runtime.getWindow(), document = window && window.document;
+      if(document && rangeClientRectsUntransformedBug(document)) {
+        return inputNumber
+      }
+      return inputNumber / zoomLevel
+    }
+    this.adaptRangeDifferenceToZoomLevel = adaptRangeDifferenceToZoomLevel;
+    function init(self) {
+      var window = runtime.getWindow(), appVersion, webKitOrSafari, ie;
+      if(window === null) {
+        return
+      }
+      appVersion = window.navigator.appVersion.toLowerCase();
+      webKitOrSafari = appVersion.indexOf("chrome") === -1 && (appVersion.indexOf("applewebkit") !== -1 || appVersion.indexOf("safari") !== -1);
+      ie = appVersion.indexOf("msie");
+      if(webKitOrSafari || ie) {
+        self.containsNode = containsNodeForBrokenWebKit
+      }
+    }
+    init(this)
+  };
+  return core.DomUtils
+})();
 runtime.loadClass("core.DomUtils");
 core.Cursor = function Cursor(document, memberId) {
   var cursorns = "urn:webodf:names:cursor", cursorNode = document.createElementNS(cursorns, "cursor"), anchorNode = document.createElementNS(cursorns, "anchor"), forwardSelection, recentlyModifiedNodes = [], selectedRange, isCollapsed, domUtils = new core.DomUtils;
@@ -3312,6 +3392,9 @@ core.Cursor = function Cursor(document, memberId) {
     recentlyModifiedNodes.forEach(domUtils.normalizeTextNodes);
     recentlyModifiedNodes.length = 0
   };
+  this.hasForwardSelection = function() {
+    return forwardSelection
+  };
   this.remove = function() {
     removeNode(cursorNode);
     recentlyModifiedNodes.forEach(domUtils.normalizeTextNodes);
@@ -3335,6 +3418,9 @@ core.Cursor = function Cursor(document, memberId) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -3355,7 +3441,7 @@ core.Cursor = function Cursor(document, memberId) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 core.EventNotifier = function EventNotifier(eventIds) {
   var eventListener = {};
@@ -3830,7 +3916,7 @@ core.PositionIterator = function PositionIterator(root, whatToShow, filter, expa
     }
     filterResult = nodeFilter(container);
     node = container.parentNode;
-    while(node && node !== root && filterResult === NodeFilter.FILTER_ACCEPT) {
+    while(node && (node !== root && filterResult === NodeFilter.FILTER_ACCEPT)) {
       filterResult = nodeFilter(node);
       if(filterResult !== NodeFilter.FILTER_ACCEPT) {
         walker.currentNode = node
@@ -3842,7 +3928,7 @@ core.PositionIterator = function PositionIterator(root, whatToShow, filter, expa
       filterResult = nodeFilter(walker.currentNode);
       currentPos = 0
     }else {
-      currentPos = offset === 0 ? 0 : 1
+      currentPos = 1
     }
     if(filterResult === NodeFilter.FILTER_REJECT) {
       currentPos = 1
@@ -3916,6 +4002,39 @@ core.PositionFilterChain = function PositionFilterChain() {
     delete filterChain[filterName]
   }
 };
+core.ScheduledTask = function ScheduledTask(fn, delay) {
+  var timeoutId, scheduled = false;
+  function execute() {
+    fn();
+    scheduled = false
+  }
+  function cancel() {
+    if(scheduled) {
+      runtime.clearTimeout(timeoutId);
+      scheduled = false
+    }
+  }
+  this.trigger = function() {
+    if(!scheduled) {
+      timeoutId = runtime.setTimeout(execute, delay)
+    }
+  };
+  this.triggerImmediate = function() {
+    cancel();
+    execute()
+  };
+  this.processRequests = function() {
+    if(scheduled) {
+      cancel();
+      execute()
+    }
+  };
+  this.cancel = cancel;
+  this.destroy = function(callback) {
+    cancel();
+    callback()
+  }
+};
 core.Async = function Async() {
   this.forEach = function(items, f, callback) {
     var i, l = items.length, itemsDone = 0;
@@ -3935,6 +4054,22 @@ core.Async = function Async() {
     for(i = 0;i < l;i += 1) {
       f(items[i], end)
     }
+  };
+  this.destroyAll = function(items, callback) {
+    function destroy(itemIndex, err) {
+      if(err) {
+        callback(err)
+      }else {
+        if(itemIndex < items.length) {
+          items[itemIndex](function(err) {
+            destroy(itemIndex + 1, err)
+          })
+        }else {
+          callback()
+        }
+      }
+    }
+    destroy(0, undefined)
   }
 };
 /*
@@ -4146,13 +4281,13 @@ core.Zip = function Zip(url, entriesReadCallback) {
       }
       var p = data, chunksize = 45E3, i = 0, dataurl;
       if(!mimetype) {
-        if(p[1] === 80 && p[2] === 78 && p[3] === 71) {
+        if(p[1] === 80 && (p[2] === 78 && p[3] === 71)) {
           mimetype = "image/png"
         }else {
-          if(p[0] === 255 && p[1] === 216 && p[2] === 255) {
+          if(p[0] === 255 && (p[1] === 216 && p[2] === 255)) {
             mimetype = "image/jpeg"
           }else {
-            if(p[0] === 71 && p[1] === 73 && p[2] === 70) {
+            if(p[0] === 71 && (p[1] === 73 && p[2] === 70)) {
               mimetype = "image/gif"
             }else {
               mimetype = ""
@@ -4190,6 +4325,17 @@ core.Zip = function Zip(url, entriesReadCallback) {
     entry = new ZipEntry(url);
     entry.set(filename, data, compressed, date);
     entries.push(entry)
+  }
+  function remove(filename) {
+    var i, entry;
+    for(i = 0;i < entries.length;i += 1) {
+      entry = entries[i];
+      if(entry.filename === filename) {
+        entries.splice(i, 1);
+        return true
+      }
+    }
+    return false
   }
   function writeEntry(entry) {
     var data = new core.ByteArrayWriter("utf8"), length = 0;
@@ -4279,6 +4425,7 @@ core.Zip = function Zip(url, entriesReadCallback) {
   }
   this.load = load;
   this.save = save;
+  this.remove = remove;
   this.write = write;
   this.writeAs = writeAs;
   this.createByteArray = createByteArray;
@@ -4300,7 +4447,7 @@ core.Zip = function Zip(url, entriesReadCallback) {
       entriesReadCallback("File '" + url + "' cannot be read.", zip)
     }else {
       runtime.read(url, filesize - 22, 22, function(err, data) {
-        if(err || entriesReadCallback === null || data === null) {
+        if(err || (entriesReadCallback === null || data === null)) {
           entriesReadCallback(err, zip)
         }else {
           handleCentralDirectoryEnd(data, entriesReadCallback)
@@ -4526,7 +4673,7 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
         if(att.localName === "name" && (name === "element" || name === "attribute")) {
           names.push(att.value)
         }
-        if(att.localName === "name" || att.localName === "combine" || att.localName === "type") {
+        if(att.localName === "name" || (att.localName === "combine" || att.localName === "type")) {
           att.value = trim(att.value)
         }
         a[att.localName] = att.value
@@ -4548,7 +4695,7 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
             names.push(nsmap[ce.a.ns] + ":" + ce.text);
             e.push(ce)
           }else {
-            if(ce.name === "choice" && ce.names && ce.names.length) {
+            if(ce.name === "choice" && (ce.names && ce.names.length)) {
               names = names.concat(ce.names);
               delete ce.names;
               e.push(ce)
@@ -4570,7 +4717,7 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
     var i, ce;
     for(i = 0;siblings && i < siblings.length;i += 1) {
       ce = siblings[i];
-      if(ce.name === "define" && ce.a && ce.a.name === name) {
+      if(ce.name === "define" && (ce.a && ce.a.name === name)) {
         ce.e = [{name:combine, e:ce.e.concat(e)}];
         return ce
       }
@@ -4594,7 +4741,7 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
       e = [{name:"name", text:i[1], a:{ns:i[0]}}].concat(e);
       delete a.name
     }
-    if(name === "name" || name === "nsName" || name === "value") {
+    if(name === "name" || (name === "nsName" || name === "value")) {
       if(a.ns === undefined) {
         a.ns = ""
       }
@@ -4606,7 +4753,7 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
       a.ns = i[0];
       text = i[1]
     }
-    if(e.length > 1 && (name === "define" || name === "oneOrMore" || name === "zeroOrMore" || name === "optional" || name === "list" || name === "mixed")) {
+    if(e.length > 1 && (name === "define" || (name === "oneOrMore" || (name === "zeroOrMore" || (name === "optional" || (name === "list" || name === "mixed")))))) {
       e = [{name:"group", e:splitToDuos({name:"group", e:e}).e}]
     }
     if(e.length > 2 && name === "element") {
@@ -4615,14 +4762,14 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
     if(e.length === 1 && name === "attribute") {
       e.push({name:"text", text:text})
     }
-    if(e.length === 1 && (name === "choice" || name === "group" || name === "interleave")) {
+    if(e.length === 1 && (name === "choice" || (name === "group" || name === "interleave"))) {
       name = e[0].name;
       names = e[0].names;
       a = e[0].a;
       text = e[0].text;
       e = e[0].e
     }else {
-      if(e.length > 2 && (name === "choice" || name === "group" || name === "interleave")) {
+      if(e.length > 2 && (name === "choice" || (name === "group" || name === "interleave"))) {
         e = splitToDuos({name:name, e:e}).e
       }
     }
@@ -4687,8 +4834,8 @@ xmldom.RelaxNGParser = function RelaxNGParser() {
     }
     e = def.e;
     if(name === "choice") {
-      if(!e || !e[1] || e[1].name === "empty") {
-        if(!e || !e[0] || e[0].name === "empty") {
+      if(!e || (!e[1] || e[1].name === "empty")) {
+        if(!e || (!e[0] || e[0].name === "empty")) {
           delete def.e;
           def.name = "empty"
         }else {
@@ -5363,7 +5510,7 @@ xmldom.RelaxNG2 = function RelaxNG2() {
     return nsmap[node.namespaceURI] + ":" + node.localName
   }
   function isWhitespace(node) {
-    return node && node.nodeType === Node.TEXT_NODE && /^\s+$/.test(node.nodeValue)
+    return node && (node.nodeType === Node.TEXT_NODE && /^\s+$/.test(node.nodeValue))
   }
   function validatePattern(elementdef, walker, element, data) {
     if(elementdef.name === "empty") {
@@ -5464,7 +5611,7 @@ xmldom.RelaxNG2 = function RelaxNG2() {
               n[i] = false
             }
           }else {
-            if(subnode === walker.currentNode || e.name === "oneOrMore" || e.name === "choice" && (e.e[0].name === "oneOrMore" || e.e[1].name === "oneOrMore")) {
+            if(subnode === walker.currentNode || (e.name === "oneOrMore" || e.name === "choice" && (e.e[0].name === "oneOrMore" || e.e[1].name === "oneOrMore"))) {
               donethisround += 1;
               n[i] = subnode
             }else {
@@ -5574,7 +5721,7 @@ xmldom.XPathIterator = function XPathIterator() {
 xmldom.XPath = function() {
   var createXPathPathIterator, parsePredicates;
   function isSmallestPositive(a, b, c) {
-    return a !== -1 && (a < b || b === -1) && (a < c || c === -1)
+    return a !== -1 && ((a < b || b === -1) && (a < c || c === -1))
   }
   function parseXPathStep(xpath, pos, end, steps) {
     var location = "", predicates = [], brapos = xpath.indexOf("[", pos), slapos = xpath.indexOf("/", pos), eqpos = xpath.indexOf("=", pos);
@@ -5815,6 +5962,9 @@ xmldom.XPath = function() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -5835,7 +5985,7 @@ xmldom.XPath = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 gui.AnnotationViewManager = function AnnotationViewManager(odfCanvas, odfFragment, annotationsPane) {
   var annotations = [], doc = odfFragment.ownerDocument, odfUtils = new odf.OdfUtils, CONNECTOR_MARGIN = 30, NOTE_MARGIN = 20, window = runtime.getWindow();
@@ -5918,7 +6068,9 @@ gui.AnnotationViewManager = function AnnotationViewManager(odfCanvas, odfFragmen
     if(creatorNode) {
       creatorName = window.getComputedStyle((creatorNode), ":before").content;
       if(creatorName && creatorName !== "none") {
-        creatorName = creatorName.substring(1, creatorName.length - 1);
+        if(/^["'].*["']$/.test(creatorName)) {
+          creatorName = creatorName.substring(1, creatorName.length - 1)
+        }
         if(creatorNode.firstChild) {
           creatorNode.firstChild.nodeValue = creatorName
         }else {
@@ -5994,6 +6146,9 @@ gui.AnnotationViewManager = function AnnotationViewManager(odfCanvas, odfFragmen
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -6014,7 +6169,7 @@ gui.AnnotationViewManager = function AnnotationViewManager(odfCanvas, odfFragmen
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 odf.OdfNodeFilter = function OdfNodeFilter() {
   this.acceptNode = function(node) {
@@ -6043,6 +6198,9 @@ odf.OdfNodeFilter = function OdfNodeFilter() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -6063,12 +6221,12 @@ odf.OdfNodeFilter = function OdfNodeFilter() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 odf.Namespaces = function() {
   var dbns = "urn:oasis:names:tc:opendocument:xmlns:database:1.0", dcns = "http://purl.org/dc/elements/1.1/", dr3dns = "urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0", drawns = "urn:oasis:names:tc:opendocument:xmlns:drawing:1.0", chartns = "urn:oasis:names:tc:opendocument:xmlns:chart:1.0", fons = "urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0", formns = "urn:oasis:names:tc:opendocument:xmlns:form:1.0", numberns = "urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0", officens = "urn:oasis:names:tc:opendocument:xmlns:office:1.0", 
-  presentationns = "urn:oasis:names:tc:opendocument:xmlns:presentation:1.0", stylens = "urn:oasis:names:tc:opendocument:xmlns:style:1.0", svgns = "urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0", tablens = "urn:oasis:names:tc:opendocument:xmlns:table:1.0", textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0", xlinkns = "http://www.w3.org/1999/xlink", xmlns = "http://www.w3.org/XML/1998/namespace", webodfns = "urn:webodf", namespaceMap = {"db":dbns, "dc":dcns, "dr3d":dr3dns, "draw":drawns, 
-  "chart":chartns, "fo":fons, "form":formns, "numberns":numberns, "office":officens, "presentation":presentationns, "style":stylens, "svg":svgns, "table":tablens, "text":textns, "xlink":xlinkns, "xml":xmlns, "webodf":webodfns}, namespaces;
+  presentationns = "urn:oasis:names:tc:opendocument:xmlns:presentation:1.0", stylens = "urn:oasis:names:tc:opendocument:xmlns:style:1.0", svgns = "urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0", tablens = "urn:oasis:names:tc:opendocument:xmlns:table:1.0", textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0", xlinkns = "http://www.w3.org/1999/xlink", xmlns = "http://www.w3.org/XML/1998/namespace", namespaceMap = {"db":dbns, "dc":dcns, "dr3d":dr3dns, "draw":drawns, "chart":chartns, 
+  "fo":fons, "form":formns, "numberns":numberns, "office":officens, "presentation":presentationns, "style":stylens, "svg":svgns, "table":tablens, "text":textns, "xlink":xlinkns, "xml":xmlns}, namespaces;
   function forEachPrefix(cb) {
     var prefix;
     for(prefix in namespaceMap) {
@@ -6102,7 +6260,6 @@ odf.Namespaces = function() {
   namespaces.textns = textns;
   namespaces.xlinkns = xlinkns;
   namespaces.xmlns = xmlns;
-  namespaces.webodfns = webodfns;
   return namespaces
 }();
 /*
@@ -6116,6 +6273,9 @@ odf.Namespaces = function() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -6137,7 +6297,7 @@ odf.Namespaces = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("xmldom.XPath");
 runtime.loadClass("odf.Namespaces");
@@ -6373,6 +6533,46 @@ odf.StyleInfo = function StyleInfo() {
       }
     })
   }
+  function collectUsedFontFaces(usedFontFaceDeclMap, styleElementsRoot) {
+    var localNames = ["font-name", "font-name-asian", "font-name-complex"], currentNode;
+    function collectByAttribute(localName) {
+      var fontFaceName = currentNode.getAttributeNS(stylens, localName);
+      if(fontFaceName) {
+        usedFontFaceDeclMap[fontFaceName] = true
+      }
+    }
+    if(styleElementsRoot) {
+      currentNode = styleElementsRoot.firstChild;
+      while(currentNode) {
+        if(currentNode.nodeType === Node.ELEMENT_NODE) {
+          localNames.forEach(collectByAttribute);
+          collectUsedFontFaces(usedFontFaceDeclMap, (currentNode))
+        }
+        currentNode = currentNode.nextSibling
+      }
+    }
+  }
+  this.collectUsedFontFaces = collectUsedFontFaces;
+  function changeFontFaceNames(styleElementsRoot, fontFaceNameChangeMap) {
+    var localNames = ["font-name", "font-name-asian", "font-name-complex"], currentNode;
+    function changeFontFaceNameByAttribute(localName) {
+      var fontFaceName = currentNode.getAttributeNS(stylens, localName);
+      if(fontFaceName && fontFaceNameChangeMap.hasOwnProperty(fontFaceName)) {
+        currentNode.setAttributeNS(stylens, "style:" + localName, fontFaceNameChangeMap[fontFaceName])
+      }
+    }
+    if(styleElementsRoot) {
+      currentNode = styleElementsRoot.firstChild;
+      while(currentNode) {
+        if(currentNode.nodeType === Node.ELEMENT_NODE) {
+          localNames.forEach(changeFontFaceNameByAttribute);
+          changeFontFaceNames((currentNode), fontFaceNameChangeMap)
+        }
+        currentNode = currentNode.nextSibling
+      }
+    }
+  }
+  this.changeFontFaceNames = changeFontFaceNames;
   this.UsedStyleList = function(styleUsingElementsRoot, automaticStylesRoot) {
     var usedStyles = {};
     this.uses = function(element) {
@@ -6412,6 +6612,9 @@ odf.StyleInfo = function StyleInfo() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -6432,12 +6635,26 @@ odf.StyleInfo = function StyleInfo() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("odf.Namespaces");
 odf.OdfUtils = function OdfUtils() {
   var textns = odf.Namespaces.textns, drawns = odf.Namespaces.drawns, whitespaceOnly = /^\s*$/, domUtils = new core.DomUtils;
+  function isImage(e) {
+    var name = e && e.localName;
+    return name === "image" && e.namespaceURI === drawns
+  }
+  this.isImage = isImage;
+  function isCharacterFrame(e) {
+    var name = e && e.localName;
+    return name === "frame" && (e.namespaceURI === drawns && e.getAttributeNS(textns, "anchor-type") === "as-char")
+  }
+  this.isCharacterFrame = isCharacterFrame;
+  this.isTextSpan = function(e) {
+    var name = e && e.localName;
+    return name === "span" && e.namespaceURI === textns
+  };
   function isParagraph(e) {
     var name = e && e.localName;
     return(name === "p" || name === "h") && e.namespaceURI === textns
@@ -6463,6 +6680,10 @@ odf.OdfUtils = function OdfUtils() {
     var name = e && e.localName;
     return name === "list-item" && e.namespaceURI === textns
   };
+  this.isLineBreak = function(e) {
+    var name = e && e.localName;
+    return name === "line-break" && e.namespaceURI === textns
+  };
   function isODFWhitespace(text) {
     return/^[ \t\r\n]+$/.test(text)
   }
@@ -6480,16 +6701,25 @@ odf.OdfUtils = function OdfUtils() {
     if(n) {
       ns = e.namespaceURI;
       if(ns === textns) {
-        r = n === "s" || n === "tab" || n === "line-break"
+        r = n === "s" || (n === "tab" || n === "line-break")
       }else {
-        if(ns === drawns) {
-          r = n === "frame" && e.getAttributeNS(textns, "anchor-type") === "as-char"
-        }
+        r = isCharacterFrame(e)
       }
     }
     return r
   }
   this.isCharacterElement = isCharacterElement;
+  function isWhitespaceElement(e) {
+    var n = e && e.localName, ns, r = false;
+    if(n) {
+      ns = e.namespaceURI;
+      if(ns === textns) {
+        r = n === "s" || n === "tab"
+      }
+    }
+    return r
+  }
+  this.isWhitespaceElement = isWhitespaceElement;
   function firstChild(node) {
     while(node.firstChild !== null && isGroupingElement(node)) {
       node = node.firstChild
@@ -6529,7 +6759,7 @@ odf.OdfUtils = function OdfUtils() {
         }
       }else {
         if(isCharacterElement(node)) {
-          r = true;
+          r = isWhitespaceElement(node) === false;
           node = null
         }else {
           node = previousNode(node)
@@ -6562,7 +6792,7 @@ odf.OdfUtils = function OdfUtils() {
   this.lookLeftForCharacter = lookLeftForCharacter;
   function lookRightForCharacter(node) {
     var r = false;
-    if(node && node.nodeType === Node.TEXT_NODE && node.length > 0) {
+    if(node && (node.nodeType === Node.TEXT_NODE && node.length > 0)) {
       r = !isODFWhitespace(node.data.substr(0, 1))
     }else {
       if(isCharacterElement(node)) {
@@ -6576,7 +6806,7 @@ odf.OdfUtils = function OdfUtils() {
     var r = false;
     node = node && lastChild(node);
     while(node) {
-      if(node.nodeType === Node.TEXT_NODE && node.length > 0 && !isODFWhitespace(node.data)) {
+      if(node.nodeType === Node.TEXT_NODE && (node.length > 0 && !isODFWhitespace(node.data))) {
         r = true;
         break
       }
@@ -6593,7 +6823,7 @@ odf.OdfUtils = function OdfUtils() {
     var r = false;
     node = node && firstChild(node);
     while(node) {
-      if(node.nodeType === Node.TEXT_NODE && node.length > 0 && !isODFWhitespace(node.data)) {
+      if(node.nodeType === Node.TEXT_NODE && (node.length > 0 && !isODFWhitespace(node.data))) {
         r = true;
         break
       }
@@ -6644,7 +6874,7 @@ odf.OdfUtils = function OdfUtils() {
   };
   function getFirstNonWhitespaceChild(node) {
     var child = node && node.firstChild;
-    while(child && child.nodeType === Node.TEXT_NODE && whitespaceOnly.test(child.nodeValue)) {
+    while(child && (child.nodeType === Node.TEXT_NODE && whitespaceOnly.test(child.nodeValue))) {
       child = child.nextSibling
     }
     return child
@@ -6742,12 +6972,15 @@ odf.OdfUtils = function OdfUtils() {
   function isSignificantTextContent(textNode) {
     return Boolean(getParagraphElement(textNode) && (!isODFWhitespace(textNode.textContent) || isSignificantWhitespace(textNode, 0)))
   }
+  function includeNode(range, nodeRange, includePartial) {
+    return includePartial && domUtils.rangesIntersect(range, nodeRange) || domUtils.containsRange(range, nodeRange)
+  }
   function getTextNodes(range, includePartial) {
     var document = range.startContainer.ownerDocument, nodeRange = document.createRange(), textNodes;
     function nodeFilter(node) {
       nodeRange.selectNodeContents(node);
       if(node.nodeType === Node.TEXT_NODE) {
-        if(includePartial && domUtils.rangesIntersect(range, nodeRange) || domUtils.containsRange(range, nodeRange)) {
+        if(includeNode(range, nodeRange, includePartial)) {
           return isSignificantTextContent(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT
         }
       }else {
@@ -6764,18 +6997,22 @@ odf.OdfUtils = function OdfUtils() {
     return textNodes
   }
   this.getTextNodes = getTextNodes;
-  this.getTextElements = function(range, includeInsignificantWhitespace) {
+  this.getTextElements = function(range, includePartial, includeInsignificantWhitespace) {
     var document = range.startContainer.ownerDocument, nodeRange = document.createRange(), elements;
     function nodeFilter(node) {
-      var nodeType = node.nodeType;
       nodeRange.selectNodeContents(node);
-      if(nodeType === Node.TEXT_NODE) {
-        if(domUtils.containsRange(range, nodeRange) && (includeInsignificantWhitespace || isSignificantTextContent(node))) {
-          return NodeFilter.FILTER_ACCEPT
+      if(isCharacterElement(node.parentNode)) {
+        return NodeFilter.FILTER_REJECT
+      }
+      if(node.nodeType === Node.TEXT_NODE) {
+        if(includeNode(range, nodeRange, includePartial)) {
+          if(includeInsignificantWhitespace || isSignificantTextContent(node)) {
+            return NodeFilter.FILTER_ACCEPT
+          }
         }
       }else {
         if(isCharacterElement(node)) {
-          if(domUtils.containsRange(range, nodeRange)) {
+          if(includeNode(range, nodeRange, includePartial)) {
             return NodeFilter.FILTER_ACCEPT
           }
         }else {
@@ -6808,6 +7045,19 @@ odf.OdfUtils = function OdfUtils() {
     elements = domUtils.getNodesInRange(range, nodeFilter);
     nodeRange.detach();
     return elements
+  };
+  this.getImageElements = function(range) {
+    var document = range.startContainer.ownerDocument, nodeRange = document.createRange(), elements;
+    function nodeFilter(node) {
+      nodeRange.selectNodeContents(node);
+      if(isImage(node) && domUtils.containsRange(range, nodeRange)) {
+        return NodeFilter.FILTER_ACCEPT
+      }
+      return NodeFilter.FILTER_SKIP
+    }
+    elements = domUtils.getNodesInRange(range, nodeFilter);
+    nodeRange.detach();
+    return elements
   }
 };
 /*
@@ -6821,6 +7071,9 @@ odf.OdfUtils = function OdfUtils() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -6842,7 +7095,7 @@ odf.OdfUtils = function OdfUtils() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.OdfUtils");
 odf.TextSerializer = function TextSerializer() {
@@ -6887,6 +7140,9 @@ odf.TextSerializer = function TextSerializer() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -6907,12 +7163,12 @@ odf.TextSerializer = function TextSerializer() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("core.LoopWatchDog");
 runtime.loadClass("odf.Namespaces");
-odf.TextStyleApplicator = function TextStyleApplicator(styleNameGenerator, formatting, automaticStyles) {
+odf.TextStyleApplicator = function TextStyleApplicator(objectNameGenerator, formatting, automaticStyles) {
   var domUtils = new core.DomUtils, textns = odf.Namespaces.textns, stylens = odf.Namespaces.stylens, textProperties = "style:text-properties", webodfns = "urn:webodf:names:scope";
   function StyleLookup(info) {
     function compare(expected, actual) {
@@ -6935,7 +7191,7 @@ odf.TextStyleApplicator = function TextStyleApplicator(styleNameGenerator, forma
       derivedStyleInfo = existingStyleName ? formatting.createDerivedStyleObject(existingStyleName, "text", info) : info;
       derivedStyleNode = document.createElementNS(stylens, "style:style");
       formatting.updateStyle(derivedStyleNode, derivedStyleInfo);
-      derivedStyleNode.setAttributeNS(stylens, "style:name", styleNameGenerator.generateName());
+      derivedStyleNode.setAttributeNS(stylens, "style:name", objectNameGenerator.generateStyleName());
       derivedStyleNode.setAttributeNS(stylens, "style:family", "text");
       derivedStyleNode.setAttributeNS(webodfns, "scope", "document-content");
       automaticStyles.appendChild(derivedStyleNode);
@@ -7023,6 +7279,9 @@ odf.TextStyleApplicator = function TextStyleApplicator(styleNameGenerator, forma
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -7043,7 +7302,7 @@ odf.TextStyleApplicator = function TextStyleApplicator(styleNameGenerator, forma
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("odf.OdfUtils");
@@ -7204,7 +7463,7 @@ odf.Style2CSS = function Style2CSS() {
       theRestOfBorderAttributes = ""
     }
     width = utils.parseLength(width);
-    if(width && width.unit === "pt" && width.value < 0.75) {
+    if(width && (width.unit === "pt" && width.value < 0.75)) {
       value = "0.75pt" + theRestOfBorderAttributes
     }
     return value
@@ -7633,6 +7892,9 @@ odf.Style2CSS = function Style2CSS() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -7653,7 +7915,7 @@ odf.Style2CSS = function Style2CSS() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.Base64");
 runtime.loadClass("core.Zip");
@@ -7662,7 +7924,8 @@ runtime.loadClass("odf.StyleInfo");
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("odf.OdfNodeFilter");
 odf.OdfContainer = function() {
-  var styleInfo = new odf.StyleInfo, officens = "urn:oasis:names:tc:opendocument:xmlns:office:1.0", manifestns = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0", webodfns = "urn:webodf:names:scope", nodeorder = ["meta", "settings", "scripts", "font-face-decls", "styles", "automatic-styles", "master-styles", "body"], automaticStylePrefix = (new Date).getTime() + "_webodf_", base64 = new core.Base64, documentStylesScope = "document-styles", documentContentScope = "document-content";
+  var styleInfo = new odf.StyleInfo, officens = "urn:oasis:names:tc:opendocument:xmlns:office:1.0", manifestns = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0", webodfns = "urn:webodf:names:scope", stylens = odf.Namespaces.stylens, nodeorder = ["meta", "settings", "scripts", "font-face-decls", "styles", "automatic-styles", "master-styles", "body"], automaticStylePrefix = (new Date).getTime() + "_webodf_", base64 = new core.Base64, documentStylesScope = "document-styles", documentContentScope = 
+  "document-content";
   function getDirectChild(node, ns, name) {
     node = node ? node.firstChild : null;
     while(node) {
@@ -7686,7 +7949,7 @@ odf.OdfContainer = function() {
     var usedStyleList = new styleInfo.UsedStyleList(styleUsingElementsRoot, automaticStyles), odfNodeFilter = new odf.OdfNodeFilter;
     this.acceptNode = function(node) {
       var result = odfNodeFilter.acceptNode(node);
-      if(result === NodeFilter.FILTER_ACCEPT && node.parentNode === automaticStyles && node.nodeType === Node.ELEMENT_NODE) {
+      if(result === NodeFilter.FILTER_ACCEPT && (node.parentNode === automaticStyles && node.nodeType === Node.ELEMENT_NODE)) {
         if(usedStyleList.uses((node))) {
           result = NodeFilter.FILTER_ACCEPT
         }else {
@@ -7700,7 +7963,7 @@ odf.OdfContainer = function() {
     var odfStylesFilter = new OdfStylesFilter(styleUsingElementsRoot, automaticStyles);
     this.acceptNode = function(node) {
       var result = odfStylesFilter.acceptNode(node);
-      if(result === NodeFilter.FILTER_ACCEPT && node.parentNode && node.parentNode.namespaceURI === odf.Namespaces.textns && (node.parentNode.localName === "s" || node.parentNode.localName === "tab")) {
+      if(result === NodeFilter.FILTER_ACCEPT && (node.parentNode && (node.parentNode.namespaceURI === odf.Namespaces.textns && (node.parentNode.localName === "s" || node.parentNode.localName === "tab")))) {
         result = NodeFilter.FILTER_REJECT
       }
       return result
@@ -7804,6 +8067,56 @@ odf.OdfContainer = function() {
         n = n.nextSibling
       }
     }
+    function mergeFontFaceDecls(targetFontFaceDeclsRootElement, sourceFontFaceDeclsRootElement) {
+      var n, s, fontFaceName, newFontFaceName, targetFontFaceDeclsMap, sourceFontFaceDeclsMap, fontFaceNameChangeMap = {};
+      function unusedKey(key, map1, map2) {
+        var i = 0, postFixedKey;
+        key = key.replace(/\d+$/, "");
+        postFixedKey = key;
+        while(map1.hasOwnProperty(postFixedKey) || map2.hasOwnProperty(postFixedKey)) {
+          i += 1;
+          postFixedKey = key + i
+        }
+        return postFixedKey
+      }
+      function mapByFontFaceName(fontFaceDecls) {
+        var fn, result = {};
+        fn = fontFaceDecls.firstChild;
+        while(fn) {
+          if(fn.nodeType === Node.ELEMENT_NODE && (fn.namespaceURI === stylens && fn.localName === "font-face")) {
+            fontFaceName = fn.getAttributeNS(stylens, "name");
+            result[fontFaceName] = fn
+          }
+          fn = fn.nextSibling
+        }
+        return result
+      }
+      targetFontFaceDeclsMap = mapByFontFaceName(targetFontFaceDeclsRootElement);
+      sourceFontFaceDeclsMap = mapByFontFaceName(sourceFontFaceDeclsRootElement);
+      n = sourceFontFaceDeclsRootElement.firstChild;
+      while(n) {
+        s = n.nextSibling;
+        if(n.nodeType === Node.ELEMENT_NODE && (n.namespaceURI === stylens && n.localName === "font-face")) {
+          fontFaceName = n.getAttributeNS(stylens, "name");
+          if(targetFontFaceDeclsMap.hasOwnProperty(fontFaceName)) {
+            if(!n.isEqualNode(targetFontFaceDeclsMap[fontFaceName])) {
+              newFontFaceName = unusedKey(fontFaceName, targetFontFaceDeclsMap, sourceFontFaceDeclsMap);
+              n.setAttributeNS(stylens, "style:name", newFontFaceName);
+              targetFontFaceDeclsRootElement.appendChild(n);
+              targetFontFaceDeclsMap[newFontFaceName] = (n);
+              delete sourceFontFaceDeclsMap[fontFaceName];
+              fontFaceNameChangeMap[fontFaceName] = newFontFaceName
+            }
+          }else {
+            targetFontFaceDeclsRootElement.appendChild(n);
+            targetFontFaceDeclsMap[fontFaceName] = (n);
+            delete sourceFontFaceDeclsMap[fontFaceName]
+          }
+        }
+        n = s
+      }
+      return fontFaceNameChangeMap
+    }
     function cloneStylesInScope(stylesRootElement, scope) {
       var copy = null, n, s, scopeAttrValue;
       if(stylesRootElement) {
@@ -7818,6 +8131,27 @@ odf.OdfContainer = function() {
             }
           }
           n = s
+        }
+      }
+      return copy
+    }
+    function cloneFontFaceDeclsUsedInStyles(fontFaceDeclsRootElement, stylesRootElementList) {
+      var copy = null, n, nextSibling, fontFaceName, usedFontFaceDeclMap = {};
+      if(fontFaceDeclsRootElement) {
+        stylesRootElementList.forEach(function(stylesRootElement) {
+          styleInfo.collectUsedFontFaces(usedFontFaceDeclMap, stylesRootElement)
+        });
+        copy = fontFaceDeclsRootElement.cloneNode(true);
+        n = copy.firstChild;
+        while(n) {
+          nextSibling = n.nextSibling;
+          if(n.nodeType === Node.ELEMENT_NODE) {
+            fontFaceName = n.getAttributeNS(stylens, "name");
+            if(!usedFontFaceDeclMap[fontFaceName]) {
+              copy.removeChild(n)
+            }
+          }
+          n = nextSibling
         }
       }
       return copy
@@ -7854,7 +8188,7 @@ odf.OdfContainer = function() {
     }
     function handleFlatXml(xmldoc) {
       var root = importRootNode(xmldoc);
-      if(!root || root.localName !== "document" || root.namespaceURI !== officens) {
+      if(!root || (root.localName !== "document" || root.namespaceURI !== officens)) {
         setState(OdfContainer.INVALID);
         return
       }
@@ -7863,7 +8197,7 @@ odf.OdfContainer = function() {
     }
     function handleStylesXml(xmldoc) {
       var node = importRootNode(xmldoc), root = self.rootElement;
-      if(!node || node.localName !== "document-styles" || node.namespaceURI !== officens) {
+      if(!node || (node.localName !== "document-styles" || node.namespaceURI !== officens)) {
         setState(OdfContainer.INVALID);
         return
       }
@@ -7879,19 +8213,15 @@ odf.OdfContainer = function() {
       styleInfo.prefixStyleNames(root.automaticStyles, automaticStylePrefix, root.masterStyles)
     }
     function handleContentXml(xmldoc) {
-      var node = importRootNode(xmldoc), root, automaticStyles, fontFaceDecls, c;
-      if(!node || node.localName !== "document-content" || node.namespaceURI !== officens) {
+      var node = importRootNode(xmldoc), root, automaticStyles, fontFaceDecls, fontFaceNameChangeMap, c;
+      if(!node || (node.localName !== "document-content" || node.namespaceURI !== officens)) {
         setState(OdfContainer.INVALID);
         return
       }
       root = self.rootElement;
       fontFaceDecls = getDirectChild(node, officens, "font-face-decls");
       if(root.fontFaceDecls && fontFaceDecls) {
-        c = fontFaceDecls.firstChild;
-        while(c) {
-          root.fontFaceDecls.appendChild(c);
-          c = fontFaceDecls.firstChild
-        }
+        fontFaceNameChangeMap = mergeFontFaceDecls(root.fontFaceDecls, fontFaceDecls)
       }else {
         if(fontFaceDecls) {
           root.fontFaceDecls = fontFaceDecls;
@@ -7900,6 +8230,9 @@ odf.OdfContainer = function() {
       }
       automaticStyles = getDirectChild(node, officens, "automatic-styles");
       setAutomaticStylesScope(automaticStyles, documentContentScope);
+      if(fontFaceNameChangeMap) {
+        styleInfo.changeFontFaceNames(automaticStyles, fontFaceNameChangeMap)
+      }
       if(root.automaticStyles && automaticStyles) {
         c = automaticStyles.firstChild;
         while(c) {
@@ -7917,7 +8250,7 @@ odf.OdfContainer = function() {
     }
     function handleMetaXml(xmldoc) {
       var node = importRootNode(xmldoc), root;
-      if(!node || node.localName !== "document-meta" || node.namespaceURI !== officens) {
+      if(!node || (node.localName !== "document-meta" || node.namespaceURI !== officens)) {
         return
       }
       root = self.rootElement;
@@ -7926,7 +8259,7 @@ odf.OdfContainer = function() {
     }
     function handleSettingsXml(xmldoc) {
       var node = importRootNode(xmldoc), root;
-      if(!node || node.localName !== "document-settings" || node.namespaceURI !== officens) {
+      if(!node || (node.localName !== "document-settings" || node.namespaceURI !== officens)) {
         return
       }
       root = self.rootElement;
@@ -7935,14 +8268,14 @@ odf.OdfContainer = function() {
     }
     function handleManifestXml(xmldoc) {
       var node = importRootNode(xmldoc), root, n;
-      if(!node || node.localName !== "manifest" || node.namespaceURI !== manifestns) {
+      if(!node || (node.localName !== "manifest" || node.namespaceURI !== manifestns)) {
         return
       }
       root = self.rootElement;
       root.manifest = node;
       n = root.manifest.firstChild;
       while(n) {
-        if(n.nodeType === Node.ELEMENT_NODE && n.localName === "file-entry" && n.namespaceURI === manifestns) {
+        if(n.nodeType === Node.ELEMENT_NODE && (n.localName === "file-entry" && n.namespaceURI === manifestns)) {
           partMimetypes[n.getAttributeNS(manifestns, "full-path")] = n.getAttributeNS(manifestns, "media-type")
         }
         n = n.nextSibling
@@ -7989,7 +8322,7 @@ odf.OdfContainer = function() {
       return element
     }
     function serializeManifestXml() {
-      var header = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n', xml = '<manifest:manifest xmlns:manifest="' + manifestns + '"></manifest:manifest>', manifest = (runtime.parseXML(xml)), manifestRoot = getDirectChild(manifest, manifestns, "manifest"), serializer = new xmldom.LSSerializer, fullPath;
+      var header = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n', xml = '<manifest:manifest xmlns:manifest="' + manifestns + '" manifest:version="1.2"></manifest:manifest>', manifest = (runtime.parseXML(xml)), manifestRoot = getDirectChild(manifest, manifestns, "manifest"), serializer = new xmldom.LSSerializer, fullPath;
       for(fullPath in partMimetypes) {
         if(partMimetypes.hasOwnProperty(fullPath)) {
           manifestRoot.appendChild(createManifestEntry(fullPath, partMimetypes[fullPath]))
@@ -8006,10 +8339,13 @@ odf.OdfContainer = function() {
       return s
     }
     function serializeStylesXml() {
-      var nsmap = odf.Namespaces.namespaceMap, serializer = new xmldom.LSSerializer, automaticStyles = cloneStylesInScope(self.rootElement.automaticStyles, documentStylesScope), masterStyles = self.rootElement.masterStyles && self.rootElement.masterStyles.cloneNode(true), s = createDocumentElement("document-styles");
+      var nsmap = odf.Namespaces.namespaceMap, serializer = new xmldom.LSSerializer, fontFaceDecls, automaticStyles, masterStyles, s = createDocumentElement("document-styles");
+      automaticStyles = cloneStylesInScope(self.rootElement.automaticStyles, documentStylesScope);
+      masterStyles = self.rootElement.masterStyles && self.rootElement.masterStyles.cloneNode(true);
+      fontFaceDecls = cloneFontFaceDeclsUsedInStyles(self.rootElement.fontFaceDecls, [masterStyles, self.rootElement.styles, automaticStyles]);
       styleInfo.removePrefixFromStyleNames(automaticStyles, automaticStylePrefix, masterStyles);
       serializer.filter = new OdfStylesFilter(masterStyles, automaticStyles);
-      s += serializer.writeToString(self.rootElement.fontFaceDecls, nsmap);
+      s += serializer.writeToString(fontFaceDecls, nsmap);
       s += serializer.writeToString(self.rootElement.styles, nsmap);
       s += serializer.writeToString(automaticStyles, nsmap);
       s += serializer.writeToString(masterStyles, nsmap);
@@ -8017,8 +8353,11 @@ odf.OdfContainer = function() {
       return s
     }
     function serializeContentXml() {
-      var nsmap = odf.Namespaces.namespaceMap, serializer = new xmldom.LSSerializer, automaticStyles = cloneStylesInScope(self.rootElement.automaticStyles, documentContentScope), s = createDocumentElement("document-content");
+      var nsmap = odf.Namespaces.namespaceMap, serializer = new xmldom.LSSerializer, fontFaceDecls, automaticStyles, s = createDocumentElement("document-content");
+      automaticStyles = cloneStylesInScope(self.rootElement.automaticStyles, documentContentScope);
+      fontFaceDecls = cloneFontFaceDeclsUsedInStyles(self.rootElement.fontFaceDecls, [automaticStyles]);
       serializer.filter = new OdfContentFilter(self.rootElement.body, automaticStyles);
+      s += serializer.writeToString(fontFaceDecls, nsmap);
       s += serializer.writeToString(automaticStyles, nsmap);
       s += serializer.writeToString(self.rootElement.body, nsmap);
       s += "</office:document-content>";
@@ -8047,7 +8386,7 @@ odf.OdfContainer = function() {
       var body;
       if(!contentElement) {
         body = self.rootElement.body;
-        contentElement = body.getElementsByTagNameNS(officens, "text")[0] || body.getElementsByTagNameNS(officens, "presentation")[0] || body.getElementsByTagNameNS(officens, "spreadsheet")[0]
+        contentElement = body.getElementsByTagNameNS(officens, "text")[0] || (body.getElementsByTagNameNS(officens, "presentation")[0] || body.getElementsByTagNameNS(officens, "spreadsheet")[0])
       }
       return contentElement
     };
@@ -8116,6 +8455,19 @@ odf.OdfContainer = function() {
     this.getUrl = function() {
       return url
     };
+    this.setBlob = function(filename, mimetype, content) {
+      var data = base64.convertBase64ToByteArray(content), date = new Date;
+      zip.save(filename, data, false, date);
+      if(partMimetypes.hasOwnProperty(filename)) {
+        runtime.log(filename + " has been overwritten.")
+      }
+      partMimetypes[filename] = mimetype
+    };
+    this.removeBlob = function(filename) {
+      var foundAndRemoved = zip.remove(filename);
+      runtime.assert(foundAndRemoved, "file is not found: " + filename);
+      delete partMimetypes[filename]
+    };
     this.state = OdfContainer.LOADING;
     this.rootElement = createElement(ODFDocumentElement);
     if(url) {
@@ -8159,6 +8511,9 @@ odf.OdfContainer = function() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -8179,7 +8534,7 @@ odf.OdfContainer = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.Base64");
 runtime.loadClass("xmldom.XPath");
@@ -8267,6 +8622,9 @@ odf.FontLoader = function() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -8287,21 +8645,70 @@ odf.FontLoader = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-odf.StyleNameGenerator = function StyleNameGenerator(prefix, formatting) {
-  var reportedNames = {};
-  this.generateName = function() {
-    var name, existingNames = {}, startIndex = 0;
-    formatting.getAllStyleNames().forEach(function(styleName) {
-      existingNames[styleName] = true
+runtime.loadClass("core.DomUtils");
+runtime.loadClass("core.Utils");
+odf.ObjectNameGenerator = function ObjectNameGenerator(odfContainer, memberId) {
+  var stylens = odf.Namespaces.stylens, drawns = odf.Namespaces.drawns, xlinkns = odf.Namespaces.xlinkns, domUtils = new core.DomUtils, utils = new core.Utils, memberIdHash = utils.hashString(memberId), styleNameGenerator = null, frameNameGenerator = null, imageNameGenerator = null, existingFrameNames = {}, existingImageNames = {};
+  function NameGenerator(prefix, findExistingNames) {
+    var reportedNames = {};
+    this.generateName = function() {
+      var existingNames = findExistingNames(), startIndex = 0, name;
+      do {
+        name = prefix + startIndex;
+        startIndex += 1
+      }while(reportedNames[name] || existingNames[name]);
+      reportedNames[name] = true;
+      return name
+    }
+  }
+  function getAllStyleNames() {
+    var styleElements = [odfContainer.rootElement.automaticStyles, odfContainer.rootElement.styles], node, styleNames = {};
+    styleElements.forEach(function(styleListElement) {
+      node = styleListElement.firstChild;
+      while(node) {
+        if(node.nodeType === Node.ELEMENT_NODE && (node.namespaceURI === stylens && node.localName === "style")) {
+          styleNames[node.getAttributeNS(stylens, "name")] = true
+        }
+        node = node.nextSibling
+      }
     });
-    do {
-      name = prefix + startIndex;
-      startIndex += 1
-    }while(reportedNames[name] || existingNames[name]);
-    reportedNames[name] = true;
-    return name
+    return styleNames
+  }
+  this.generateStyleName = function() {
+    if(styleNameGenerator === null) {
+      styleNameGenerator = new NameGenerator("auto" + memberIdHash + "_", function() {
+        return getAllStyleNames()
+      })
+    }
+    return styleNameGenerator.generateName()
+  };
+  this.generateFrameName = function() {
+    if(frameNameGenerator === null) {
+      var nodes = domUtils.getElementsByTagNameNS(odfContainer.rootElement.body, drawns, "frame");
+      nodes.forEach(function(frame) {
+        existingFrameNames[frame.getAttributeNS(drawns, "name")] = true
+      });
+      frameNameGenerator = new NameGenerator("fr" + memberIdHash + "_", function() {
+        return existingFrameNames
+      })
+    }
+    return frameNameGenerator.generateName()
+  };
+  this.generateImageName = function() {
+    if(imageNameGenerator === null) {
+      var nodes = domUtils.getElementsByTagNameNS(odfContainer.rootElement.body, drawns, "image");
+      nodes.forEach(function(image) {
+        var path = image.getAttributeNS(xlinkns, "href");
+        path = path.substring("Pictures/".length, path.lastIndexOf("."));
+        existingImageNames[path] = true
+      });
+      imageNameGenerator = new NameGenerator("img" + memberIdHash + "_", function() {
+        return existingImageNames
+      })
+    }
+    return imageNameGenerator.generateName()
   }
 };
 /*
@@ -8316,6 +8723,9 @@ odf.StyleNameGenerator = function StyleNameGenerator(prefix, formatting) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -8336,17 +8746,17 @@ odf.StyleNameGenerator = function StyleNameGenerator(prefix, formatting) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.Utils");
-runtime.loadClass("odf.StyleNameGenerator");
+runtime.loadClass("odf.ObjectNameGenerator");
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("odf.OdfContainer");
 runtime.loadClass("odf.StyleInfo");
 runtime.loadClass("odf.OdfUtils");
 runtime.loadClass("odf.TextStyleApplicator");
 odf.Formatting = function Formatting() {
-  var self = this, odfContainer, styleInfo = new odf.StyleInfo, svgns = odf.Namespaces.svgns, stylens = odf.Namespaces.stylens, textns = odf.Namespaces.textns, numberns = odf.Namespaces.numberns, odfUtils = new odf.OdfUtils, utils = new core.Utils, builtInDefaultStyleAttributesByFamily = {"paragraph":{"style:paragraph-properties":{"fo:text-align":"left"}}};
+  var self = this, odfContainer, styleInfo = new odf.StyleInfo, svgns = odf.Namespaces.svgns, stylens = odf.Namespaces.stylens, textns = odf.Namespaces.textns, numberns = odf.Namespaces.numberns, fons = odf.Namespaces.fons, odfUtils = new odf.OdfUtils, domUtils = new core.DomUtils, utils = new core.Utils, builtInDefaultStyleAttributesByFamily = {"paragraph":{"style:paragraph-properties":{"fo:text-align":"left"}}}, defaultPageFormatSettings = {width:21.001, height:29.7, margin:2, padding:0};
   function getBuiltInDefaultStyleAttributes(styleFamily) {
     var result, builtInDefaultStyleAttributes = builtInDefaultStyleAttributesByFamily[styleFamily];
     if(builtInDefaultStyleAttributes) {
@@ -8380,7 +8790,7 @@ odf.Formatting = function Formatting() {
   this.getAvailableParagraphStyles = function() {
     var node = odfContainer.rootElement.styles && odfContainer.rootElement.styles.firstChild, p_family, p_name, p_displayName, paragraphStyles = [], style;
     while(node) {
-      if(node.nodeType === Node.ELEMENT_NODE && node.localName === "style" && node.namespaceURI === stylens) {
+      if(node.nodeType === Node.ELEMENT_NODE && (node.localName === "style" && node.namespaceURI === stylens)) {
         style = node;
         p_family = style.getAttributeNS(stylens, "family");
         if(p_family === "paragraph") {
@@ -8398,13 +8808,13 @@ odf.Formatting = function Formatting() {
   this.isStyleUsed = function(styleElement) {
     var hasDerivedStyles, isUsed;
     hasDerivedStyles = styleInfo.hasDerivedStyles(odfContainer.rootElement, odf.Namespaces.resolvePrefix, styleElement);
-    isUsed = (new styleInfo.UsedStyleList(odfContainer.rootElement.styles)).uses(styleElement) || (new styleInfo.UsedStyleList(odfContainer.rootElement.automaticStyles)).uses(styleElement) || (new styleInfo.UsedStyleList(odfContainer.rootElement.body)).uses(styleElement);
+    isUsed = (new styleInfo.UsedStyleList(odfContainer.rootElement.styles)).uses(styleElement) || ((new styleInfo.UsedStyleList(odfContainer.rootElement.automaticStyles)).uses(styleElement) || (new styleInfo.UsedStyleList(odfContainer.rootElement.body)).uses(styleElement));
     return hasDerivedStyles || isUsed
   };
   function getDefaultStyleElement(family) {
     var node = odfContainer.rootElement.styles.firstChild;
     while(node) {
-      if(node.nodeType === Node.ELEMENT_NODE && node.namespaceURI === stylens && node.localName === "default-style" && node.getAttributeNS(stylens, "family") === family) {
+      if(node.nodeType === Node.ELEMENT_NODE && (node.namespaceURI === stylens && (node.localName === "default-style" && node.getAttributeNS(stylens, "family") === family))) {
         return node
       }
       node = node.nextSibling
@@ -8421,13 +8831,13 @@ odf.Formatting = function Formatting() {
       while(node) {
         if(node.nodeType === Node.ELEMENT_NODE) {
           nodeStyleName = node.getAttributeNS(stylens, "name");
-          if(node.namespaceURI === stylens && node.localName === "style" && node.getAttributeNS(stylens, "family") === family && nodeStyleName === styleName) {
+          if(node.namespaceURI === stylens && (node.localName === "style" && (node.getAttributeNS(stylens, "family") === family && nodeStyleName === styleName))) {
             return node
           }
-          if(family === "list-style" && node.namespaceURI === textns && node.localName === "list-style" && nodeStyleName === styleName) {
+          if(family === "list-style" && (node.namespaceURI === textns && (node.localName === "list-style" && nodeStyleName === styleName))) {
             return node
           }
-          if(family === "data" && node.namespaceURI === numberns && nodeStyleName === styleName) {
+          if(family === "data" && (node.namespaceURI === numberns && nodeStyleName === styleName)) {
             return node
           }
         }
@@ -8571,25 +8981,9 @@ odf.Formatting = function Formatting() {
     return styleChain ? calculateAppliedStyle(styleChain) : undefined
   };
   this.applyStyle = function(memberId, textNodes, limits, info) {
-    var textStyles = new odf.TextStyleApplicator(new odf.StyleNameGenerator("auto" + utils.hashString(memberId) + "_", self), self, odfContainer.rootElement.automaticStyles);
+    var textStyles = new odf.TextStyleApplicator(new odf.ObjectNameGenerator((odfContainer), memberId), self, odfContainer.rootElement.automaticStyles);
     textStyles.applyStyle(textNodes, limits, info)
   };
-  function getAllStyleNames() {
-    var styleElements = [odfContainer.rootElement.automaticStyles, odfContainer.rootElement.styles], node, styleNames = [];
-    styleElements.forEach(function(styleListElement) {
-      node = styleListElement.firstChild;
-      while(node) {
-        if(node.nodeType === Node.ELEMENT_NODE) {
-          if(node.namespaceURI === stylens && node.localName === "style" || node.namespaceURI === textns && node.localName === "list-style") {
-            styleNames.push(node.getAttributeNS(stylens, "name"))
-          }
-        }
-        node = node.nextSibling
-      }
-    });
-    return styleNames
-  }
-  this.getAllStyleNames = getAllStyleNames;
   this.updateStyle = function(styleNode, properties) {
     var fontName, fontFaceNode;
     mapObjOntoNode(styleNode, properties);
@@ -8622,6 +9016,99 @@ odf.Formatting = function Formatting() {
       tabStopDistance = "1.25cm"
     }
     return odfUtils.parseNonNegativeLength(tabStopDistance)
+  };
+  function getPageLayoutStyleElement(styleName, styleFamily) {
+    var styleElement = getStyleElement(styleName, styleFamily), masterPageName, layoutName, pageLayoutElements, node, i;
+    runtime.assert(styleFamily === "paragraph" || styleFamily === "table", "styleFamily has to be either paragraph or table");
+    if(styleElement) {
+      masterPageName = styleElement.getAttributeNS(stylens, "master-page-name") || "Standard";
+      node = odfContainer.rootElement.masterStyles.lastChild;
+      while(node && node.previousSibling) {
+        if(node.getAttributeNS(stylens, "name") === masterPageName) {
+          break
+        }
+        node = node.previousSibling
+      }
+      layoutName = node.getAttributeNS(stylens, "page-layout-name");
+      pageLayoutElements = domUtils.getElementsByTagNameNS(odfContainer.rootElement.automaticStyles, stylens, "page-layout");
+      for(i = 0;i < pageLayoutElements.length;i += 1) {
+        node = pageLayoutElements[i];
+        if(node.getAttributeNS(stylens, "name") === layoutName) {
+          return(node)
+        }
+      }
+    }
+    return null
+  }
+  function lengthInCm(length, defaultValue) {
+    var result = odfUtils.parseLength(length), value = defaultValue;
+    if(result) {
+      switch(result.unit) {
+        case "cm":
+          value = result.value;
+          break;
+        case "mm":
+          value = result.value * 0.1;
+          break;
+        case "in":
+          value = result.value * 2.54;
+          break;
+        case "pt":
+          value = result.value * 0.035277778;
+          break;
+        case "pc":
+        ;
+        case "px":
+        ;
+        case "em":
+          break;
+        default:
+          runtime.log("Unit identifier: " + result.unit + " is not supported.");
+          break
+      }
+    }
+    return value
+  }
+  this.getContentSize = function(styleName, styleFamily) {
+    var pageLayoutElement, props, printOrientation, defaultOrientedPageWidth, defaultOrientedPageHeight, pageWidth, pageHeight, margin, marginLeft, marginRight, marginTop, marginBottom, padding, paddingLeft, paddingRight, paddingTop, paddingBottom;
+    pageLayoutElement = getPageLayoutStyleElement(styleName, styleFamily);
+    if(!pageLayoutElement) {
+      pageLayoutElement = odfContainer.rootElement.styles.getElementsByTagNameNS(stylens, "default-page-layout")[0]
+    }
+    if(pageLayoutElement) {
+      props = pageLayoutElement.getElementsByTagNameNS(stylens, "page-layout-properties")[0]
+    }
+    if(props) {
+      printOrientation = props.getAttributeNS(stylens, "print-orientation") || "portrait";
+      if(printOrientation === "portrait") {
+        defaultOrientedPageWidth = defaultPageFormatSettings.width;
+        defaultOrientedPageHeight = defaultPageFormatSettings.height
+      }else {
+        defaultOrientedPageWidth = defaultPageFormatSettings.height;
+        defaultOrientedPageHeight = defaultPageFormatSettings.width
+      }
+      pageWidth = lengthInCm(props.getAttributeNS(fons, "page-width"), defaultOrientedPageWidth);
+      pageHeight = lengthInCm(props.getAttributeNS(fons, "page-height"), defaultOrientedPageHeight);
+      margin = lengthInCm(props.getAttributeNS(fons, "margin"), null);
+      if(margin === null) {
+        marginLeft = lengthInCm(props.getAttributeNS(fons, "margin-left"), defaultPageFormatSettings.margin);
+        marginRight = lengthInCm(props.getAttributeNS(fons, "margin-right"), defaultPageFormatSettings.margin);
+        marginTop = lengthInCm(props.getAttributeNS(fons, "margin-top"), defaultPageFormatSettings.margin);
+        marginBottom = lengthInCm(props.getAttributeNS(fons, "margin-bottom"), defaultPageFormatSettings.margin)
+      }else {
+        marginLeft = marginRight = marginTop = marginBottom = margin
+      }
+      padding = lengthInCm(props.getAttributeNS(fons, "padding"), null);
+      if(padding === null) {
+        paddingLeft = lengthInCm(props.getAttributeNS(fons, "padding-left"), defaultPageFormatSettings.padding);
+        paddingRight = lengthInCm(props.getAttributeNS(fons, "padding-right"), defaultPageFormatSettings.padding);
+        paddingTop = lengthInCm(props.getAttributeNS(fons, "padding-top"), defaultPageFormatSettings.padding);
+        paddingBottom = lengthInCm(props.getAttributeNS(fons, "padding-bottom"), defaultPageFormatSettings.padding)
+      }else {
+        paddingLeft = paddingRight = paddingTop = paddingBottom = padding
+      }
+    }
+    return{width:pageWidth - marginLeft - marginRight - paddingLeft - paddingRight, height:pageHeight - marginTop - marginBottom - paddingTop - paddingBottom}
   }
 };
 /*
@@ -8635,6 +9122,9 @@ odf.Formatting = function Formatting() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -8656,7 +9146,7 @@ odf.Formatting = function Formatting() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("odf.OdfContainer");
@@ -8787,7 +9277,7 @@ odf.OdfCanvas = function() {
       if(rangeA === null || rangeB === null) {
         return true
       }
-      return rangeA.startContainer !== rangeB.startContainer || rangeA.startOffset !== rangeB.startOffset || rangeA.endContainer !== rangeB.endContainer || rangeA.endOffset !== rangeB.endOffset
+      return rangeA.startContainer !== rangeB.startContainer || (rangeA.startOffset !== rangeB.startOffset || (rangeA.endContainer !== rangeB.endContainer || rangeA.endOffset !== rangeB.endOffset))
     }
     function emitNewSelection() {
       var i, l = listeners.length;
@@ -8841,7 +9331,7 @@ odf.OdfCanvas = function() {
     listenEvent(element, "keyup", checkSelection);
     listenEvent(element, "keydown", checkSelection)
   }
-  var drawns = odf.Namespaces.drawns, fons = odf.Namespaces.fons, officens = odf.Namespaces.officens, stylens = odf.Namespaces.stylens, svgns = odf.Namespaces.svgns, tablens = odf.Namespaces.tablens, textns = odf.Namespaces.textns, xlinkns = odf.Namespaces.xlinkns, xmlns = odf.Namespaces.xmlns, presentationns = odf.Namespaces.presentationns, window = runtime.getWindow(), xpath = new xmldom.XPath, utils = new odf.OdfUtils, domUtils = new core.DomUtils, shadowContent;
+  var drawns = odf.Namespaces.drawns, fons = odf.Namespaces.fons, officens = odf.Namespaces.officens, stylens = odf.Namespaces.stylens, svgns = odf.Namespaces.svgns, tablens = odf.Namespaces.tablens, textns = odf.Namespaces.textns, xlinkns = odf.Namespaces.xlinkns, xmlns = odf.Namespaces.xmlns, presentationns = odf.Namespaces.presentationns, webodfhelperns = "urn:webodf:names:helper", window = runtime.getWindow(), xpath = new xmldom.XPath, odfUtils = new odf.OdfUtils, domUtils = new core.DomUtils;
   function clear(element) {
     while(element.firstChild) {
       element.removeChild(element.firstChild)
@@ -8855,56 +9345,61 @@ odf.OdfCanvas = function() {
     var fontLoader = new odf.FontLoader;
     fontLoader.loadFonts(odfContainer, fontcss.sheet)
   }
-  function getMasterPage(odfContainer, masterPageName) {
+  function getMasterPageElement(odfContainer, masterPageName) {
     if(!masterPageName) {
       return null
     }
-    var masterStyles = odfContainer.rootElement.masterStyles, masterPages = masterStyles.getElementsByTagNameNS(stylens, "master-page"), masterPage = null, i;
-    for(i = 0;i < masterPages.length;i += 1) {
-      if(masterPages[i].getAttributeNS(stylens, "name") === masterPageName) {
-        masterPage = masterPages[i];
+    var masterStyles = odfContainer.rootElement.masterStyles, masterPageElements = masterStyles.getElementsByTagNameNS(stylens, "master-page"), masterPageElement = null, i;
+    for(i = 0;i < masterPageElements.length;i += 1) {
+      if(masterPageElements[i].getAttributeNS(stylens, "name") === masterPageName) {
+        masterPageElement = masterPageElements[i];
         break
       }
     }
-    return masterPage
+    return masterPageElement
   }
-  function setFramePosition(odfContainer, id, frame, stylesheet) {
-    frame.setAttribute("styleid", id);
-    var rule, anchor = frame.getAttributeNS(textns, "anchor-type"), x = frame.getAttributeNS(svgns, "x"), y = frame.getAttributeNS(svgns, "y"), width = frame.getAttributeNS(svgns, "width"), height = frame.getAttributeNS(svgns, "height"), minheight = frame.getAttributeNS(fons, "min-height"), minwidth = frame.getAttributeNS(fons, "min-width"), masterPageName = frame.getAttributeNS(drawns, "master-page-name"), masterPage = null, j, clonedPage, clonedNode, pageNumber = 0, pageNumberContainer, node, document = 
-    odfContainer.rootElement.ownerDocument;
-    masterPage = getMasterPage(odfContainer, masterPageName);
-    if(masterPage) {
-      clonedPage = document.createElementNS(drawns, "draw:page");
-      node = masterPage.firstElementChild;
-      j = 0;
-      while(node) {
-        if(node.getAttributeNS(presentationns, "placeholder") !== "true") {
-          clonedNode = node.cloneNode(true);
-          clonedPage.appendChild(clonedNode);
-          setFramePosition(odfContainer, id + "_" + j, (clonedNode), stylesheet)
-        }
-        node = node.nextElementSibling;
-        j += 1
+  function dropTemplateDrawFrames(clonedNode) {
+    var i, element, presentationClass, clonedDrawFrameElements = clonedNode.getElementsByTagNameNS(drawns, "frame");
+    for(i = 0;i < clonedDrawFrameElements.length;i += 1) {
+      element = clonedDrawFrameElements[i];
+      presentationClass = element.getAttributeNS(presentationns, "class");
+      if(presentationClass && !/^(date-time|footer|header|page-number')$/.test(presentationClass)) {
+        element.parentNode.removeChild(element)
       }
-      shadowContent.appendChild(clonedPage);
-      pageNumber = shadowContent.getElementsByTagNameNS(drawns, "page").length;
-      pageNumberContainer = clonedPage.getElementsByTagNameNS(textns, "page-number")[0];
-      if(pageNumberContainer) {
-        while(pageNumberContainer.firstChild) {
-          pageNumberContainer.removeChild(pageNumberContainer.firstChild)
-        }
-        pageNumberContainer.appendChild(document.createTextNode(pageNumber))
-      }
-      setFramePosition(odfContainer, id, clonedPage, stylesheet);
-      clonedPage.setAttributeNS(drawns, "draw:master-page-name", masterPage.getAttributeNS(stylens, "name"))
     }
+  }
+  function getHeaderFooter(odfContainer, frame, headerFooterId) {
+    var headerFooter = null, i, declElements = odfContainer.rootElement.body.getElementsByTagNameNS(presentationns, headerFooterId + "-decl"), headerFooterName = frame.getAttributeNS(presentationns, "use-" + headerFooterId + "-name");
+    if(headerFooterName && declElements.length > 0) {
+      for(i = 0;i < declElements.length;i += 1) {
+        if(declElements[i].getAttributeNS(presentationns, "name") === headerFooterName) {
+          headerFooter = declElements[i].textContent;
+          break
+        }
+      }
+    }
+    return headerFooter
+  }
+  function setContainerValue(rootElement, ns, localName, value) {
+    var i, containerList, document = rootElement.ownerDocument;
+    containerList = rootElement.getElementsByTagNameNS(ns, localName);
+    for(i = 0;i < containerList.length;i += 1) {
+      clear(containerList[i]);
+      if(value) {
+        containerList[i].appendChild(document.createTextNode(value))
+      }
+    }
+  }
+  function setDrawElementPosition(styleid, frame, stylesheet) {
+    frame.setAttributeNS(webodfhelperns, "styleid", styleid);
+    var rule, anchor = frame.getAttributeNS(textns, "anchor-type"), x = frame.getAttributeNS(svgns, "x"), y = frame.getAttributeNS(svgns, "y"), width = frame.getAttributeNS(svgns, "width"), height = frame.getAttributeNS(svgns, "height"), minheight = frame.getAttributeNS(fons, "min-height"), minwidth = frame.getAttributeNS(fons, "min-width");
     if(anchor === "as-char") {
       rule = "display: inline-block;"
     }else {
-      if(anchor || x || y) {
+      if(anchor || (x || y)) {
         rule = "position: absolute;"
       }else {
-        if(width || height || minheight || minwidth) {
+        if(width || (height || (minheight || minwidth))) {
           rule = "display: block;"
         }
       }
@@ -8928,7 +9423,7 @@ odf.OdfCanvas = function() {
       rule += "min-width: " + minwidth + ";"
     }
     if(rule) {
-      rule = "draw|" + frame.localName + '[styleid="' + id + '"] {' + rule + "}";
+      rule = "draw|" + frame.localName + '[webodfhelper|styleid="' + styleid + '"] {' + rule + "}";
       stylesheet.insertRule(rule, stylesheet.cssRules.length)
     }
   }
@@ -8943,13 +9438,13 @@ odf.OdfCanvas = function() {
     return""
   }
   function setImage(id, container, image, stylesheet) {
-    image.setAttribute("styleid", id);
+    image.setAttributeNS(webodfhelperns, "styleid", id);
     var url = image.getAttributeNS(xlinkns, "href"), part;
     function callback(url) {
       var rule;
       if(url) {
         rule = "background-image: url(" + url + ");";
-        rule = 'draw|image[styleid="' + id + '"] {' + rule + "}";
+        rule = 'draw|image[webodfhelper|styleid="' + id + '"] {' + rule + "}";
         stylesheet.insertRule(rule, stylesheet.cssRules.length)
       }
     }
@@ -8969,11 +9464,11 @@ odf.OdfCanvas = function() {
     }
   }
   function formatParagraphAnchors(odfbody) {
-    var runtimens = "urn:webodf", n, i, nodes = xpath.getODFElementsWithXPath(odfbody, ".//*[*[@text:anchor-type='paragraph']]", odf.Namespaces.resolvePrefix);
+    var n, i, nodes = xpath.getODFElementsWithXPath(odfbody, ".//*[*[@text:anchor-type='paragraph']]", odf.Namespaces.resolvePrefix);
     for(i = 0;i < nodes.length;i += 1) {
       n = nodes[i];
       if(n.setAttributeNS) {
-        n.setAttributeNS(runtimens, "containsparagraphanchor", true)
+        n.setAttributeNS(webodfhelperns, "containsparagraphanchor", true)
       }
     }
   }
@@ -9026,6 +9521,14 @@ odf.OdfCanvas = function() {
       modifyLink(node)
     }
   }
+  function modifyLineBreakElements(odffragment) {
+    var document = odffragment.ownerDocument, lineBreakElements = domUtils.getElementsByTagNameNS(odffragment, textns, "line-break");
+    lineBreakElements.forEach(function(lineBreak) {
+      if(!lineBreak.hasChildNodes()) {
+        lineBreak.appendChild(document.createElement("br"))
+      }
+    })
+  }
   function expandSpaceElements(odffragment) {
     var spaces, doc = odffragment.ownerDocument;
     function expandSpaceElement(space) {
@@ -9052,18 +9555,18 @@ odf.OdfCanvas = function() {
       tab.textContent = "\t"
     })
   }
-  function modifyImages(container, odfbody, stylesheet) {
-    var node, frames, i;
-    frames = [];
+  function modifyDrawElements(odfbody, stylesheet) {
+    var node, drawElements, i;
+    drawElements = [];
     node = odfbody.firstChild;
     while(node && node !== odfbody) {
       if(node.namespaceURI === drawns) {
-        frames[frames.length] = node
+        drawElements[drawElements.length] = node
       }
       if(node.firstChild) {
         node = node.firstChild
       }else {
-        while(node && node !== odfbody && !node.nextSibling) {
+        while(node && (node !== odfbody && !node.nextSibling)) {
           node = node.parentNode
         }
         if(node && node.nextSibling) {
@@ -9071,11 +9574,47 @@ odf.OdfCanvas = function() {
         }
       }
     }
-    for(i = 0;i < frames.length;i += 1) {
-      node = frames[i];
-      setFramePosition(container, "frame" + String(i), node, stylesheet)
+    for(i = 0;i < drawElements.length;i += 1) {
+      node = drawElements[i];
+      setDrawElementPosition("frame" + String(i), node, stylesheet)
     }
     formatParagraphAnchors(odfbody)
+  }
+  function cloneMasterPages(odfContainer, shadowContent, odfbody, stylesheet) {
+    var masterPageName, masterPageElement, styleId, clonedPageElement, clonedElement, pageNumber = 0, i, element, elementToClone, document = odfContainer.rootElement.ownerDocument;
+    element = odfbody.firstElementChild;
+    if(!(element && (element.namespaceURI === officens && (element.localName === "presentation" || element.localName === "drawing")))) {
+      return
+    }
+    element = element.firstElementChild;
+    while(element) {
+      masterPageName = element.getAttributeNS(drawns, "master-page-name");
+      masterPageElement = getMasterPageElement(odfContainer, masterPageName);
+      if(masterPageElement) {
+        styleId = element.getAttributeNS(webodfhelperns, "styleid");
+        clonedPageElement = document.createElementNS(drawns, "draw:page");
+        elementToClone = masterPageElement.firstElementChild;
+        i = 0;
+        while(elementToClone) {
+          if(elementToClone.getAttributeNS(presentationns, "placeholder") !== "true") {
+            clonedElement = elementToClone.cloneNode(true);
+            clonedPageElement.appendChild(clonedElement);
+            setDrawElementPosition(styleId + "_" + i, (clonedElement), stylesheet)
+          }
+          elementToClone = elementToClone.nextElementSibling;
+          i += 1
+        }
+        dropTemplateDrawFrames(clonedPageElement);
+        shadowContent.appendChild(clonedPageElement);
+        pageNumber = String(shadowContent.getElementsByTagNameNS(drawns, "page").length);
+        setContainerValue(clonedPageElement, textns, "page-number", pageNumber);
+        setContainerValue(clonedPageElement, presentationns, "header", getHeaderFooter(odfContainer, (element), "header"));
+        setContainerValue(clonedPageElement, presentationns, "footer", getHeaderFooter(odfContainer, (element), "footer"));
+        setDrawElementPosition(styleId, clonedPageElement, stylesheet);
+        clonedPageElement.setAttributeNS(drawns, "draw:master-page-name", masterPageElement.getAttributeNS(stylens, "name"))
+      }
+      element = element.nextElementSibling
+    }
   }
   function setVideo(container, plugin) {
     var video, source, url, doc = plugin.ownerDocument, part;
@@ -9174,7 +9713,7 @@ odf.OdfCanvas = function() {
         styleName = node.getAttributeNS(textns, "style-name");
         if(styleName) {
           node = listStyleMap[styleName];
-          bulletRule = getBulletsRule((utils.getFirstNonWhitespaceChild(node)))
+          bulletRule = getBulletsRule((odfUtils.getFirstNonWhitespaceChild(node)))
         }
         if(continueList) {
           parentList = listMap[continueList];
@@ -9234,6 +9773,7 @@ odf.OdfCanvas = function() {
     odf.Namespaces.forEachPrefix(function(prefix, ns) {
       text += "@namespace " + prefix + " url(" + ns + ");\n"
     });
+    text += "@namespace webodfhelper url(" + webodfhelperns + ");\n";
     style.appendChild(document.createTextNode(text));
     head.appendChild(style);
     return(style)
@@ -9241,7 +9781,7 @@ odf.OdfCanvas = function() {
   odf.OdfCanvas = function OdfCanvas(element) {
     runtime.assert(element !== null && element !== undefined, "odf.OdfCanvas constructor needs DOM element");
     runtime.assert(element.ownerDocument !== null && element.ownerDocument !== undefined, "odf.OdfCanvas constructor needs DOM");
-    var self = this, doc = (element.ownerDocument), odfcontainer, formatting = new odf.Formatting, selectionWatcher = new SelectionWatcher(element), pageSwitcher, sizer, annotationsPane, allowAnnotations = false, annotationManager, webodfcss, fontcss, stylesxmlcss, positioncss, zoomLevel = 1, eventHandlers = {}, loadingQueue = new LoadingQueue;
+    var self = this, doc = (element.ownerDocument), odfcontainer, formatting = new odf.Formatting, selectionWatcher = new SelectionWatcher(element), pageSwitcher, sizer, annotationsPane, allowAnnotations = false, annotationManager, webodfcss, fontcss, stylesxmlcss, positioncss, shadowContent, zoomLevel = 1, eventHandlers = {}, loadingQueue = new LoadingQueue;
     function loadImages(container, odffragment, stylesheet) {
       var i, images, node;
       function loadImage(name, container, node, stylesheet) {
@@ -9325,9 +9865,11 @@ odf.OdfCanvas = function() {
       shadowContent.style.top = 0;
       shadowContent.style.left = 0;
       container.getContentElement().appendChild(shadowContent);
-      modifyImages(container, odfnode.body, css);
+      modifyDrawElements(odfnode.body, css);
+      cloneMasterPages(container, shadowContent, odfnode.body, css);
       modifyTables(odfnode.body);
       modifyLinks(odfnode.body);
+      modifyLineBreakElements(odfnode.body);
       expandSpaceElements(odfnode.body);
       expandTabElements(odfnode.body);
       loadImages(container, odfnode.body, css);
@@ -9414,7 +9956,7 @@ odf.OdfCanvas = function() {
     };
     function load(url) {
       loadingQueue.clearQueue();
-      element.innerHTML = "loading " + url;
+      element.innerHTML = runtime.tr("Loading") + " " + url + "...";
       element.removeAttribute("style");
       odfcontainer = new odf.OdfContainer(url, function(container) {
         odfcontainer = container;
@@ -9528,6 +10070,11 @@ odf.OdfCanvas = function() {
     this.getElement = function() {
       return element
     };
+    this.addCssForFrameWithImage = function(frame) {
+      var frameName = frame.getAttributeNS(drawns, "name");
+      setDrawElementPosition(frameName, frame, positioncss.sheet);
+      setImage(frameName + "img", odfcontainer, (frame.firstChild), positioncss.sheet)
+    };
     this.destroy = function(callback) {
       var head = doc.getElementsByTagName("head")[0];
       if(annotationsPane && annotationsPane.parentNode) {
@@ -9601,6 +10148,9 @@ odf.CommandLineTools = function CommandLineTools() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9621,7 +10171,7 @@ odf.CommandLineTools = function CommandLineTools() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.Server = function Server() {
 };
@@ -9649,6 +10199,9 @@ ops.Server.prototype.getGenesisUrl = function(sessionId) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9669,13 +10222,11 @@ ops.Server.prototype.getGenesisUrl = function(sessionId) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.Operation = function Operation() {
 };
 ops.Operation.prototype.init = function(data) {
-};
-ops.Operation.prototype.transform = function(otherOp, hasPriority) {
 };
 ops.Operation.prototype.execute = function(odtDocument) {
 };
@@ -9693,6 +10244,9 @@ ops.Operation.prototype.spec = function() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9713,16 +10267,13 @@ ops.Operation.prototype.spec = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpAddCursor = function OpAddCursor() {
-  var self = this, memberid, timestamp;
+  var memberid, timestamp;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp
-  };
-  this.transform = function(otherOp, hasPriority) {
-    return[self]
   };
   this.execute = function(odtDocument) {
     var cursor = odtDocument.getCursor(memberid);
@@ -9750,6 +10301,9 @@ ops.OpAddCursor = function OpAddCursor() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9770,7 +10324,7 @@ ops.OpAddCursor = function OpAddCursor() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("odf.Namespaces");
@@ -9797,11 +10351,10 @@ gui.StyleHelper = function StyleHelper(formatting) {
     formatting.applyStyle(memberId, textNodes, limits, info);
     nextTextNodes.forEach(domUtils.normalizeTextNodes)
   };
-  function hasTextPropertyValue(range, propertyName, propertyValue) {
-    var hasOtherValue = true, styles, properties, i;
-    styles = getAppliedStyles(range);
-    for(i = 0;i < styles.length;i += 1) {
-      properties = styles[i]["style:text-properties"];
+  function hasTextPropertyValue(appliedStyles, propertyName, propertyValue) {
+    var hasOtherValue = true, properties, i;
+    for(i = 0;i < appliedStyles.length;i += 1) {
+      properties = appliedStyles[i]["style:text-properties"];
       hasOtherValue = !properties || properties[propertyName] !== propertyValue;
       if(hasOtherValue) {
         break
@@ -9809,17 +10362,17 @@ gui.StyleHelper = function StyleHelper(formatting) {
     }
     return!hasOtherValue
   }
-  this.isBold = function(range) {
-    return hasTextPropertyValue(range, "fo:font-weight", "bold")
+  this.isBold = function(appliedStyles) {
+    return hasTextPropertyValue(appliedStyles, "fo:font-weight", "bold")
   };
-  this.isItalic = function(range) {
-    return hasTextPropertyValue(range, "fo:font-style", "italic")
+  this.isItalic = function(appliedStyles) {
+    return hasTextPropertyValue(appliedStyles, "fo:font-style", "italic")
   };
-  this.hasUnderline = function(range) {
-    return hasTextPropertyValue(range, "style:text-underline-style", "solid")
+  this.hasUnderline = function(appliedStyles) {
+    return hasTextPropertyValue(appliedStyles, "style:text-underline-style", "solid")
   };
-  this.hasStrikeThrough = function(range) {
-    return hasTextPropertyValue(range, "style:text-line-through-style", "solid")
+  this.hasStrikeThrough = function(appliedStyles) {
+    return hasTextPropertyValue(appliedStyles, "style:text-line-through-style", "solid")
   };
   function hasParagraphPropertyValue(range, propertyName, propertyValues) {
     var nodes = odfUtils.getParagraphElements(range), isStyleChecked = {}, isDefaultParagraphStyleChecked = false, paragraphStyleName, paragraphStyleElement, paragraphStyleAttributes, properties;
@@ -9874,6 +10427,9 @@ gui.StyleHelper = function StyleHelper(formatting) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9894,7 +10450,7 @@ gui.StyleHelper = function StyleHelper(formatting) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("gui.StyleHelper");
 runtime.loadClass("odf.OdfUtils");
@@ -9907,9 +10463,6 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
     length = parseInt(data.length, 10);
     setProperties = data.setProperties
   };
-  this.transform = function(otherOp, hasPriority) {
-    return null
-  };
   function getRange(odtDocument) {
     var point1 = length >= 0 ? position : position + length, point2 = length >= 0 ? position + length : position, p1 = odtDocument.getIteratorAtPosition(point1), p2 = length ? odtDocument.getIteratorAtPosition(point2) : p1, range = odtDocument.getDOM().createRange();
     range.setStart(p1.container(), p1.unfilteredDomOffset());
@@ -9921,6 +10474,7 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
     styleHelper.applyStyle(memberid, range, setProperties);
     range.detach();
     odtDocument.getOdfCanvas().refreshCSS();
+    odtDocument.fixCursorPositions();
     impactedParagraphs.forEach(function(n) {
       odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:n, memberId:memberid, timeStamp:timestamp})
     });
@@ -9943,6 +10497,9 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -9963,20 +10520,13 @@ ops.OpApplyDirectStyling = function OpApplyDirectStyling() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpRemoveCursor = function OpRemoveCursor() {
-  var self = this, optype = "RemoveCursor", memberid, timestamp;
+  var memberid, timestamp;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), result = [self];
-    if(otherOpspec.optype === optype && otherOpspec.memberid === memberid) {
-      result = []
-    }
-    return result
   };
   this.execute = function(odtDocument) {
     if(!odtDocument.removeCursor(memberid)) {
@@ -9985,7 +10535,7 @@ ops.OpRemoveCursor = function OpRemoveCursor() {
     return true
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp}
+    return{optype:"RemoveCursor", memberid:memberid, timestamp:timestamp}
   }
 };
 /*
@@ -10000,6 +10550,9 @@ ops.OpRemoveCursor = function OpRemoveCursor() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -10020,97 +10573,16 @@ ops.OpRemoveCursor = function OpRemoveCursor() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpMoveCursor = function OpMoveCursor() {
-  var self = this, memberid, timestamp, position, length;
+  var memberid, timestamp, position, length, selectionType;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
-    position = parseInt(data.position, 10);
-    length = data.length !== undefined ? parseInt(data.length, 10) : 0
-  };
-  function countSteps(number, stepCounter, positionFilter) {
-    if(number > 0) {
-      return stepCounter.countForwardSteps(number, positionFilter)
-    }
-    if(number < 0) {
-      return-stepCounter.countBackwardSteps(-number, positionFilter)
-    }
-    return 0
-  }
-  this.merge = function(otherOpspec) {
-    if(otherOpspec.optype === "MoveCursor" && otherOpspec.memberid === memberid) {
-      position = otherOpspec.position;
-      length = otherOpspec.length;
-      timestamp = otherOpspec.timestamp;
-      return true
-    }
-    return false
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, end = position + length, otherOpspecEnd, result = [self];
-    switch(otherOptype) {
-      case "RemoveText":
-        otherOpspecEnd = otherOpspec.position + otherOpspec.length;
-        if(otherOpspecEnd <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < end) {
-            if(position < otherOpspec.position) {
-              if(otherOpspecEnd < end) {
-                length = length - otherOpspec.length
-              }else {
-                length = otherOpspec.position - position
-              }
-            }else {
-              position = otherOpspec.position;
-              if(otherOpspecEnd < end) {
-                length = end - otherOpspecEnd
-              }else {
-                length = 0
-              }
-            }
-          }
-        }
-        break;
-      case "SplitParagraph":
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position <= end) {
-            length += 1
-          }
-        }
-        break;
-      case "AddAnnotation":
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position < end) {
-            length += 1
-          }
-        }
-        break;
-      case "InsertText":
-        if(otherOpspec.position < position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position <= end) {
-            length += otherOpspec.text.length
-          }
-        }
-        break;
-      case "RemoveCursor":
-        if(otherOpspec.memberid === memberid) {
-          result = []
-        }
-        break;
-      case "InsertTable":
-        result = null;
-        break
-    }
-    return result
+    position = data.position;
+    length = data.length || 0;
+    selectionType = data.selectionType || ops.OdtCursor.RangeSelection
   };
   this.execute = function(odtDocument) {
     var cursor = odtDocument.getCursor(memberid), oldPosition = odtDocument.getCursorPosition(memberid), positionFilter = odtDocument.getPositionFilter(), number = position - oldPosition, stepsToSelectionStart, stepsToSelectionEnd, stepCounter;
@@ -10118,17 +10590,210 @@ ops.OpMoveCursor = function OpMoveCursor() {
       return false
     }
     stepCounter = cursor.getStepCounter();
-    stepsToSelectionStart = countSteps(number, stepCounter, positionFilter);
+    stepsToSelectionStart = stepCounter.countSteps(number, positionFilter);
     cursor.move(stepsToSelectionStart);
     if(length) {
-      stepsToSelectionEnd = countSteps(length, stepCounter, positionFilter);
+      stepsToSelectionEnd = stepCounter.countSteps(length, positionFilter);
       cursor.move(stepsToSelectionEnd, true)
     }
+    cursor.setSelectionType(selectionType);
     odtDocument.emit(ops.OdtDocument.signalCursorMoved, cursor);
     return true
   };
   this.spec = function() {
-    return{optype:"MoveCursor", memberid:memberid, timestamp:timestamp, position:position, length:length}
+    return{optype:"MoveCursor", memberid:memberid, timestamp:timestamp, position:position, length:length, selectionType:selectionType}
+  }
+};
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.OpSetBlob = function OpSetBlob() {
+  var memberid, timestamp, filename, mimetype, content;
+  this.init = function(data) {
+    memberid = data.memberid;
+    timestamp = data.timestamp;
+    filename = data.filename;
+    mimetype = data.mimetype;
+    content = data.content
+  };
+  this.execute = function(odtDocument) {
+    odtDocument.getOdfCanvas().odfContainer().setBlob(filename, mimetype, content);
+    return true
+  };
+  this.spec = function() {
+    return{optype:"SetBlob", memberid:memberid, timestamp:timestamp, filename:filename, mimetype:mimetype, content:content}
+  }
+};
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.OpRemoveBlob = function OpRemoveBlob() {
+  var memberid, timestamp, filename;
+  this.init = function(data) {
+    memberid = data.memberid;
+    timestamp = data.timestamp;
+    filename = data.filename
+  };
+  this.execute = function(odtDocument) {
+    odtDocument.getOdfCanvas().odfContainer().removeBlob(filename);
+    return true
+  };
+  this.spec = function() {
+    return{optype:"RemoveBlob", memberid:memberid, timestamp:timestamp, filename:filename}
+  }
+};
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.OpInsertImage = function OpInsertImage() {
+  var memberid, timestamp, position, filename, frameWidth, frameHeight, frameStyleName, frameName, drawns = odf.Namespaces.drawns, svgns = odf.Namespaces.svgns, textns = odf.Namespaces.textns, xlinkns = odf.Namespaces.xlinkns;
+  this.init = function(data) {
+    memberid = data.memberid;
+    timestamp = data.timestamp;
+    position = data.position;
+    filename = data.filename;
+    frameWidth = data.frameWidth;
+    frameHeight = data.frameHeight;
+    frameStyleName = data.frameStyleName;
+    frameName = data.frameName
+  };
+  function createFrameElement(document) {
+    var imageNode = document.createElementNS(drawns, "draw:image"), frameNode = document.createElementNS(drawns, "draw:frame");
+    imageNode.setAttributeNS(xlinkns, "xlink:href", filename);
+    imageNode.setAttributeNS(xlinkns, "xlink:type", "simple");
+    imageNode.setAttributeNS(xlinkns, "xlink:show", "embed");
+    imageNode.setAttributeNS(xlinkns, "xlink:actuate", "onLoad");
+    frameNode.setAttributeNS(drawns, "draw:style-name", frameStyleName);
+    frameNode.setAttributeNS(drawns, "draw:name", frameName);
+    frameNode.setAttributeNS(textns, "text:anchor-type", "as-char");
+    frameNode.setAttributeNS(svgns, "svg:width", frameWidth);
+    frameNode.setAttributeNS(svgns, "svg:height", frameHeight);
+    frameNode.appendChild(imageNode);
+    return frameNode
+  }
+  this.execute = function(odtDocument) {
+    var odfCanvas = odtDocument.getOdfCanvas(), domPosition = odtDocument.getPositionInTextNode(position, memberid), textNode, refNode, paragraphElement, frameElement;
+    if(!domPosition) {
+      return false
+    }
+    textNode = domPosition.textNode;
+    paragraphElement = odtDocument.getParagraphElement(textNode);
+    refNode = domPosition.offset !== textNode.length ? textNode.splitText(domPosition.offset) : textNode.nextSibling;
+    frameElement = createFrameElement(odtDocument.getDOM());
+    textNode.parentNode.insertBefore(frameElement, refNode);
+    if(textNode.length === 0) {
+      textNode.parentNode.removeChild(textNode)
+    }
+    odfCanvas.addCssForFrameWithImage(frameElement);
+    odfCanvas.refreshCSS();
+    odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:paragraphElement, memberId:memberid, timeStamp:timestamp});
+    odfCanvas.rerenderAnnotations();
+    return true
+  };
+  this.spec = function() {
+    return{optype:"InsertImage", memberid:memberid, timestamp:timestamp, filename:filename, position:position, frameWidth:frameWidth, frameHeight:frameHeight, frameStyleName:frameStyleName, frameName:frameName}
   }
 };
 /*
@@ -10143,6 +10808,9 @@ ops.OpMoveCursor = function OpMoveCursor() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -10163,63 +10831,20 @@ ops.OpMoveCursor = function OpMoveCursor() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpInsertTable = function OpInsertTable() {
-  var self = this, optype = "InsertTable", memberid, timestamp, initialRows, initialColumns, position, tableName, tableStyleName, tableColumnStyleName, tableCellStyleMatrix, tablens = "urn:oasis:names:tc:opendocument:xmlns:table:1.0", textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0";
+  var memberid, timestamp, initialRows, initialColumns, position, tableName, tableStyleName, tableColumnStyleName, tableCellStyleMatrix, tablens = "urn:oasis:names:tc:opendocument:xmlns:table:1.0", textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0";
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
-    position = parseInt(data.position, 10);
-    initialRows = parseInt(data.initialRows, 10);
-    initialColumns = parseInt(data.initialColumns, 10);
+    position = data.position;
+    initialRows = data.initialRows;
+    initialColumns = data.initialColumns;
     tableName = data.tableName;
     tableStyleName = data.tableStyleName;
     tableColumnStyleName = data.tableColumnStyleName;
     tableCellStyleMatrix = data.tableCellStyleMatrix
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, result = [self];
-    switch(otherOptype) {
-      case optype:
-        result = null;
-        break;
-      case "AddAnnotation":
-        if(otherOpspec.position < position) {
-          position += 1
-        }
-        break;
-      case "SplitParagraph":
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += 1;
-            result = null
-          }
-        }
-        break;
-      case "InsertText":
-        if(otherOpspec.position < position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += otherOpspec.text.length;
-            result = null
-          }
-        }
-        break;
-      case "RemoveText":
-        if(otherOpspec.position + otherOpspec.length <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < position) {
-            position = otherOpspec.position
-          }
-        }
-        break
-    }
-    return result
   };
   function getCellStyleName(row, column) {
     var rowStyles;
@@ -10291,7 +10916,7 @@ ops.OpInsertTable = function OpInsertTable() {
     if(domPosition) {
       tableNode = createTableNode(odtDocument.getDOM());
       previousSibling = odtDocument.getParagraphElement(domPosition.textNode);
-      rootNode.insertBefore(tableNode, previousSibling ? previousSibling.nextSibling : undefined);
+      rootNode.insertBefore(tableNode, previousSibling.nextSibling);
       odtDocument.getOdfCanvas().refreshSize();
       odtDocument.emit(ops.OdtDocument.signalTableAdded, {tableElement:tableNode, memberId:memberid, timeStamp:timestamp});
       odtDocument.getOdfCanvas().rerenderAnnotations();
@@ -10300,7 +10925,7 @@ ops.OpInsertTable = function OpInsertTable() {
     return false
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position, initialRows:initialRows, initialColumns:initialColumns, tableName:tableName, tableStyleName:tableStyleName, tableColumnStyleName:tableColumnStyleName, tableCellStyleMatrix:tableCellStyleMatrix}
+    return{optype:"InsertTable", memberid:memberid, timestamp:timestamp, position:position, initialRows:initialRows, initialColumns:initialColumns, tableName:tableName, tableStyleName:tableStyleName, tableColumnStyleName:tableColumnStyleName, tableCellStyleMatrix:tableCellStyleMatrix}
   }
 };
 /*
@@ -10314,6 +10939,9 @@ ops.OpInsertTable = function OpInsertTable() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -10335,66 +10963,15 @@ ops.OpInsertTable = function OpInsertTable() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpInsertText = function OpInsertText() {
-  var self = this, space = " ", tab = "\t", optype = "InsertText", memberid, timestamp, position, text;
+  var space = " ", tab = "\t", memberid, timestamp, position, text;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
-    position = parseInt(data.position, 10);
+    position = data.position;
     text = data.text
-  };
-  this.merge = function(otherOpspec) {
-    if(otherOpspec.optype === optype && otherOpspec.memberid === memberid && otherOpspec.position === position + text.length) {
-      text = text + otherOpspec.text;
-      timestamp = otherOpspec.timestamp;
-      return true
-    }
-    return false
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, result = [self];
-    switch(otherOptype) {
-      case optype:
-        if(otherOpspec.position < position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += otherOpspec.text.length;
-            result = null
-          }
-        }
-        break;
-      case "AddAnnotation":
-        if(otherOpspec.position < position) {
-          position += 1
-        }
-        break;
-      case "SplitParagraph":
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += 1;
-            result = null
-          }
-        }
-        break;
-      case "InsertTable":
-        result = null;
-        break;
-      case "RemoveText":
-        if(otherOpspec.position + otherOpspec.length <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < position) {
-            position = otherOpspec.position
-          }
-        }
-        break
-    }
-    return result
   };
   function triggerLayoutInWebkit(textNode) {
     var parent = textNode.parentNode, next = textNode.nextSibling;
@@ -10402,10 +10979,10 @@ ops.OpInsertText = function OpInsertText() {
     parent.insertBefore(textNode, next)
   }
   function requiresSpaceElement(text, index) {
-    return text[index] === space && (index === 0 || text[index - 1] === space)
+    return text[index] === space && (index === 0 || (index === text.length - 1 || text[index - 1] === space))
   }
   this.execute = function(odtDocument) {
-    var domPosition, previousNode, parentElement, nextNode, ownerDocument = odtDocument.getDOM(), paragraphElement, textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0", toInsertIndex = 0, spaceTag, spaceElement, i;
+    var domPosition, previousNode, parentElement, nextNode = null, ownerDocument = odtDocument.getDOM(), paragraphElement, textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0", toInsertIndex = 0, spaceTag, spaceElement, i;
     function insertTextNode(toInsertText) {
       parentElement.insertBefore(ownerDocument.createTextNode(toInsertText), nextNode)
     }
@@ -10449,12 +11026,13 @@ ops.OpInsertText = function OpInsertText() {
         previousNode.parentNode.removeChild(previousNode)
       }
       if(position > 0) {
-        odtDocument.downgradeWhitespacesAtPosition(position - 1);
         if(position > 1) {
           odtDocument.downgradeWhitespacesAtPosition(position - 2)
         }
+        odtDocument.downgradeWhitespacesAtPosition(position - 1)
       }
       odtDocument.downgradeWhitespacesAtPosition(position);
+      odtDocument.downgradeWhitespacesAtPosition(position + text.length - 1);
       odtDocument.downgradeWhitespacesAtPosition(position + text.length);
       odtDocument.getOdfCanvas().refreshSize();
       odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:paragraphElement, memberId:memberid, timeStamp:timestamp});
@@ -10464,7 +11042,7 @@ ops.OpInsertText = function OpInsertText() {
     return false
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position, text:text}
+    return{optype:"InsertText", memberid:memberid, timestamp:timestamp, position:position, text:text}
   }
 };
 /*
@@ -10478,6 +11056,9 @@ ops.OpInsertText = function OpInsertText() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -10499,13 +11080,13 @@ ops.OpInsertText = function OpInsertText() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("odf.OdfUtils");
 runtime.loadClass("core.DomUtils");
 ops.OpRemoveText = function OpRemoveText() {
-  var self = this, optype = "RemoveText", memberid, timestamp, position, length, odfUtils, domUtils, editinfons = "urn:webodf:names:editinfo";
+  var memberid, timestamp, position, length, odfUtils, domUtils, editinfons = "urn:webodf:names:editinfo", FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT, odfNodeNamespaceMap = {};
   this.init = function(data) {
     runtime.assert(data.length >= 0, "OpRemoveText only supports positive lengths");
     memberid = data.memberid;
@@ -10513,73 +11094,28 @@ ops.OpRemoveText = function OpRemoveText() {
     position = parseInt(data.position, 10);
     length = parseInt(data.length, 10);
     odfUtils = new odf.OdfUtils;
-    domUtils = new core.DomUtils
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, end = position + length, otherOpspecEnd, helperOp, result = [self];
-    switch(otherOptype) {
-      case optype:
-        otherOpspecEnd = otherOpspec.position + otherOpspec.length;
-        if(otherOpspecEnd <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < end) {
-            if(position < otherOpspec.position) {
-              if(otherOpspecEnd < end) {
-                length = length - otherOpspec.length
-              }else {
-                length = otherOpspec.position - position
-              }
-            }else {
-              if(otherOpspecEnd < end) {
-                position = otherOpspec.position;
-                length = end - otherOpspecEnd
-              }else {
-                result = []
-              }
-            }
-          }
-        }
-        break;
-      case "InsertText":
-        if(otherOpspec.position <= position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position < end) {
-            length = otherOpspec.position - position;
-            helperOp = new ops.OpRemoveText;
-            helperOp.init({memberid:memberid, timestamp:timestamp, position:otherOpspec.position + otherOpspec.text.length, length:end - otherOpspec.position});
-            result = [helperOp, self]
-          }
-        }
-        break;
-      case "SplitParagraph":
-        if(otherOpspec.position <= position) {
-          position += 1
-        }else {
-          if(otherOpspec.position < end) {
-            length = otherOpspec.position - position;
-            helperOp = new ops.OpRemoveText;
-            helperOp.init({memberid:memberid, timestamp:timestamp, position:otherOpspec.position + 1, length:end - otherOpspec.position});
-            result = [helperOp, self]
-          }
-        }
-        break;
-      case "InsertTable":
-        result = null;
-        break;
-      case "AddAnnotation":
-      ;
-      case "RemoveAnnotation":
-        result = null;
-        break;
-      case "ApplyDirectStyling":
-        result = null;
-        break
-    }
-    return result
+    domUtils = new core.DomUtils;
+    odfNodeNamespaceMap[odf.Namespaces.dbns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.dcns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.dr3dns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.drawns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.chartns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.formns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.numberns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.officens] = true;
+    odfNodeNamespaceMap[odf.Namespaces.presentationns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.stylens] = true;
+    odfNodeNamespaceMap[odf.Namespaces.svgns] = true;
+    odfNodeNamespaceMap[odf.Namespaces.tablens] = true;
+    odfNodeNamespaceMap[odf.Namespaces.textns] = true
   };
   function CollapsingRules(rootNode) {
+    function isOdfNode(node) {
+      return odfNodeNamespaceMap.hasOwnProperty(node.namespaceURI)
+    }
+    function shouldRemove(node) {
+      return isOdfNode(node) || (node.localName === "br" && odfUtils.isLineBreak(node.parentNode) || node.nodeType === Node.TEXT_NODE && isOdfNode((node.parentNode)))
+    }
     function isEmpty(node) {
       var childNode;
       if(odfUtils.isCharacterElement(node)) {
@@ -10590,7 +11126,7 @@ ops.OpRemoveText = function OpRemoveText() {
       }
       childNode = node.firstChild;
       while(childNode) {
-        if(!isEmpty(childNode)) {
+        if(isOdfNode(childNode) || !isEmpty(childNode)) {
           return false
         }
         childNode = childNode.nextSibling
@@ -10599,10 +11135,16 @@ ops.OpRemoveText = function OpRemoveText() {
     }
     this.isEmpty = isEmpty;
     function isCollapsibleContainer(node) {
-      return!odfUtils.isParagraph(node) && node !== rootNode && isEmpty(node)
+      return!odfUtils.isParagraph(node) && (node !== rootNode && isEmpty(node))
     }
-    function mergeChildrenIntoParent(node) {
-      var parent = domUtils.mergeIntoParent(node);
+    function mergeChildrenIntoParent(targetNode) {
+      var parent;
+      if(targetNode.nodeType === Node.TEXT_NODE) {
+        parent = targetNode.parentNode;
+        parent.removeChild(targetNode)
+      }else {
+        parent = domUtils.removeUnwantedNodes(targetNode, shouldRemove)
+      }
       if(isCollapsibleContainer(parent)) {
         return mergeChildrenIntoParent(parent)
       }
@@ -10611,7 +11153,7 @@ ops.OpRemoveText = function OpRemoveText() {
     this.mergeChildrenIntoParent = mergeChildrenIntoParent
   }
   function mergeParagraphs(first, second, collapseRules) {
-    var child, mergeForward, destination = first, source = second, secondParent, insertionPoint;
+    var child, mergeForward = false, destination = first, source = second, secondParent, insertionPoint = null;
     if(collapseRules.isEmpty(first)) {
       mergeForward = true;
       if(second.parentNode !== first.parentNode) {
@@ -10643,7 +11185,7 @@ ops.OpRemoveText = function OpRemoveText() {
     while(remainingLength && iterator.nextPosition()) {
       endContainer = iterator.container();
       endOffset = iterator.unfilteredDomOffset();
-      if(filter.acceptPosition(iterator) === NodeFilter.FILTER_ACCEPT) {
+      if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
         remainingLength -= 1
       }
     }
@@ -10653,13 +11195,13 @@ ops.OpRemoveText = function OpRemoveText() {
     return range
   }
   this.execute = function(odtDocument) {
-    var paragraphElement, destinationParagraph, range, textNodes, paragraphs, collapseRules = new CollapsingRules(odtDocument.getRootNode());
+    var paragraphElement, destinationParagraph, range, textNodes, paragraphs, cursor = odtDocument.getCursor(memberid), collapseRules = new CollapsingRules(odtDocument.getRootNode());
     odtDocument.upgradeWhitespacesAtPosition(position);
     odtDocument.upgradeWhitespacesAtPosition(position + length);
     range = stepsToRange(odtDocument);
     paragraphElement = odtDocument.getParagraphElement(range.startContainer);
-    textNodes = odtDocument.getTextElements(range, true);
-    paragraphs = odtDocument.getParagraphElements(range);
+    textNodes = odfUtils.getTextElements(range, false, true);
+    paragraphs = odfUtils.getParagraphElements(range);
     range.detach();
     textNodes.forEach(function(element) {
       collapseRules.mergeChildrenIntoParent(element)
@@ -10671,12 +11213,15 @@ ops.OpRemoveText = function OpRemoveText() {
     odtDocument.fixCursorPositions();
     odtDocument.getOdfCanvas().refreshSize();
     odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:destinationParagraph || paragraphElement, memberId:memberid, timeStamp:timestamp});
-    odtDocument.emit(ops.OdtDocument.signalCursorMoved, odtDocument.getCursor(memberid));
+    if(cursor) {
+      cursor.resetSelectionType();
+      odtDocument.emit(ops.OdtDocument.signalCursorMoved, cursor)
+    }
     odtDocument.getOdfCanvas().rerenderAnnotations();
     return true
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position, length:length}
+    return{optype:"RemoveText", memberid:memberid, timestamp:timestamp, position:position, length:length}
   }
 };
 /*
@@ -10690,6 +11235,9 @@ ops.OpRemoveText = function OpRemoveText() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -10711,57 +11259,15 @@ ops.OpRemoveText = function OpRemoveText() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpSplitParagraph = function OpSplitParagraph() {
-  var self = this, optype = "SplitParagraph", memberid, timestamp, position, odfUtils = new odf.OdfUtils;
+  var memberid, timestamp, position, odfUtils;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
-    position = parseInt(data.position, 10)
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, result = [self];
-    switch(otherOptype) {
-      case optype:
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += 1;
-            result = null
-          }
-        }
-        break;
-      case "AddAnnotation":
-        if(otherOpspec.position < position) {
-          position += 1
-        }
-        break;
-      case "InsertText":
-        if(otherOpspec.position < position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += otherOpspec.text.length;
-            result = null
-          }
-        }
-        break;
-      case "InsertTable":
-        result = null;
-        break;
-      case "RemoveText":
-        if(otherOpspec.position + otherOpspec.length <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < position) {
-            position = otherOpspec.position
-          }
-        }
-        break
-    }
-    return result
+    position = data.position;
+    odfUtils = new odf.OdfUtils
   };
   this.execute = function(odtDocument) {
     var domPosition, paragraphNode, targetNode, node, splitNode, splitChildNode, keptChildNode;
@@ -10816,7 +11322,7 @@ ops.OpSplitParagraph = function OpSplitParagraph() {
     if(domPosition.textNode.length === 0) {
       domPosition.textNode.parentNode.removeChild(domPosition.textNode)
     }
-    odtDocument.fixCursorPositions(memberid);
+    odtDocument.fixCursorPositions();
     odtDocument.getOdfCanvas().refreshSize();
     odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:paragraphNode, memberId:memberid, timeStamp:timestamp});
     odtDocument.emit(ops.OdtDocument.signalParagraphChanged, {paragraphElement:splitChildNode, memberId:memberid, timeStamp:timestamp});
@@ -10824,7 +11330,7 @@ ops.OpSplitParagraph = function OpSplitParagraph() {
     return true
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position}
+    return{optype:"SplitParagraph", memberid:memberid, timestamp:timestamp, position:position}
   }
 };
 /*
@@ -10838,6 +11344,9 @@ ops.OpSplitParagraph = function OpSplitParagraph() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -10859,26 +11368,15 @@ ops.OpSplitParagraph = function OpSplitParagraph() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpSetParagraphStyle = function OpSetParagraphStyle() {
-  var self = this, optype = "SetParagraphStyle", memberid, timestamp, position, styleName, textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0";
+  var memberid, timestamp, position, styleName, textns = "urn:oasis:names:tc:opendocument:xmlns:text:1.0";
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
     position = data.position;
     styleName = data.styleName
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOpType = otherOpspec.optype, result = [self];
-    switch(otherOpType) {
-      case "RemoveStyle":
-        if(otherOpspec.styleName === styleName && otherOpspec.styleFamily === "paragraph") {
-          styleName = ""
-        }
-        break
-    }
-    return result
   };
   this.execute = function(odtDocument) {
     var iterator, paragraphNode;
@@ -10898,7 +11396,7 @@ ops.OpSetParagraphStyle = function OpSetParagraphStyle() {
     return false
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position, styleName:styleName}
+    return{optype:"SetParagraphStyle", memberid:memberid, timestamp:timestamp, position:position, styleName:styleName}
   }
 };
 /*
@@ -10912,6 +11410,9 @@ ops.OpSetParagraphStyle = function OpSetParagraphStyle() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -10933,83 +11434,16 @@ ops.OpSetParagraphStyle = function OpSetParagraphStyle() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
-  var self = this, optype = "UpdateParagraphStyle", memberid, timestamp, styleName, setProperties, removedProperties, paragraphPropertiesName = "style:paragraph-properties", textPropertiesName = "style:text-properties", stylens = odf.Namespaces.stylens;
+  var memberid, timestamp, styleName, setProperties, removedProperties, paragraphPropertiesName = "style:paragraph-properties", textPropertiesName = "style:text-properties", stylens = odf.Namespaces.stylens;
   function removedAttributesFromStyleNode(node, removedAttributeNames) {
     var i, attributeNameParts, attributeNameList = removedAttributeNames ? removedAttributeNames.split(",") : [];
     for(i = 0;i < attributeNameList.length;i += 1) {
       attributeNameParts = attributeNameList[i].split(":");
       node.removeAttributeNS(odf.Namespaces.resolvePrefix(attributeNameParts[0]), attributeNameParts[1])
-    }
-  }
-  function dropShadowedAttributes(properties, removedProperties, shadowingProperties, shadowingRemovedProperties) {
-    var value, i, name, removedPropertyNames, shadowingRemovedPropertyNames = shadowingRemovedProperties && shadowingRemovedProperties.attributes ? shadowingRemovedProperties.attributes.split(",") : [];
-    if(properties && (shadowingProperties || shadowingRemovedPropertyNames.length > 0)) {
-      Object.keys(properties).forEach(function(key) {
-        value = properties[key];
-        if(shadowingProperties && shadowingProperties[key] !== undefined || shadowingRemovedPropertyNames && shadowingRemovedPropertyNames.indexOf(key) !== -1) {
-          if(typeof value !== "object") {
-            delete properties[key]
-          }
-        }
-      })
-    }
-    if(removedProperties && removedProperties.attributes && (shadowingProperties || shadowingRemovedPropertyNames.length > 0)) {
-      removedPropertyNames = removedProperties.attributes.split(",");
-      for(i = 0;i < removedPropertyNames.length;i += 1) {
-        name = removedPropertyNames[i];
-        if(shadowingProperties && shadowingProperties[name] !== undefined || shadowingRemovedPropertyNames && shadowingRemovedPropertyNames.indexOf(name) !== -1) {
-          removedPropertyNames.splice(i, 1);
-          i -= 1
-        }
-      }
-      if(removedPropertyNames.length > 0) {
-        removedProperties.attributes = removedPropertyNames.join(",")
-      }else {
-        delete removedProperties.attributes
-      }
-    }
-  }
-  function hasProperties(properties) {
-    var key;
-    for(key in properties) {
-      if(properties.hasOwnProperty(key)) {
-        return true
-      }
-    }
-    return false
-  }
-  function hasRemovedProperties(properties) {
-    var key;
-    for(key in properties) {
-      if(properties.hasOwnProperty(key)) {
-        if(key !== "attributes" || properties.attributes.length > 0) {
-          return true
-        }
-      }
-    }
-    return false
-  }
-  function dropShadowedProperties(otherOpspec, propertiesName) {
-    var sp = setProperties ? setProperties[propertiesName] : null, rp = removedProperties ? removedProperties[propertiesName] : null;
-    dropShadowedAttributes(sp, rp, otherOpspec.setProperties ? otherOpspec.setProperties[propertiesName] : null, otherOpspec.removedProperties ? otherOpspec.removedProperties[propertiesName] : null);
-    if(sp && !hasProperties(sp)) {
-      delete setProperties[propertiesName]
-    }
-    if(rp && !hasRemovedProperties(rp)) {
-      delete removedProperties[propertiesName]
-    }
-  }
-  function dropStyleReferencingAttributes(deletedStyleName) {
-    if(setProperties) {
-      ["style:parent-style-name", "style:next-style-name"].forEach(function(attributeName) {
-        if(setProperties[attributeName] === deletedStyleName) {
-          delete setProperties[attributeName]
-        }
-      })
     }
   }
   this.init = function(data) {
@@ -11018,33 +11452,6 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
     styleName = data.styleName;
     setProperties = data.setProperties;
     removedProperties = data.removedProperties
-  };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOpType = otherOpspec.optype, result = [self];
-    switch(otherOpType) {
-      case optype:
-        if(otherOpspec.styleName === styleName) {
-          if(!hasPriority) {
-            dropShadowedProperties(otherOpspec, paragraphPropertiesName);
-            dropShadowedProperties(otherOpspec, textPropertiesName);
-            dropShadowedAttributes(setProperties || null, removedProperties || null, otherOpspec.setProperties || null, otherOpspec.removedProperties || null);
-            if(!(setProperties && hasProperties(setProperties)) && !(removedProperties && hasRemovedProperties(removedProperties))) {
-              result = []
-            }
-          }
-        }
-        break;
-      case "RemoveStyle":
-        if(otherOpspec.styleFamily === "paragraph") {
-          if(otherOpspec.styleName === styleName) {
-            result = []
-          }else {
-            dropStyleReferencingAttributes(otherOpspec.styleName)
-          }
-        }
-        break
-    }
-    return result
   };
   this.execute = function(odtDocument) {
     var formatting = odtDocument.getFormatting(), styleNode, paragraphPropertiesNode, textPropertiesNode;
@@ -11082,7 +11489,7 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
     return false
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, styleName:styleName, setProperties:setProperties, removedProperties:removedProperties}
+    return{optype:"UpdateParagraphStyle", memberid:memberid, timestamp:timestamp, styleName:styleName, setProperties:setProperties, removedProperties:removedProperties}
   }
 };
 /*
@@ -11096,6 +11503,9 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -11117,11 +11527,11 @@ ops.OpUpdateParagraphStyle = function OpUpdateParagraphStyle() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 ops.OpAddStyle = function OpAddStyle() {
-  var self = this, memberid, timestamp, styleName, styleFamily, isAutomaticStyle, setProperties, stylens = odf.Namespaces.stylens;
+  var memberid, timestamp, styleName, styleFamily, isAutomaticStyle, setProperties, stylens = odf.Namespaces.stylens;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
@@ -11129,22 +11539,6 @@ ops.OpAddStyle = function OpAddStyle() {
     styleFamily = data.styleFamily;
     isAutomaticStyle = data.isAutomaticStyle === "true" || data.isAutomaticStyle === true;
     setProperties = data.setProperties
-  };
-  function dropStyleReferencingAttributes(deletedStyleName) {
-    if(setProperties) {
-      ["style:parent-style-name", "style:next-style-name"].forEach(function(attributeName) {
-        if(setProperties[attributeName] === deletedStyleName) {
-          delete setProperties[attributeName]
-        }
-      })
-    }
-  }
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec();
-    if(otherOpspec.optype === "RemoveStyle" && otherOpspec.styleFamily === styleFamily) {
-      dropStyleReferencingAttributes(otherOpspec.styleName)
-    }
-    return[self]
   };
   this.execute = function(odtDocument) {
     var odfContainer = odtDocument.getOdfCanvas().odfContainer(), formatting = odtDocument.getFormatting(), dom = odtDocument.getDOM(), styleNode = dom.createElementNS(stylens, "style:style");
@@ -11183,6 +11577,9 @@ ops.OpAddStyle = function OpAddStyle() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -11203,65 +11600,15 @@ ops.OpAddStyle = function OpAddStyle() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpRemoveStyle = function OpRemoveStyle() {
-  var self = this, optype = "RemoveStyle", memberid, timestamp, styleName, styleFamily;
+  var memberid, timestamp, styleName, styleFamily;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = data.timestamp;
     styleName = data.styleName;
     styleFamily = data.styleFamily
-  };
-  function getStyleReferencingAttributes(setProperties) {
-    var attributes = [];
-    if(setProperties) {
-      ["style:parent-style-name", "style:next-style-name"].forEach(function(attributeName) {
-        if(setProperties[attributeName] === styleName) {
-          attributes.push(attributeName)
-        }
-      })
-    }
-    return attributes
-  }
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOpType = otherOpspec.optype, helperOp, setAttributes, result = [self];
-    switch(otherOpType) {
-      case optype:
-        if(otherOpspec.styleName === styleName && otherOpspec.styleFamily === styleFamily) {
-          result = []
-        }
-        break;
-      case "UpdateParagraphStyle":
-        if(styleFamily === "paragraph") {
-          setAttributes = getStyleReferencingAttributes(otherOpspec.setProperties);
-          if(setAttributes.length > 0) {
-            helperOp = new ops.OpUpdateParagraphStyle;
-            helperOp.init({memberid:memberid, timestamp:timestamp, styleName:otherOpspec.styleName, removedProperties:{attributes:setAttributes.join(",")}});
-            result = [helperOp, self]
-          }
-        }
-        break;
-      case "AddStyle":
-        if(otherOpspec.styleFamily === styleFamily) {
-          setAttributes = getStyleReferencingAttributes(otherOpspec.setProperties);
-          if(setAttributes.length > 0) {
-            helperOp = new ops.OpUpdateParagraphStyle;
-            helperOp.init({memberid:memberid, timestamp:timestamp, styleName:otherOpspec.styleName, removedProperties:{attributes:setAttributes.join(",")}});
-            result = [helperOp, self]
-          }
-        }
-        break;
-      case "SetParagraphStyle":
-        if(styleFamily === "paragraph" && otherOpspec.styleName === styleName) {
-          otherOpspec.styleName = "";
-          helperOp = new ops.OpSetParagraphStyle;
-          helperOp.init(otherOpspec);
-          result = [helperOp, self]
-        }
-        break
-    }
-    return result
   };
   this.execute = function(odtDocument) {
     var styleNode = odtDocument.getStyleElement(styleName, styleFamily);
@@ -11274,7 +11621,7 @@ ops.OpRemoveStyle = function OpRemoveStyle() {
     return true
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, styleName:styleName, styleFamily:styleFamily}
+    return{optype:"RemoveStyle", memberid:memberid, timestamp:timestamp, styleName:styleName, styleFamily:styleFamily}
   }
 };
 /*
@@ -11289,6 +11636,9 @@ ops.OpRemoveStyle = function OpRemoveStyle() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -11309,10 +11659,10 @@ ops.OpRemoveStyle = function OpRemoveStyle() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OpAddAnnotation = function OpAddAnnotation() {
-  var self = this, optype = "AddAnnotation", memberid, timestamp, position, length, name;
+  var memberid, timestamp, position, length, name;
   this.init = function(data) {
     memberid = data.memberid;
     timestamp = parseInt(data.timestamp, 10);
@@ -11320,58 +11670,12 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
     length = parseInt(data.length, 10) || 0;
     name = data.name
   };
-  this.transform = function(otherOp, hasPriority) {
-    var otherOpspec = otherOp.spec(), otherOptype = otherOpspec.optype, end = position + length, result = [self];
-    switch(otherOptype) {
-      case optype:
-        if(otherOpspec.position < position) {
-          position += 1
-        }else {
-          if(otherOpspec.position === position && !hasPriority) {
-            position += 1;
-            result = null
-          }
-        }
-        break;
-      case "InsertText":
-        if(otherOpspec.position <= position) {
-          position += otherOpspec.text.length
-        }else {
-          if(otherOpspec.position <= end) {
-            length += otherOpspec.text.length
-          }
-        }
-        break;
-      case "SplitParagraph":
-        if(otherOpspec.position <= position) {
-          position += 1
-        }else {
-          if(otherOpspec.position <= end) {
-            length += 1
-          }
-        }
-        break;
-      case "InsertTable":
-        result = null;
-        break;
-      case "RemoveText":
-        if(otherOpspec.position + otherOpspec.length <= position) {
-          position -= otherOpspec.length
-        }else {
-          if(otherOpspec.position < position) {
-            position = otherOpspec.position
-          }
-        }
-        break
-    }
-    return result
-  };
   function createAnnotationNode(odtDocument, date) {
     var annotationNode, creatorNode, dateNode, listNode, listItemNode, paragraphNode, doc = odtDocument.getDOM();
     annotationNode = doc.createElementNS(odf.Namespaces.officens, "office:annotation");
     annotationNode.setAttributeNS(odf.Namespaces.officens, "office:name", name);
     creatorNode = doc.createElementNS(odf.Namespaces.dcns, "dc:creator");
-    creatorNode.setAttributeNS(odf.Namespaces.webodfns + ":names:editinfo", "editinfo:memberid", memberid);
+    creatorNode.setAttributeNS("urn:webodf:names:editinfo", "editinfo:memberid", memberid);
     dateNode = doc.createElementNS(odf.Namespaces.dcns, "dc:date");
     dateNode.appendChild(doc.createTextNode(date.toISOString()));
     listNode = doc.createElementNS(odf.Namespaces.textns, "text:list");
@@ -11404,15 +11708,6 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
       }
     }
   }
-  function countSteps(number, stepCounter, positionFilter) {
-    if(number > 0) {
-      return stepCounter.countForwardSteps(number, positionFilter)
-    }
-    if(number < 0) {
-      return-stepCounter.countBackwardSteps(-number, positionFilter)
-    }
-    return 0
-  }
   this.execute = function(odtDocument) {
     var annotation = {}, positionFilter = odtDocument.getPositionFilter(), cursor = odtDocument.getCursor(memberid), oldCursorPosition = odtDocument.getCursorPosition(memberid), lengthToMove = position - oldCursorPosition - 1, stepsToParagraph;
     annotation.node = createAnnotationNode(odtDocument, new Date(timestamp));
@@ -11428,15 +11723,17 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
     }
     insertNodeAtPosition(odtDocument, annotation.node, position);
     if(cursor) {
-      stepsToParagraph = countSteps(lengthToMove, cursor.getStepCounter(), positionFilter);
+      stepsToParagraph = cursor.getStepCounter().countSteps(lengthToMove, positionFilter);
       cursor.move(stepsToParagraph);
+      cursor.resetSelectionType();
       odtDocument.emit(ops.OdtDocument.signalCursorMoved, cursor)
     }
     odtDocument.getOdfCanvas().addAnnotation(annotation);
+    odtDocument.fixCursorPositions();
     return true
   };
   this.spec = function() {
-    return{optype:optype, memberid:memberid, timestamp:timestamp, position:position, length:length, name:name}
+    return{optype:"AddAnnotation", memberid:memberid, timestamp:timestamp, position:position, length:length, name:name}
   }
 };
 /*
@@ -11450,6 +11747,9 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -11471,7 +11771,7 @@ ops.OpAddAnnotation = function OpAddAnnotation() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("core.DomUtils");
@@ -11483,9 +11783,6 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
     position = parseInt(data.position, 10);
     length = parseInt(data.length, 10);
     domUtils = new core.DomUtils
-  };
-  this.transform = function(otherOp, hasPriority) {
-    return null
   };
   this.execute = function(odtDocument) {
     var iterator = odtDocument.getIteratorAtPosition(position), container = iterator.container(), annotationName, annotationNode = null, annotationEnd = null, cursors;
@@ -11503,7 +11800,7 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
       })[0] || null
     }
     odtDocument.getOdfCanvas().forgetAnnotations();
-    cursors = domUtils.getElementsByTagNameNS(annotationNode, odf.Namespaces.webodfns + ":names:cursor", "cursor");
+    cursors = domUtils.getElementsByTagNameNS(annotationNode, "urn:webodf:names:cursor", "cursor");
     while(cursors.length) {
       annotationNode.parentNode.insertBefore(cursors.pop(), annotationNode)
     }
@@ -11531,6 +11828,9 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -11551,12 +11851,15 @@ ops.OpRemoveAnnotation = function OpRemoveAnnotation() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("ops.OpAddCursor");
 runtime.loadClass("ops.OpApplyDirectStyling");
 runtime.loadClass("ops.OpRemoveCursor");
 runtime.loadClass("ops.OpMoveCursor");
+runtime.loadClass("ops.OpSetBlob");
+runtime.loadClass("ops.OpRemoveBlob");
+runtime.loadClass("ops.OpInsertImage");
 runtime.loadClass("ops.OpInsertTable");
 runtime.loadClass("ops.OpInsertText");
 runtime.loadClass("ops.OpRemoveText");
@@ -11586,11 +11889,48 @@ ops.OperationFactory = function OperationFactory() {
     }
   }
   function init() {
-    specs = {AddCursor:constructor(ops.OpAddCursor), ApplyDirectStyling:constructor(ops.OpApplyDirectStyling), InsertTable:constructor(ops.OpInsertTable), InsertText:constructor(ops.OpInsertText), RemoveText:constructor(ops.OpRemoveText), SplitParagraph:constructor(ops.OpSplitParagraph), SetParagraphStyle:constructor(ops.OpSetParagraphStyle), UpdateParagraphStyle:constructor(ops.OpUpdateParagraphStyle), AddStyle:constructor(ops.OpAddStyle), RemoveStyle:constructor(ops.OpRemoveStyle), MoveCursor:constructor(ops.OpMoveCursor), 
-    RemoveCursor:constructor(ops.OpRemoveCursor), AddAnnotation:constructor(ops.OpAddAnnotation), RemoveAnnotation:constructor(ops.OpRemoveAnnotation)}
+    specs = {AddCursor:constructor(ops.OpAddCursor), ApplyDirectStyling:constructor(ops.OpApplyDirectStyling), SetBlob:constructor(ops.OpSetBlob), RemoveBlob:constructor(ops.OpRemoveBlob), InsertImage:constructor(ops.OpInsertImage), InsertTable:constructor(ops.OpInsertTable), InsertText:constructor(ops.OpInsertText), RemoveText:constructor(ops.OpRemoveText), SplitParagraph:constructor(ops.OpSplitParagraph), SetParagraphStyle:constructor(ops.OpSetParagraphStyle), UpdateParagraphStyle:constructor(ops.OpUpdateParagraphStyle), 
+    AddStyle:constructor(ops.OpAddStyle), RemoveStyle:constructor(ops.OpRemoveStyle), MoveCursor:constructor(ops.OpMoveCursor), RemoveCursor:constructor(ops.OpRemoveCursor), AddAnnotation:constructor(ops.OpAddAnnotation), RemoveAnnotation:constructor(ops.OpRemoveAnnotation)}
   }
   init()
 };
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
 runtime.loadClass("core.Cursor");
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("core.PositionIterator");
@@ -11649,8 +11989,8 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
     runtime.assert(Boolean(rectangle), "No visible rectangle found");
     return(rectangle)
   }
-  function doMove(steps, extend, move) {
-    var left = steps, iterator = getIteratorAtCursor(), initialRect, range = (rootNode.ownerDocument.createRange()), selectionRange = cursor.getSelectedRange() ? cursor.getSelectedRange().cloneRange() : rootNode.ownerDocument.createRange(), newRect, horizontalMovement, o, c, isForwardSelection, window = runtime.getWindow();
+  function doMove(positions, extend, move) {
+    var left = positions, iterator = getIteratorAtCursor(), initialRect, range = (rootNode.ownerDocument.createRange()), selectionRange = cursor.getSelectedRange() ? cursor.getSelectedRange().cloneRange() : rootNode.ownerDocument.createRange(), newRect, horizontalMovement, o, c, isForwardSelection;
     initialRect = getVisibleRect(iterator.container(), iterator.unfilteredDomOffset(), range);
     while(left > 0 && move()) {
       left -= 1
@@ -11675,92 +12015,90 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
     if(horizontalMovement || cachedXOffset === undefined) {
       cachedXOffset = newRect.left
     }
-    window.clearTimeout(timeoutHandle);
-    timeoutHandle = window.setTimeout(function() {
+    runtime.clearTimeout(timeoutHandle);
+    timeoutHandle = runtime.setTimeout(function() {
       cachedXOffset = undefined
     }, 2E3);
     range.detach();
-    return steps - left
+    return positions - left
   }
-  this.movePointForward = function(steps, extend) {
-    return doMove(steps, extend, positionIterator.nextPosition)
+  this.movePointForward = function(positions, extend) {
+    return doMove(positions, extend || false, positionIterator.nextPosition)
   };
-  this.movePointBackward = function(steps, extend) {
-    return doMove(steps, extend, positionIterator.previousPosition)
+  this.movePointBackward = function(positions, extend) {
+    return doMove(positions, extend || false, positionIterator.previousPosition)
   };
   function isPositionWalkable(filter) {
     var iterator = getIteratorAtCursor();
     if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-      return true
+      iterator.setUnfilteredPosition(cursor.getAnchorNode(), 0);
+      if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
+        return true
+      }
     }
     return false
   }
-  function countForwardSteps(steps, filter) {
-    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), stepCount = 0, count = 0;
-    while(steps > 0 && iterator.nextPosition()) {
-      stepCount += 1;
+  function countSteps(iterator, steps, filter) {
+    var watch = new core.LoopWatchDog(1E3), positions = 0, positionsCount = 0, increment = steps >= 0 ? 1 : -1, delegate = (steps >= 0 ? iterator.nextPosition : iterator.previousPosition);
+    while(steps !== 0 && delegate()) {
       watch.check();
+      positionsCount += increment;
       if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-        count += stepCount;
-        stepCount = 0;
-        steps -= 1
+        steps -= increment;
+        positions += positionsCount;
+        positionsCount = 0
       }
     }
-    return count
+    return positions
   }
-  function convertForwardStepsBetweenFilters(steps, filter1, filter2) {
-    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), stepCount = 0, count = 0;
-    while(steps > 0 && iterator.nextPosition()) {
+  function convertForwardStepsBetweenFilters(stepsFilter1, filter1, filter2) {
+    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), pendingStepsFilter2 = 0, stepsFilter2 = 0;
+    while(stepsFilter1 > 0 && iterator.nextPosition()) {
       watch.check();
       if(filter2.acceptPosition(iterator) === FILTER_ACCEPT) {
-        stepCount += 1;
+        pendingStepsFilter2 += 1;
         if(filter1.acceptPosition(iterator) === FILTER_ACCEPT) {
-          count += stepCount;
-          stepCount = 0;
-          steps -= 1
+          stepsFilter2 += pendingStepsFilter2;
+          pendingStepsFilter2 = 0;
+          stepsFilter1 -= 1
         }
       }
     }
-    return count
+    return stepsFilter2
   }
-  function convertBackwardStepsBetweenFilters(steps, filter1, filter2) {
-    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), stepCount = 0, count = 0;
-    while(steps > 0 && iterator.previousPosition()) {
+  function convertBackwardStepsBetweenFilters(stepsFilter1, filter1, filter2) {
+    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), pendingStepsFilter2 = 0, stepsFilter2 = 0;
+    while(stepsFilter1 > 0 && iterator.previousPosition()) {
       watch.check();
       if(filter2.acceptPosition(iterator) === FILTER_ACCEPT) {
-        stepCount += 1;
+        pendingStepsFilter2 += 1;
         if(filter1.acceptPosition(iterator) === FILTER_ACCEPT) {
-          count += stepCount;
-          stepCount = 0;
-          steps -= 1
+          stepsFilter2 += pendingStepsFilter2;
+          pendingStepsFilter2 = 0;
+          stepsFilter1 -= 1
         }
       }
     }
-    return count
+    return stepsFilter2
   }
-  function countBackwardSteps(steps, filter) {
-    var iterator = getIteratorAtCursor(), watch = new core.LoopWatchDog(1E3), stepCount = 0, count = 0;
-    while(steps > 0 && iterator.previousPosition()) {
-      stepCount += 1;
-      watch.check();
-      if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-        count += stepCount;
-        stepCount = 0;
-        steps -= 1
+  function countStepsPublic(steps, filter) {
+    var iterator = getIteratorAtCursor();
+    return countSteps(iterator, steps, filter)
+  }
+  function countPositionsToClosestStep(container, offset, filter) {
+    var iterator = getIteratorAtCursor(), paragraphNode = odfUtils.getParagraphElement(iterator.getCurrentNode()), count = 0;
+    iterator.setUnfilteredPosition(container, offset);
+    if(filter.acceptPosition(iterator) !== FILTER_ACCEPT) {
+      count = countSteps(iterator, -1, filter);
+      if(count === 0 || paragraphNode && paragraphNode !== odfUtils.getParagraphElement(iterator.getCurrentNode())) {
+        iterator.setUnfilteredPosition(container, offset);
+        count = countSteps(iterator, 1, filter)
       }
-    }
-    return count
-  }
-  function countStepsToValidPosition(filter) {
-    var iterator = getIteratorAtCursor(), paragraphNode = odfUtils.getParagraphElement(iterator.getCurrentNode()), count;
-    count = -countBackwardSteps(1, filter);
-    if(count === 0 || paragraphNode && paragraphNode !== odfUtils.getParagraphElement(iterator.getCurrentNode())) {
-      count = countForwardSteps(1, filter)
     }
     return count
   }
   function countLineSteps(filter, direction, iterator) {
-    var c = iterator.container(), count = 0, bestContainer = null, bestOffset, bestXDiff = 10, xDiff, bestCount = 0, top, left, lastTop, rect, range = (rootNode.ownerDocument.createRange()), watch = new core.LoopWatchDog(1E3);
+    var c = iterator.container(), steps = 0, bestContainer = null, bestOffset, bestXDiff = 10, xDiff, bestCount = 0, top, left, lastTop, rect, range = (rootNode.ownerDocument.createRange()), watch = new core.LoopWatchDog(1E3);
     rect = getVisibleRect(c, iterator.unfilteredDomOffset(), range);
     top = rect.top;
     if(cachedXOffset === undefined) {
@@ -11772,7 +12110,7 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
     while((direction < 0 ? iterator.previousPosition() : iterator.nextPosition()) === true) {
       watch.check();
       if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
-        count += 1;
+        steps += 1;
         c = iterator.container();
         rect = getVisibleRect(c, iterator.unfilteredDomOffset(), range);
         if(rect.top !== top) {
@@ -11785,35 +12123,35 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
             bestContainer = c;
             bestOffset = iterator.unfilteredDomOffset();
             bestXDiff = xDiff;
-            bestCount = count
+            bestCount = steps
           }
         }
       }
     }
     if(bestContainer !== null) {
       iterator.setUnfilteredPosition(bestContainer, (bestOffset));
-      count = bestCount
+      steps = bestCount
     }else {
-      count = 0
+      steps = 0
     }
     range.detach();
-    return count
+    return steps
   }
   function countLinesSteps(lines, filter) {
-    var iterator = getIteratorAtCursor(), stepCount = 0, count = 0, direction = lines < 0 ? -1 : 1;
+    var iterator = getIteratorAtCursor(), stepCount = 0, steps = 0, direction = lines < 0 ? -1 : 1;
     lines = Math.abs(lines);
     while(lines > 0) {
       stepCount += countLineSteps(filter, direction, iterator);
       if(stepCount === 0) {
         break
       }
-      count += stepCount;
+      steps += stepCount;
       lines -= 1
     }
-    return count * direction
+    return steps * direction
   }
   function countStepsToLineBoundary(direction, filter) {
-    var fnNextPos, increment, lastRect, rect, onSameLine, iterator = getIteratorAtCursor(), paragraphNode = odfUtils.getParagraphElement(iterator.getCurrentNode()), count = 0, range = (rootNode.ownerDocument.createRange());
+    var fnNextPos, increment, lastRect, rect, onSameLine, iterator = getIteratorAtCursor(), paragraphNode = odfUtils.getParagraphElement(iterator.getCurrentNode()), steps = 0, range = (rootNode.ownerDocument.createRange());
     if(direction < 0) {
       fnNextPos = iterator.previousPosition;
       increment = -1
@@ -11834,21 +12172,27 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
             break
           }
         }
-        count += increment;
+        steps += increment;
         lastRect = rect
       }
     }
     range.detach();
-    return count
+    return steps
   }
   function countStepsToPosition(targetNode, targetOffset, filter) {
     runtime.assert(targetNode !== null, "SelectionMover.countStepsToPosition called with element===null");
     var iterator = getIteratorAtCursor(), c = iterator.container(), o = iterator.unfilteredDomOffset(), steps = 0, watch = new core.LoopWatchDog(1E3), comparison;
     iterator.setUnfilteredPosition(targetNode, targetOffset);
+    while(filter.acceptPosition(iterator) !== FILTER_ACCEPT && iterator.previousPosition()) {
+      watch.check()
+    }
     targetNode = iterator.container();
     runtime.assert(Boolean(targetNode), "SelectionMover.countStepsToPosition: positionIterator.container() returned null");
     targetOffset = iterator.unfilteredDomOffset();
     iterator.setUnfilteredPosition(c, o);
+    while(filter.acceptPosition(iterator) !== FILTER_ACCEPT && iterator.previousPosition()) {
+      watch.check()
+    }
     comparison = domUtils.comparePoints(targetNode, targetOffset, iterator.container(), iterator.unfilteredDomOffset());
     if(comparison < 0) {
       while(iterator.nextPosition()) {
@@ -11856,10 +12200,8 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
         if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
           steps += 1
         }
-        if(iterator.container() === targetNode) {
-          if(iterator.unfilteredDomOffset() === targetOffset) {
-            return steps
-          }
+        if(iterator.container() === targetNode && iterator.unfilteredDomOffset() === targetOffset) {
+          return steps
         }
       }
     }else {
@@ -11868,7 +12210,7 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
           watch.check();
           if(filter.acceptPosition(iterator) === FILTER_ACCEPT) {
             steps -= 1;
-            if(domUtils.comparePoints(targetNode, targetOffset, iterator.container(), iterator.unfilteredDomOffset()) <= 0) {
+            if(iterator.container() === targetNode && iterator.unfilteredDomOffset() === targetOffset) {
               break
             }
           }
@@ -11878,7 +12220,7 @@ gui.SelectionMover = function SelectionMover(cursor, rootNode) {
     return steps
   }
   this.getStepCounter = function() {
-    return{countForwardSteps:countForwardSteps, countBackwardSteps:countBackwardSteps, convertForwardStepsBetweenFilters:convertForwardStepsBetweenFilters, convertBackwardStepsBetweenFilters:convertBackwardStepsBetweenFilters, countLinesSteps:countLinesSteps, countStepsToLineBoundary:countStepsToLineBoundary, countStepsToPosition:countStepsToPosition, isPositionWalkable:isPositionWalkable, countStepsToValidPosition:countStepsToValidPosition}
+    return{countSteps:countStepsPublic, convertForwardStepsBetweenFilters:convertForwardStepsBetweenFilters, convertBackwardStepsBetweenFilters:convertBackwardStepsBetweenFilters, countLinesSteps:countLinesSteps, countStepsToLineBoundary:countStepsToLineBoundary, countStepsToPosition:countStepsToPosition, isPositionWalkable:isPositionWalkable, countPositionsToNearestStep:countPositionsToClosestStep}
   };
   function init() {
     odfUtils = new odf.OdfUtils;
@@ -11911,119 +12253,490 @@ gui.SelectionMover.createPositionIterator = function(rootNode) {
  Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ This file is part of WebODF.
 
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
+ WebODF is free software: you can redistribute it and/or modify it
+ under the terms of the GNU Affero General Public License (GNU AGPL)
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
 
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
+ WebODF is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
 
- This license applies to this entire compilation.
+ You should have received a copy of the GNU Affero General Public License
+ along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
  @licend
+
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("ops.OpAddCursor");
-runtime.loadClass("ops.OpRemoveCursor");
-runtime.loadClass("ops.OpMoveCursor");
-runtime.loadClass("ops.OpInsertTable");
-runtime.loadClass("ops.OpInsertText");
-runtime.loadClass("ops.OpRemoveText");
-runtime.loadClass("ops.OpSplitParagraph");
-runtime.loadClass("ops.OpSetParagraphStyle");
-runtime.loadClass("ops.OpAddStyle");
-runtime.loadClass("ops.OpUpdateParagraphStyle");
-runtime.loadClass("ops.OpRemoveStyle");
-ops.OperationTransformer = function OperationTransformer() {
-  var operationFactory;
-  function transformOpVsOp(opA, opB) {
-    var oldOpB, opATransformResult, opBTransformResult;
-    runtime.log("Crosstransforming:");
-    runtime.log(runtime.toJson(opA.spec()));
-    runtime.log(runtime.toJson(opB.spec()));
-    oldOpB = operationFactory.create(opB.spec());
-    opBTransformResult = opB.transform(opA, true);
-    opATransformResult = opA.transform(oldOpB, false);
-    if(!opATransformResult || !opBTransformResult) {
-      return null
-    }
-    return{opsA:opATransformResult, opsB:opBTransformResult}
+ops.OperationTransformMatrix = function OperationTransformMatrix() {
+  function passUnchanged(opSpecA, opSpecB) {
+    return{opSpecsA:[opSpecA], opSpecsB:[opSpecB]}
   }
-  function transformOpListVsOp(opsA, opB) {
-    var b, transformResult, transformListResult, transformedOpsA = [], transformedOpsB = [];
-    while(opsA.length > 0 && opB) {
-      transformResult = transformOpVsOp(opsA.shift(), (opB));
+  function getStyleReferencingAttributes(setProperties, styleName) {
+    var attributes = [];
+    if(setProperties) {
+      ["style:parent-style-name", "style:next-style-name"].forEach(function(attributeName) {
+        if(setProperties[attributeName] === styleName) {
+          attributes.push(attributeName)
+        }
+      })
+    }
+    return attributes
+  }
+  function dropStyleReferencingAttributes(setProperties, deletedStyleName) {
+    if(setProperties) {
+      ["style:parent-style-name", "style:next-style-name"].forEach(function(attributeName) {
+        if(setProperties[attributeName] === deletedStyleName) {
+          delete setProperties[attributeName]
+        }
+      })
+    }
+  }
+  function transformAddStyleRemoveStyle(addStyleSpec, removeStyleSpec) {
+    var setAttributes, helperOpspec, addStyleSpecResult = [addStyleSpec], removeStyleSpecResult = [removeStyleSpec];
+    if(addStyleSpec.styleFamily === removeStyleSpec.styleFamily) {
+      setAttributes = getStyleReferencingAttributes(addStyleSpec.setProperties, removeStyleSpec.styleName);
+      if(setAttributes.length > 0) {
+        helperOpspec = {optype:"UpdateParagraphStyle", memberid:removeStyleSpec.memberid, timestamp:removeStyleSpec.timestamp, styleName:addStyleSpec.styleName, removedProperties:{attributes:setAttributes.join(",")}};
+        removeStyleSpecResult.unshift(helperOpspec)
+      }
+      dropStyleReferencingAttributes(addStyleSpec.setProperties, removeStyleSpec.styleName)
+    }
+    return{opSpecsA:addStyleSpecResult, opSpecsB:removeStyleSpecResult}
+  }
+  function transformInsertTextInsertText(insertTextSpecA, insertTextSpecB, hasAPriority) {
+    if(insertTextSpecA.position < insertTextSpecB.position) {
+      insertTextSpecB.position += insertTextSpecA.text.length
+    }else {
+      if(insertTextSpecA.position > insertTextSpecB.position) {
+        insertTextSpecA.position += insertTextSpecB.text.length
+      }else {
+        if(hasAPriority) {
+          insertTextSpecB.position += insertTextSpecA.text.length
+        }else {
+          insertTextSpecA.position += insertTextSpecB.text.length
+        }
+        return null
+      }
+    }
+    return{opSpecsA:[insertTextSpecA], opSpecsB:[insertTextSpecB]}
+  }
+  function transformInsertTextMoveCursor(insertTextSpec, moveCursorSpec) {
+    if(insertTextSpec.position < moveCursorSpec.position) {
+      moveCursorSpec.position += insertTextSpec.text.length
+    }else {
+      if(insertTextSpec.position <= moveCursorSpec.position + moveCursorSpec.length) {
+        moveCursorSpec.length += insertTextSpec.text.length
+      }
+    }
+    return{opSpecsA:[insertTextSpec], opSpecsB:[moveCursorSpec]}
+  }
+  function transformInsertTextRemoveText(insertTextSpec, removeTextSpec) {
+    var helperOpspec, removeTextSpecEnd = removeTextSpec.position + removeTextSpec.length, insertTextSpecResult = [insertTextSpec], removeTextSpecResult = [removeTextSpec];
+    if(removeTextSpecEnd <= insertTextSpec.position) {
+      insertTextSpec.position -= removeTextSpec.length
+    }else {
+      if(insertTextSpec.position <= removeTextSpec.position) {
+        removeTextSpec.position += insertTextSpec.text.length
+      }else {
+        removeTextSpec.length = insertTextSpec.position - removeTextSpec.position;
+        helperOpspec = {optype:"RemoveText", memberid:removeTextSpec.memberid, timestamp:removeTextSpec.timestamp, position:insertTextSpec.position + insertTextSpec.text.length, length:removeTextSpecEnd - insertTextSpec.position};
+        removeTextSpecResult.unshift(helperOpspec);
+        insertTextSpec.position = removeTextSpec.position
+      }
+    }
+    return{opSpecsA:insertTextSpecResult, opSpecsB:removeTextSpecResult}
+  }
+  function transformInsertTextSplitParagraph(insertTextSpec, splitParagraphSpec, hasAPriority) {
+    if(insertTextSpec.position < splitParagraphSpec.position) {
+      splitParagraphSpec.position += insertTextSpec.text.length
+    }else {
+      if(insertTextSpec.position > splitParagraphSpec.position) {
+        insertTextSpec.position += 1
+      }else {
+        if(hasAPriority) {
+          splitParagraphSpec.position += insertTextSpec.text.length
+        }else {
+          insertTextSpec.position += 1
+        }
+        return null
+      }
+    }
+    return{opSpecsA:[insertTextSpec], opSpecsB:[splitParagraphSpec]}
+  }
+  function dropShadowedAttributes(properties, removedProperties, shadowingProperties, shadowingRemovedProperties) {
+    var value, i, name, removedPropertyNames, shadowingRemovedPropertyNames = shadowingRemovedProperties && shadowingRemovedProperties.attributes ? shadowingRemovedProperties.attributes.split(",") : [];
+    if(properties && (shadowingProperties || shadowingRemovedPropertyNames.length > 0)) {
+      Object.keys(properties).forEach(function(key) {
+        value = properties[key];
+        if(shadowingProperties && shadowingProperties[key] !== undefined || shadowingRemovedPropertyNames && shadowingRemovedPropertyNames.indexOf(key) !== -1) {
+          if(typeof value !== "object") {
+            delete properties[key]
+          }
+        }
+      })
+    }
+    if(removedProperties && (removedProperties.attributes && (shadowingProperties || shadowingRemovedPropertyNames.length > 0))) {
+      removedPropertyNames = removedProperties.attributes.split(",");
+      for(i = 0;i < removedPropertyNames.length;i += 1) {
+        name = removedPropertyNames[i];
+        if(shadowingProperties && shadowingProperties[name] !== undefined || shadowingRemovedPropertyNames && shadowingRemovedPropertyNames.indexOf(name) !== -1) {
+          removedPropertyNames.splice(i, 1);
+          i -= 1
+        }
+      }
+      if(removedPropertyNames.length > 0) {
+        removedProperties.attributes = removedPropertyNames.join(",")
+      }else {
+        delete removedProperties.attributes
+      }
+    }
+  }
+  function hasProperties(properties) {
+    var key;
+    for(key in properties) {
+      if(properties.hasOwnProperty(key)) {
+        return true
+      }
+    }
+    return false
+  }
+  function hasRemovedProperties(properties) {
+    var key;
+    for(key in properties) {
+      if(properties.hasOwnProperty(key)) {
+        if(key !== "attributes" || properties.attributes.length > 0) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+  function dropShadowedProperties(targetOpspec, shadowingOpspec, propertiesName) {
+    var sp = targetOpspec.setProperties ? targetOpspec.setProperties[propertiesName] : null, rp = targetOpspec.removedProperties ? targetOpspec.removedProperties[propertiesName] : null;
+    dropShadowedAttributes(sp, rp, shadowingOpspec.setProperties ? shadowingOpspec.setProperties[propertiesName] : null, shadowingOpspec.removedProperties ? shadowingOpspec.removedProperties[propertiesName] : null);
+    if(sp && !hasProperties(sp)) {
+      delete targetOpspec.setProperties[propertiesName]
+    }
+    if(rp && !hasRemovedProperties(rp)) {
+      delete targetOpspec.removedProperties[propertiesName]
+    }
+  }
+  function transformUpdateParagraphStyleUpdateParagraphStyle(updateParagraphStyleSpecA, updateParagraphStyleSpecB, hasAPriority) {
+    var majorSpec, minorSpec, updateParagraphStyleSpecAResult = [updateParagraphStyleSpecA], updateParagraphStyleSpecBResult = [updateParagraphStyleSpecB];
+    if(updateParagraphStyleSpecA.styleName === updateParagraphStyleSpecB.styleName) {
+      majorSpec = hasAPriority ? updateParagraphStyleSpecA : updateParagraphStyleSpecB;
+      minorSpec = hasAPriority ? updateParagraphStyleSpecB : updateParagraphStyleSpecA;
+      dropShadowedProperties(minorSpec, majorSpec, "style:paragraph-properties");
+      dropShadowedProperties(minorSpec, majorSpec, "style:text-properties");
+      dropShadowedAttributes(minorSpec.setProperties || null, minorSpec.removedProperties || null, majorSpec.setProperties || null, majorSpec.removedProperties || null);
+      if(!(minorSpec.setProperties && hasProperties(minorSpec.setProperties)) && !(minorSpec.removedProperties && hasRemovedProperties(minorSpec.removedProperties))) {
+        if(hasAPriority) {
+          updateParagraphStyleSpecBResult = []
+        }else {
+          updateParagraphStyleSpecAResult = []
+        }
+      }
+    }
+    return{opSpecsA:updateParagraphStyleSpecAResult, opSpecsB:updateParagraphStyleSpecBResult}
+  }
+  function transformSplitParagraphSplitParagraph(splitParagraphSpecA, splitParagraphSpecB, hasAPriority) {
+    if(splitParagraphSpecA.position < splitParagraphSpecB.position) {
+      splitParagraphSpecB.position += 1
+    }else {
+      if(splitParagraphSpecA.position > splitParagraphSpecB.position) {
+        splitParagraphSpecA.position += 1
+      }else {
+        if(splitParagraphSpecA.position === splitParagraphSpecB.position) {
+          if(hasAPriority) {
+            splitParagraphSpecB.position += 1
+          }else {
+            splitParagraphSpecA.position += 1
+          }
+          return null
+        }
+      }
+    }
+    return{opSpecsA:[splitParagraphSpecA], opSpecsB:[splitParagraphSpecB]}
+  }
+  function transformMoveCursorRemoveCursor(moveCursorSpec, removeCursorSpec) {
+    var isSameCursorRemoved = moveCursorSpec.memberid === removeCursorSpec.memberid;
+    return{opSpecsA:isSameCursorRemoved ? [] : [moveCursorSpec], opSpecsB:[removeCursorSpec]}
+  }
+  function transformMoveCursorRemoveText(moveCursorSpec, removeTextSpec) {
+    var moveCursorSpecEnd = moveCursorSpec.position + moveCursorSpec.length, removeTextSpecEnd = removeTextSpec.position + removeTextSpec.length;
+    if(removeTextSpecEnd <= moveCursorSpec.position) {
+      moveCursorSpec.position -= removeTextSpec.length
+    }else {
+      if(removeTextSpec.position < moveCursorSpecEnd) {
+        if(moveCursorSpec.position < removeTextSpec.position) {
+          if(removeTextSpecEnd < moveCursorSpecEnd) {
+            moveCursorSpec.length -= removeTextSpec.length
+          }else {
+            moveCursorSpec.length = removeTextSpec.position - moveCursorSpec.position
+          }
+        }else {
+          moveCursorSpec.position = removeTextSpec.position;
+          if(removeTextSpecEnd < moveCursorSpecEnd) {
+            moveCursorSpec.length = moveCursorSpecEnd - removeTextSpecEnd
+          }else {
+            moveCursorSpec.length = 0
+          }
+        }
+      }
+    }
+    return{opSpecsA:[moveCursorSpec], opSpecsB:[removeTextSpec]}
+  }
+  function transformMoveCursorSplitParagraph(moveCursorSpec, splitParagraphSpec) {
+    if(splitParagraphSpec.position < moveCursorSpec.position) {
+      moveCursorSpec.position += 1
+    }else {
+      if(splitParagraphSpec.position <= moveCursorSpec.position + moveCursorSpec.length) {
+        moveCursorSpec.length += 1
+      }
+    }
+    return{opSpecsA:[moveCursorSpec], opSpecsB:[splitParagraphSpec]}
+  }
+  function transformRemoveCursorRemoveCursor(removeCursorSpecA, removeCursorSpecB) {
+    var isSameMemberid = removeCursorSpecA.memberid === removeCursorSpecB.memberid;
+    return{opSpecsA:isSameMemberid ? [] : [removeCursorSpecA], opSpecsB:isSameMemberid ? [] : [removeCursorSpecB]}
+  }
+  function transformRemoveStyleRemoveStyle(removeStyleSpecA, removeStyleSpecB) {
+    var isSameStyle = removeStyleSpecA.styleName === removeStyleSpecB.styleName && removeStyleSpecA.styleFamily === removeStyleSpecB.styleFamily;
+    return{opSpecsA:isSameStyle ? [] : [removeStyleSpecA], opSpecsB:isSameStyle ? [] : [removeStyleSpecB]}
+  }
+  function transformRemoveStyleSetParagraphStyle(removeStyleSpec, setParagraphStyleSpec) {
+    var helperOpspec, removeStyleSpecResult = [removeStyleSpec], setParagraphStyleSpecResult = [setParagraphStyleSpec];
+    if(removeStyleSpec.styleFamily === "paragraph" && removeStyleSpec.styleName === setParagraphStyleSpec.styleName) {
+      helperOpspec = {optype:"SetParagraphStyle", memberid:removeStyleSpec.memberid, timestamp:removeStyleSpec.timestamp, position:setParagraphStyleSpec.position, styleName:""};
+      removeStyleSpecResult.unshift(helperOpspec);
+      setParagraphStyleSpec.styleName = ""
+    }
+    return{opSpecsA:removeStyleSpecResult, opSpecsB:setParagraphStyleSpecResult}
+  }
+  function transformRemoveStyleUpdateParagraphStyle(removeStyleSpec, updateParagraphStyleSpec) {
+    var setAttributes, helperOpspec, removeStyleSpecResult = [removeStyleSpec], updateParagraphStyleSpecResult = [updateParagraphStyleSpec];
+    if(removeStyleSpec.styleFamily === "paragraph") {
+      setAttributes = getStyleReferencingAttributes(updateParagraphStyleSpec.setProperties, removeStyleSpec.styleName);
+      if(setAttributes.length > 0) {
+        helperOpspec = {optype:"UpdateParagraphStyle", memberid:removeStyleSpec.memberid, timestamp:removeStyleSpec.timestamp, styleName:updateParagraphStyleSpec.styleName, removedProperties:{attributes:setAttributes.join(",")}};
+        removeStyleSpecResult.unshift(helperOpspec)
+      }
+      if(removeStyleSpec.styleName === updateParagraphStyleSpec.styleName) {
+        updateParagraphStyleSpecResult = []
+      }else {
+        dropStyleReferencingAttributes(updateParagraphStyleSpec.setProperties, removeStyleSpec.styleName)
+      }
+    }
+    return{opSpecsA:removeStyleSpecResult, opSpecsB:updateParagraphStyleSpecResult}
+  }
+  function transformRemoveTextRemoveText(removeTextSpecA, removeTextSpecB) {
+    var removeTextSpecAEnd = removeTextSpecA.position + removeTextSpecA.length, removeTextSpecBEnd = removeTextSpecB.position + removeTextSpecB.length, removeTextSpecAResult = [removeTextSpecA], removeTextSpecBResult = [removeTextSpecB];
+    if(removeTextSpecBEnd <= removeTextSpecA.position) {
+      removeTextSpecA.position -= removeTextSpecB.length
+    }else {
+      if(removeTextSpecAEnd <= removeTextSpecB.position) {
+        removeTextSpecB.position -= removeTextSpecA.length
+      }else {
+        if(removeTextSpecB.position < removeTextSpecAEnd) {
+          if(removeTextSpecA.position < removeTextSpecB.position) {
+            if(removeTextSpecBEnd < removeTextSpecAEnd) {
+              removeTextSpecA.length = removeTextSpecA.length - removeTextSpecB.length
+            }else {
+              removeTextSpecA.length = removeTextSpecB.position - removeTextSpecA.position
+            }
+            if(removeTextSpecAEnd < removeTextSpecBEnd) {
+              removeTextSpecB.position = removeTextSpecA.position;
+              removeTextSpecB.length = removeTextSpecBEnd - removeTextSpecAEnd
+            }else {
+              removeTextSpecBResult = []
+            }
+          }else {
+            if(removeTextSpecAEnd < removeTextSpecBEnd) {
+              removeTextSpecB.length = removeTextSpecB.length - removeTextSpecA.length
+            }else {
+              if(removeTextSpecB.position < removeTextSpecA.position) {
+                removeTextSpecB.length = removeTextSpecA.position - removeTextSpecB.position
+              }else {
+                removeTextSpecBResult = []
+              }
+            }
+            if(removeTextSpecBEnd < removeTextSpecAEnd) {
+              removeTextSpecA.position = removeTextSpecB.position;
+              removeTextSpecA.length = removeTextSpecAEnd - removeTextSpecBEnd
+            }else {
+              removeTextSpecAResult = []
+            }
+          }
+        }
+      }
+    }
+    return{opSpecsA:removeTextSpecAResult, opSpecsB:removeTextSpecBResult}
+  }
+  function transformRemoveTextSplitParagraph(removeTextSpec, splitParagraphSpec) {
+    var removeTextSpecEnd = removeTextSpec.position + removeTextSpec.length, helperOpspec, removeTextSpecResult = [removeTextSpec], splitParagraphSpecResult = [splitParagraphSpec];
+    if(splitParagraphSpec.position <= removeTextSpec.position) {
+      removeTextSpec.position += 1
+    }else {
+      if(splitParagraphSpec.position < removeTextSpecEnd) {
+        removeTextSpec.length = splitParagraphSpec.position - removeTextSpec.position;
+        helperOpspec = {optype:"RemoveText", memberid:removeTextSpec.memberid, timestamp:removeTextSpec.timestamp, position:splitParagraphSpec.position + 1, length:removeTextSpecEnd - splitParagraphSpec.position};
+        removeTextSpecResult.unshift(helperOpspec)
+      }
+    }
+    if(removeTextSpec.position + removeTextSpec.length <= splitParagraphSpec.position) {
+      splitParagraphSpec.position -= removeTextSpec.length
+    }else {
+      if(removeTextSpec.position < splitParagraphSpec.position) {
+        splitParagraphSpec.position = removeTextSpec.position
+      }
+    }
+    return{opSpecsA:removeTextSpecResult, opSpecsB:splitParagraphSpecResult}
+  }
+  var transformations = {"AddCursor":{"AddCursor":passUnchanged, "AddStyle":passUnchanged, "InsertText":passUnchanged, "MoveCursor":passUnchanged, "RemoveCursor":passUnchanged, "RemoveStyle":passUnchanged, "RemoveText":passUnchanged, "SetParagraphStyle":passUnchanged, "SplitParagraph":passUnchanged, "UpdateParagraphStyle":passUnchanged}, "AddStyle":{"AddStyle":passUnchanged, "InsertText":passUnchanged, "MoveCursor":passUnchanged, "RemoveCursor":passUnchanged, "RemoveStyle":transformAddStyleRemoveStyle, 
+  "RemoveText":passUnchanged, "SetParagraphStyle":passUnchanged, "SplitParagraph":passUnchanged, "UpdateParagraphStyle":passUnchanged}, "InsertText":{"InsertText":transformInsertTextInsertText, "MoveCursor":transformInsertTextMoveCursor, "RemoveCursor":passUnchanged, "RemoveStyle":passUnchanged, "RemoveText":transformInsertTextRemoveText, "SplitParagraph":transformInsertTextSplitParagraph, "UpdateParagraphStyle":passUnchanged}, "MoveCursor":{"MoveCursor":passUnchanged, "RemoveCursor":transformMoveCursorRemoveCursor, 
+  "RemoveStyle":passUnchanged, "RemoveText":transformMoveCursorRemoveText, "SetParagraphStyle":passUnchanged, "SplitParagraph":transformMoveCursorSplitParagraph, "UpdateParagraphStyle":passUnchanged}, "RemoveCursor":{"RemoveCursor":transformRemoveCursorRemoveCursor, "RemoveStyle":passUnchanged, "RemoveText":passUnchanged, "SetParagraphStyle":passUnchanged, "SplitParagraph":passUnchanged, "UpdateParagraphStyle":passUnchanged}, "RemoveStyle":{"RemoveStyle":transformRemoveStyleRemoveStyle, "RemoveText":passUnchanged, 
+  "SetParagraphStyle":transformRemoveStyleSetParagraphStyle, "SplitParagraph":passUnchanged, "UpdateParagraphStyle":transformRemoveStyleUpdateParagraphStyle}, "RemoveText":{"RemoveText":transformRemoveTextRemoveText, "SplitParagraph":transformRemoveTextSplitParagraph, "UpdateParagraphStyle":passUnchanged}, "SetParagraphStyle":{"UpdateParagraphStyle":passUnchanged}, "SplitParagraph":{"SplitParagraph":transformSplitParagraphSplitParagraph, "UpdateParagraphStyle":passUnchanged}, "UpdateParagraphStyle":{"UpdateParagraphStyle":transformUpdateParagraphStyleUpdateParagraphStyle}};
+  this.passUnchanged = passUnchanged;
+  this.extendTransformations = function(moreTransformations) {
+    Object.keys(moreTransformations).forEach(function(optypeA) {
+      var moreTransformationsOptypeAMap = moreTransformations[optypeA], optypeAMap, isExtendingOptypeAMap = transformations.hasOwnProperty(optypeA);
+      runtime.log((isExtendingOptypeAMap ? "Extending" : "Adding") + " map for optypeA: " + optypeA);
+      if(!isExtendingOptypeAMap) {
+        transformations[optypeA] = {}
+      }
+      optypeAMap = transformations[optypeA];
+      Object.keys(moreTransformationsOptypeAMap).forEach(function(optypeB) {
+        var isOverwritingOptypeBEntry = optypeAMap.hasOwnProperty(optypeB);
+        runtime.assert(optypeA <= optypeB, "Wrong order:" + optypeA + ", " + optypeB);
+        runtime.log("  " + (isOverwritingOptypeBEntry ? "Overwriting" : "Adding") + " entry for optypeB: " + optypeB);
+        optypeAMap[optypeB] = moreTransformationsOptypeAMap[optypeB]
+      })
+    })
+  };
+  this.transformOpspecVsOpspec = function(opSpecA, opSpecB) {
+    var isOptypeAAlphaNumericSmaller = opSpecA.optype <= opSpecB.optype, helper, transformationFunctionMap, transformationFunction, result;
+    runtime.log("Crosstransforming:");
+    runtime.log(runtime.toJson(opSpecA));
+    runtime.log(runtime.toJson(opSpecB));
+    if(!isOptypeAAlphaNumericSmaller) {
+      helper = opSpecA;
+      opSpecA = opSpecB;
+      opSpecB = helper
+    }
+    transformationFunctionMap = transformations[opSpecA.optype];
+    transformationFunction = transformationFunctionMap && transformationFunctionMap[opSpecB.optype];
+    if(transformationFunction) {
+      result = transformationFunction(opSpecA, opSpecB, !isOptypeAAlphaNumericSmaller);
+      if(!isOptypeAAlphaNumericSmaller && result !== null) {
+        result = {opSpecsA:result.opSpecsB, opSpecsB:result.opSpecsA}
+      }
+    }else {
+      result = null
+    }
+    runtime.log("result:");
+    if(result) {
+      runtime.log(runtime.toJson(result.opSpecsA));
+      runtime.log(runtime.toJson(result.opSpecsB))
+    }else {
+      runtime.log("null")
+    }
+    return result
+  }
+};
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ This file is part of WebODF.
+
+ WebODF is free software: you can redistribute it and/or modify it
+ under the terms of the GNU Affero General Public License (GNU AGPL)
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ WebODF is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
+ @licend
+
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("ops.OperationFactory");
+runtime.loadClass("ops.OperationTransformMatrix");
+ops.OperationTransformer = function OperationTransformer() {
+  var operationFactory, operationTransformMatrix = new ops.OperationTransformMatrix;
+  function operations(opspecs) {
+    var ops = [];
+    opspecs.forEach(function(opspec) {
+      ops.push(operationFactory.create(opspec))
+    });
+    return ops
+  }
+  function transformOpVsOp(opSpecA, opSpecB) {
+    return operationTransformMatrix.transformOpspecVsOpspec(opSpecA, opSpecB)
+  }
+  function transformOpListVsOp(opSpecsA, opSpecB) {
+    var transformResult, transformListResult, transformedOpspecsA = [], transformedOpspecsB = [];
+    while(opSpecsA.length > 0 && opSpecB) {
+      transformResult = transformOpVsOp(opSpecsA.shift(), (opSpecB));
       if(!transformResult) {
         return null
       }
-      transformedOpsA = transformedOpsA.concat(transformResult.opsA);
-      if(transformResult.opsB.length === 0) {
-        transformedOpsA = transformedOpsA.concat(opsA);
-        opB = null;
+      transformedOpspecsA = transformedOpspecsA.concat(transformResult.opSpecsA);
+      if(transformResult.opSpecsB.length === 0) {
+        transformedOpspecsA = transformedOpspecsA.concat(opSpecsA);
+        opSpecB = null;
         break
       }
-      if(transformResult.opsB.length > 1) {
-        for(b = 0;b < transformResult.opsB.length - 1;b += 1) {
-          transformListResult = transformOpListVsOp(opsA, transformResult.opsB[b]);
-          if(!transformListResult) {
-            return null
-          }
-          transformedOpsB = transformedOpsB.concat(transformListResult.opsB);
-          opsA = transformListResult.opsA
+      while(transformResult.opSpecsB.length > 1) {
+        transformListResult = transformOpListVsOp(opSpecsA, transformResult.opSpecsB.shift());
+        if(!transformListResult) {
+          return null
         }
+        transformedOpspecsB = transformedOpspecsB.concat(transformListResult.opSpecsB);
+        opSpecsA = transformListResult.opSpecsA
       }
-      opB = transformResult.opsB.pop()
+      opSpecB = transformResult.opSpecsB.pop()
     }
-    if(opB) {
-      transformedOpsB.push(opB)
+    if(opSpecB) {
+      transformedOpspecsB.push(opSpecB)
     }
-    return{opsA:transformedOpsA, opsB:transformedOpsB}
+    return{opSpecsA:transformedOpspecsA, opSpecsB:transformedOpspecsB}
   }
   this.setOperationFactory = function(f) {
     operationFactory = f
   };
-  this.transform = function(opspecsA, opspecsB) {
-    var c, s, opsA = [], clientOp, serverOp, transformResult, transformedOpsB = [];
-    for(c = 0;c < opspecsA.length;c += 1) {
-      clientOp = operationFactory.create(opspecsA[c]);
-      if(!clientOp) {
-        return null
-      }
-      opsA.push(clientOp)
-    }
-    for(s = 0;s < opspecsB.length;s += 1) {
-      serverOp = operationFactory.create(opspecsB[s]);
-      transformResult = transformOpListVsOp(opsA, serverOp);
+  this.getOperationTransformMatrix = function() {
+    return operationTransformMatrix
+  };
+  this.transform = function(opSpecsA, opSpecsB) {
+    var transformResult, transformedOpspecsB = [];
+    while(opSpecsB.length > 0) {
+      transformResult = transformOpListVsOp(opSpecsA, opSpecsB.shift());
       if(!transformResult) {
         return null
       }
-      opsA = transformResult.opsA;
-      transformedOpsB = transformedOpsB.concat(transformResult.opsB)
+      opSpecsA = transformResult.opSpecsA;
+      transformedOpspecsB = transformedOpspecsB.concat(transformResult.opSpecsB)
     }
-    return{opsA:opsA, opsB:transformedOpsB}
+    return{opsA:operations(opSpecsA), opsB:operations(transformedOpspecsB)}
   }
 };
 runtime.loadClass("core.Cursor");
 runtime.loadClass("gui.SelectionMover");
 ops.OdtCursor = function OdtCursor(memberId, odtDocument) {
-  var self = this, selectionMover, cursor;
+  var self = this, validSelectionTypes = {}, selectionType, selectionMover, cursor;
   this.removeFromOdtDocument = function() {
     cursor.remove()
   };
@@ -12056,15 +12769,42 @@ ops.OdtCursor = function OdtCursor(memberId, odtDocument) {
   this.getSelectedRange = function() {
     return cursor.getSelectedRange()
   };
+  this.setSelectedRange = function(range, isForwardSelection) {
+    cursor.setSelectedRange(range, isForwardSelection)
+  };
+  this.hasForwardSelection = function() {
+    return cursor.hasForwardSelection()
+  };
   this.getOdtDocument = function() {
     return odtDocument
   };
+  this.getSelectionType = function() {
+    return selectionType
+  };
+  this.setSelectionType = function(value) {
+    if(validSelectionTypes.hasOwnProperty(value)) {
+      selectionType = value
+    }else {
+      runtime.log("Invalid selection type: " + value)
+    }
+  };
+  this.resetSelectionType = function() {
+    self.setSelectionType(ops.OdtCursor.RangeSelection)
+  };
   function init() {
     cursor = new core.Cursor(odtDocument.getDOM(), memberId);
-    selectionMover = new gui.SelectionMover(cursor, odtDocument.getRootNode())
+    selectionMover = new gui.SelectionMover(cursor, odtDocument.getRootNode());
+    validSelectionTypes[ops.OdtCursor.RangeSelection] = true;
+    validSelectionTypes[ops.OdtCursor.RegionSelection] = true;
+    self.resetSelectionType()
   }
   init()
 };
+ops.OdtCursor.RangeSelection = "Range";
+ops.OdtCursor.RegionSelection = "Region";
+(function() {
+  return ops.OdtCursor
+})();
 /*
 
  Copyright (C) 2012 KO GmbH <aditya.bhatt@kogmbh.com>
@@ -12076,6 +12816,9 @@ ops.OdtCursor = function OdtCursor(memberId, odtDocument) {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -12097,7 +12840,7 @@ ops.OdtCursor = function OdtCursor(memberId, odtDocument) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.EditInfo = function EditInfo(container, odtDocument) {
   var editInfoNode, editHistory = {};
@@ -12144,6 +12887,39 @@ ops.EditInfo = function EditInfo(container, odtDocument) {
   }
   init()
 };
+runtime.loadClass("gui.SelectionMover");
+gui.ShadowCursor = function ShadowCursor(odtDocument) {
+  var selectedRange = odtDocument.getDOM().createRange(), forwardSelection = true;
+  this.removeFromOdtDocument = function() {
+  };
+  this.getMemberId = function() {
+    return gui.ShadowCursor.ShadowCursorMemberId
+  };
+  this.getSelectedRange = function() {
+    return selectedRange
+  };
+  this.setSelectedRange = function(range, isForwardSelection) {
+    selectedRange = range;
+    forwardSelection = isForwardSelection !== false
+  };
+  this.hasForwardSelection = function() {
+    return forwardSelection
+  };
+  this.getOdtDocument = function() {
+    return odtDocument
+  };
+  this.getSelectionType = function() {
+    return ops.OdtCursor.RangeSelection
+  };
+  function init() {
+    selectedRange.setStart(odtDocument.getRootNode(), 0)
+  }
+  init()
+};
+gui.ShadowCursor.ShadowCursorMemberId = "";
+(function() {
+  return gui.ShadowCursor
+})();
 gui.Avatar = function Avatar(parentElement, avatarInitiallyVisible) {
   var self = this, handle, image, pendingImageUrl, displayShown = "block", displayHidden = "none";
   this.setColor = function(color) {
@@ -12193,10 +12969,11 @@ gui.Avatar = function Avatar(parentElement, avatarInitiallyVisible) {
   }
   init()
 };
+runtime.loadClass("core.DomUtils");
 runtime.loadClass("gui.Avatar");
 runtime.loadClass("ops.OdtCursor");
 gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
-  var span, avatar, cursorNode, shouldBlink = false, blinking = false, blinkTimeout;
+  var MIN_CARET_HEIGHT_PX = 8, DEFAULT_CARET_TOP = "5%", DEFAULT_CARET_HEIGHT = "1em", span, avatar, cursorNode, isShown = true, shouldBlink = false, blinking = false, blinkTimeout, domUtils = new core.DomUtils;
   function blink(reset) {
     if(!shouldBlink || !cursorNode.parentNode) {
       return
@@ -12217,6 +12994,69 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
     var caretRect = caretElement.getBoundingClientRect();
     return{left:caretRect.left - margin.left, top:caretRect.top - margin.top, right:caretRect.right + margin.right, bottom:caretRect.bottom + margin.bottom}
   }
+  function length(node) {
+    return node.nodeType === Node.TEXT_NODE ? node.textContent.length : node.childNodes.length
+  }
+  function verticalOverlap(cursorNode, rangeRect) {
+    var cursorRect = cursorNode.getBoundingClientRect(), intersectTop = 0, intersectBottom = 0;
+    if(cursorRect && rangeRect) {
+      intersectTop = Math.max(cursorRect.top, rangeRect.top);
+      intersectBottom = Math.min(cursorRect.bottom, rangeRect.bottom)
+    }
+    return intersectBottom - intersectTop
+  }
+  function getSelectionRect() {
+    var range = cursor.getSelectedRange().cloneRange(), node = cursor.getNode(), nextRectangle, selectionRectangle = null, nodeLength;
+    if(node.previousSibling) {
+      nodeLength = length(node.previousSibling);
+      range.setStart(node.previousSibling, nodeLength > 0 ? nodeLength - 1 : 0);
+      range.setEnd(node.previousSibling, nodeLength);
+      nextRectangle = range.getBoundingClientRect();
+      if(nextRectangle && nextRectangle.height) {
+        selectionRectangle = nextRectangle
+      }
+    }
+    if(node.nextSibling) {
+      range.setStart(node.nextSibling, 0);
+      range.setEnd(node.nextSibling, length(node.nextSibling) > 0 ? 1 : 0);
+      nextRectangle = range.getBoundingClientRect();
+      if(nextRectangle && nextRectangle.height) {
+        if(!selectionRectangle || verticalOverlap(node, nextRectangle) > verticalOverlap(node, selectionRectangle)) {
+          selectionRectangle = nextRectangle
+        }
+      }
+    }
+    return selectionRectangle
+  }
+  function getSpanBoundingClientRect() {
+    var range, rangeRect;
+    range = span.ownerDocument.createRange();
+    range.selectNode(span);
+    rangeRect = range.getBoundingClientRect();
+    range.detach();
+    return rangeRect
+  }
+  function handleUpdate() {
+    var selectionRect = getSelectionRect(), zoomLevel = cursor.getOdtDocument().getOdfCanvas().getZoomLevel(), caretRect;
+    if(isShown && cursor.getSelectionType() === ops.OdtCursor.RangeSelection) {
+      span.style.visibility = "visible"
+    }else {
+      span.style.visibility = "hidden"
+    }
+    if(selectionRect) {
+      span.style.top = "0";
+      caretRect = getSpanBoundingClientRect();
+      if(selectionRect.height < MIN_CARET_HEIGHT_PX) {
+        selectionRect = {top:selectionRect.top - (MIN_CARET_HEIGHT_PX - selectionRect.height) / 2, height:MIN_CARET_HEIGHT_PX}
+      }
+      span.style.height = domUtils.adaptRangeDifferenceToZoomLevel(selectionRect.height, zoomLevel) + "px";
+      span.style.top = domUtils.adaptRangeDifferenceToZoomLevel(selectionRect.top - caretRect.top, zoomLevel) + "px"
+    }else {
+      span.style.height = DEFAULT_CARET_HEIGHT;
+      span.style.top = DEFAULT_CARET_TOP
+    }
+  }
+  this.handleUpdate = handleUpdate;
   this.refreshCursorBlinking = function() {
     if(blinkOnRangeSelect || cursor.getSelectedRange().collapsed) {
       shouldBlink = true;
@@ -12237,11 +13077,13 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
     span.style.opacity = "1"
   };
   this.show = function() {
-    span.style.visibility = "visible";
+    isShown = true;
+    handleUpdate();
     avatar.markAsFocussed(true)
   };
   this.hide = function() {
-    span.style.visibility = "hidden";
+    isShown = false;
+    handleUpdate();
     avatar.markAsFocussed(false)
   };
   this.setAvatarImageUrl = function(url) {
@@ -12288,6 +13130,7 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
         canvasContainerElement.scrollLeft += caretRect.right - canvasContainerRect.right
       }
     }
+    handleUpdate()
   };
   this.destroy = function(callback) {
     avatar.destroy(function(err) {
@@ -12302,109 +13145,14 @@ gui.Caret = function Caret(cursor, avatarInitiallyVisible, blinkOnRangeSelect) {
   function init() {
     var dom = cursor.getOdtDocument().getDOM(), htmlns = dom.documentElement.namespaceURI;
     span = dom.createElementNS(htmlns, "span");
+    span.style.top = DEFAULT_CARET_TOP;
     cursorNode = cursor.getNode();
     cursorNode.appendChild(span);
-    avatar = new gui.Avatar(cursorNode, avatarInitiallyVisible)
+    avatar = new gui.Avatar(cursorNode, avatarInitiallyVisible);
+    handleUpdate()
   }
   init()
 };
-/*
-
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-gui.KeyboardHandler = function KeyboardHandler() {
-  var modifier = gui.KeyboardHandler.Modifier, defaultBinding = null, bindings = {};
-  function getModifiers(e) {
-    var modifiers = modifier.None;
-    if(e.metaKey) {
-      modifiers |= modifier.Meta
-    }
-    if(e.ctrlKey) {
-      modifiers |= modifier.Ctrl
-    }
-    if(e.altKey) {
-      modifiers |= modifier.Alt
-    }
-    if(e.shiftKey) {
-      modifiers |= modifier.Shift
-    }
-    return modifiers
-  }
-  function getKeyCombo(keyCode, modifiers) {
-    if(!modifiers) {
-      modifiers = modifier.None
-    }
-    return keyCode + ":" + modifiers
-  }
-  this.setDefault = function(callback) {
-    defaultBinding = callback
-  };
-  this.bind = function(keyCode, modifiers, callback) {
-    var keyCombo = getKeyCombo(keyCode, modifiers);
-    runtime.assert(bindings.hasOwnProperty(keyCombo) === false, "tried to overwrite the callback handler of key combo: " + keyCombo);
-    bindings[keyCombo] = callback
-  };
-  this.unbind = function(keyCode, modifiers) {
-    var keyCombo = getKeyCombo(keyCode, modifiers);
-    delete bindings[keyCombo]
-  };
-  this.reset = function() {
-    defaultBinding = null;
-    bindings = {}
-  };
-  this.handleEvent = function(e) {
-    var keyCombo = getKeyCombo(e.keyCode, getModifiers(e)), callback = bindings[keyCombo], handled = false;
-    if(callback) {
-      handled = callback()
-    }else {
-      if(defaultBinding !== null) {
-        handled = defaultBinding(e)
-      }
-    }
-    if(handled) {
-      if(e.preventDefault) {
-        e.preventDefault()
-      }else {
-        e.returnValue = false
-      }
-    }
-  }
-};
-gui.KeyboardHandler.Modifier = {None:0, Meta:1, Ctrl:2, Alt:4, Shift:8, MetaShift:9, CtrlShift:10, AltShift:12};
-gui.KeyboardHandler.KeyCode = {Backspace:8, Tab:9, Clear:12, Enter:13, End:35, Home:36, Left:37, Up:38, Right:39, Down:40, Delete:46, A:65, B:66, C:67, D:68, E:69, F:70, G:71, H:72, I:73, J:74, K:75, L:76, M:77, N:78, O:79, P:80, Q:81, R:82, S:83, T:84, U:85, V:86, W:87, X:88, Y:89, Z:90};
-(function() {
-  return gui.KeyboardHandler
-})();
 /*
 
  Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
@@ -12417,6 +13165,9 @@ gui.KeyboardHandler.KeyCode = {Backspace:8, Tab:9, Clear:12, Enter:13, End:35, H
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -12437,7 +13188,7 @@ gui.KeyboardHandler.KeyCode = {Backspace:8, Tab:9, Clear:12, Enter:13, End:35, H
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("xmldom.LSSerializer");
@@ -12484,6 +13235,9 @@ gui.Clipboard = function Clipboard() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -12504,13 +13258,14 @@ gui.Clipboard = function Clipboard() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.EventNotifier");
+runtime.loadClass("core.Utils");
 runtime.loadClass("ops.OpApplyDirectStyling");
 runtime.loadClass("gui.StyleHelper");
 gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
-  var self = this, odtDocument = session.getOdtDocument(), styleHelper = new gui.StyleHelper(odtDocument.getFormatting()), eventNotifier = new core.EventNotifier([gui.DirectTextStyler.textStylingChanged]), isBoldValue = false, isItalicValue = false, hasUnderlineValue = false, hasStrikeThroughValue = false, fontSizeValue, fontNameValue;
+  var self = this, utils = new core.Utils, odtDocument = session.getOdtDocument(), styleHelper = new gui.StyleHelper(odtDocument.getFormatting()), eventNotifier = new core.EventNotifier([gui.DirectTextStyler.textStylingChanged]), directCursorStyleProperties, currentSelectionStyles = [], isBoldValue = false, isItalicValue = false, hasUnderlineValue = false, hasStrikeThroughValue = false, fontSizeValue, fontNameValue;
   function get(obj, keys) {
     var i = 0, key = keys[i];
     while(key && obj) {
@@ -12526,8 +13281,16 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
       return value === get(obj, keys)
     }) ? value : undefined
   }
+  function getAppliedStyles() {
+    var cursor = odtDocument.getCursor(inputMemberId), range = cursor && cursor.getSelectedRange(), selectionStyles = range && styleHelper.getAppliedStyles(range) || [];
+    if(selectionStyles[0] && directCursorStyleProperties) {
+      selectionStyles[0] = utils.mergeObjects(selectionStyles[0], (directCursorStyleProperties))
+    }
+    return selectionStyles
+  }
   function updatedCachedValues() {
-    var cursor = odtDocument.getCursor(inputMemberId), range = cursor && cursor.getSelectedRange(), currentSelectionStyles = range && styleHelper.getAppliedStyles(range), fontSize, diffMap;
+    var fontSize, diffMap;
+    currentSelectionStyles = getAppliedStyles();
     function noteChange(oldValue, newValue, id) {
       if(oldValue !== newValue) {
         if(diffMap === undefined) {
@@ -12537,10 +13300,10 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
       }
       return newValue
     }
-    isBoldValue = noteChange(isBoldValue, range ? styleHelper.isBold(range) : false, "isBold");
-    isItalicValue = noteChange(isItalicValue, range ? styleHelper.isItalic(range) : false, "isItalic");
-    hasUnderlineValue = noteChange(hasUnderlineValue, range ? styleHelper.hasUnderline(range) : false, "hasUnderline");
-    hasStrikeThroughValue = noteChange(hasStrikeThroughValue, range ? styleHelper.hasStrikeThrough(range) : false, "hasStrikeThrough");
+    isBoldValue = noteChange(isBoldValue, currentSelectionStyles ? styleHelper.isBold(currentSelectionStyles) : false, "isBold");
+    isItalicValue = noteChange(isItalicValue, currentSelectionStyles ? styleHelper.isItalic(currentSelectionStyles) : false, "isItalic");
+    hasUnderlineValue = noteChange(hasUnderlineValue, currentSelectionStyles ? styleHelper.hasUnderline(currentSelectionStyles) : false, "hasUnderline");
+    hasStrikeThroughValue = noteChange(hasStrikeThroughValue, currentSelectionStyles ? styleHelper.hasStrikeThrough(currentSelectionStyles) : false, "hasStrikeThrough");
     fontSize = currentSelectionStyles && getCommonValue(currentSelectionStyles, ["style:text-properties", "fo:font-size"]);
     fontSizeValue = noteChange(fontSizeValue, fontSize && parseFloat(fontSize), "fontSize");
     fontNameValue = noteChange(fontNameValue, currentSelectionStyles && getCommonValue(currentSelectionStyles, ["style:text-properties", "style:font-name"]), "fontName");
@@ -12573,47 +13336,81 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
     }
   }
   function toggle(predicate, toggleMethod) {
-    var cursor = odtDocument.getCursor(inputMemberId);
+    var cursor = odtDocument.getCursor(inputMemberId), appliedStyles;
     if(!cursor) {
       return false
     }
-    toggleMethod(!predicate(cursor.getSelectedRange()));
+    appliedStyles = styleHelper.getAppliedStyles(cursor.getSelectedRange());
+    toggleMethod(!predicate(appliedStyles));
     return true
   }
-  function formatTextSelection(propertyName, propertyValue) {
-    var selection = odtDocument.getCursorSelection(inputMemberId), op = new ops.OpApplyDirectStyling, properties = {};
-    properties[propertyName] = propertyValue;
-    op.init({memberid:inputMemberId, position:selection.position, length:selection.length, setProperties:{"style:text-properties":properties}});
-    session.enqueue(op)
+  function formatTextSelection(textProperties) {
+    var selection = odtDocument.getCursorSelection(inputMemberId), op, properties = {"style:text-properties":textProperties};
+    if(selection.length !== 0) {
+      op = new ops.OpApplyDirectStyling;
+      op.init({memberid:inputMemberId, position:selection.position, length:selection.length, setProperties:properties});
+      session.enqueue([op])
+    }else {
+      directCursorStyleProperties = utils.mergeObjects(directCursorStyleProperties || {}, properties);
+      updatedCachedValues()
+    }
+  }
+  this.formatTextSelection = formatTextSelection;
+  function applyTextPropertyToSelection(propertyName, propertyValue) {
+    var textProperties = {};
+    textProperties[propertyName] = propertyValue;
+    formatTextSelection(textProperties)
+  }
+  this.createCursorStyleOp = function(position, length) {
+    var styleOp = null;
+    if(directCursorStyleProperties) {
+      styleOp = new ops.OpApplyDirectStyling;
+      styleOp.init({memberid:inputMemberId, position:position, length:length, setProperties:directCursorStyleProperties});
+      directCursorStyleProperties = null;
+      updatedCachedValues()
+    }
+    return styleOp
+  };
+  function clearCursorStyle(op) {
+    var spec = op.spec();
+    if(directCursorStyleProperties && spec.memberid === inputMemberId) {
+      if(spec.optype !== "SplitParagraph") {
+        directCursorStyleProperties = null;
+        updatedCachedValues()
+      }
+    }
   }
   function setBold(checked) {
     var value = checked ? "bold" : "normal";
-    formatTextSelection("fo:font-weight", value)
+    applyTextPropertyToSelection("fo:font-weight", value)
   }
   this.setBold = setBold;
   function setItalic(checked) {
     var value = checked ? "italic" : "normal";
-    formatTextSelection("fo:font-style", value)
+    applyTextPropertyToSelection("fo:font-style", value)
   }
   this.setItalic = setItalic;
   function setHasUnderline(checked) {
     var value = checked ? "solid" : "none";
-    formatTextSelection("style:text-underline-style", value)
+    applyTextPropertyToSelection("style:text-underline-style", value)
   }
   this.setHasUnderline = setHasUnderline;
   function setHasStrikethrough(checked) {
     var value = checked ? "solid" : "none";
-    formatTextSelection("style:text-line-through-style", value)
+    applyTextPropertyToSelection("style:text-line-through-style", value)
   }
   this.setHasStrikethrough = setHasStrikethrough;
   function setFontSize(value) {
-    formatTextSelection("fo:font-size", value + "pt")
+    applyTextPropertyToSelection("fo:font-size", value + "pt")
   }
   this.setFontSize = setFontSize;
   function setFontName(value) {
-    formatTextSelection("style:font-name", value)
+    applyTextPropertyToSelection("style:font-name", value)
   }
   this.setFontName = setFontName;
+  this.getAppliedStyles = function() {
+    return currentSelectionStyles
+  };
   this.toggleBold = toggle.bind(self, styleHelper.isBold, setBold);
   this.toggleItalic = toggle.bind(self, styleHelper.isItalic, setItalic);
   this.toggleUnderline = toggle.bind(self, styleHelper.hasUnderline, setHasUnderline);
@@ -12648,6 +13445,7 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
     odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
     odtDocument.unsubscribe(ops.OdtDocument.signalParagraphStyleModified, onParagraphStyleModified);
     odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
+    odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, clearCursorStyle);
     callback()
   };
   function init() {
@@ -12656,6 +13454,7 @@ gui.DirectTextStyler = function DirectTextStyler(session, inputMemberId) {
     odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
     odtDocument.subscribe(ops.OdtDocument.signalParagraphStyleModified, onParagraphStyleModified);
     odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
+    odtDocument.subscribe(ops.OdtDocument.signalOperationExecuted, clearCursorStyle);
     updatedCachedValues()
   }
   init()
@@ -12675,6 +13474,9 @@ gui.DirectTextStyler.textStylingChanged = "textStyling/changed";
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -12696,7 +13498,7 @@ gui.DirectTextStyler.textStylingChanged = "textStyling/changed";
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.EventNotifier");
 runtime.loadClass("core.Utils");
@@ -12704,7 +13506,7 @@ runtime.loadClass("odf.OdfUtils");
 runtime.loadClass("ops.OpAddStyle");
 runtime.loadClass("ops.OpSetParagraphStyle");
 runtime.loadClass("gui.StyleHelper");
-gui.DirectParagraphStyler = function DirectParagraphStyler(session, inputMemberId, styleNameGenerator) {
+gui.DirectParagraphStyler = function DirectParagraphStyler(session, inputMemberId, objectNameGenerator) {
   var odtDocument = session.getOdtDocument(), utils = new core.Utils, odfUtils = new odf.OdfUtils, styleHelper = new gui.StyleHelper(odtDocument.getFormatting()), eventNotifier = new core.EventNotifier([gui.DirectParagraphStyler.paragraphStylingChanged]), isAlignedLeftValue, isAlignedCenterValue, isAlignedRightValue, isAlignedJustifiedValue;
   function updatedCachedValues() {
     var cursor = odtDocument.getCursor(inputMemberId), range = cursor && cursor.getSelectedRange(), diffMap;
@@ -12764,7 +13566,7 @@ gui.DirectParagraphStyler = function DirectParagraphStyler(session, inputMemberI
   function applyParagraphDirectStyling(applyDirectStyling) {
     var range = odtDocument.getCursor(inputMemberId).getSelectedRange(), position = odtDocument.getCursorPosition(inputMemberId), paragraphs = odfUtils.getParagraphElements(range), formatting = odtDocument.getFormatting();
     paragraphs.forEach(function(paragraph) {
-      var paragraphStartPoint = position + odtDocument.getDistanceFromCursor(inputMemberId, paragraph, 0), paragraphStyleName = paragraph.getAttributeNS(odf.Namespaces.textns, "style-name"), newParagraphStyleName = styleNameGenerator.generateName(), opAddStyle, opSetParagraphStyle, paragraphProperties;
+      var paragraphStartPoint = position + odtDocument.getDistanceFromCursor(inputMemberId, paragraph, 0), paragraphStyleName = paragraph.getAttributeNS(odf.Namespaces.textns, "style-name"), newParagraphStyleName = objectNameGenerator.generateStyleName(), opAddStyle, opSetParagraphStyle, paragraphProperties;
       paragraphStartPoint += 1;
       if(paragraphStyleName) {
         paragraphProperties = formatting.createDerivedStyleObject(paragraphStyleName, "paragraph", {})
@@ -12774,8 +13576,7 @@ gui.DirectParagraphStyler = function DirectParagraphStyler(session, inputMemberI
       opAddStyle.init({memberid:inputMemberId, styleName:newParagraphStyleName, styleFamily:"paragraph", isAutomaticStyle:true, setProperties:paragraphProperties});
       opSetParagraphStyle = new ops.OpSetParagraphStyle;
       opSetParagraphStyle.init({memberid:inputMemberId, styleName:newParagraphStyleName, position:paragraphStartPoint});
-      session.enqueue(opAddStyle);
-      session.enqueue(opSetParagraphStyle)
+      session.enqueue([opAddStyle, opSetParagraphStyle])
     })
   }
   function applySimpleParagraphDirectStyling(styleOverrides) {
@@ -12849,7 +13650,7 @@ gui.DirectParagraphStyler.paragraphStylingChanged = "paragraphStyling/changed";
 })();
 /*
 
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -12858,6 +13659,9 @@ gui.DirectParagraphStyler.paragraphStylingChanged = "paragraphStyling/changed";
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -12879,9 +13683,224 @@ gui.DirectParagraphStyler.paragraphStylingChanged = "paragraphStyling/changed";
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-gui.TextManipulator = function TextManipulator(session, inputMemberId) {
+gui.KeyboardHandler = function KeyboardHandler() {
+  var modifier = gui.KeyboardHandler.Modifier, defaultBinding = null, bindings = {};
+  function getModifiers(e) {
+    var modifiers = modifier.None;
+    if(e.metaKey) {
+      modifiers |= modifier.Meta
+    }
+    if(e.ctrlKey) {
+      modifiers |= modifier.Ctrl
+    }
+    if(e.altKey) {
+      modifiers |= modifier.Alt
+    }
+    if(e.shiftKey) {
+      modifiers |= modifier.Shift
+    }
+    return modifiers
+  }
+  function getKeyCombo(keyCode, modifiers) {
+    if(!modifiers) {
+      modifiers = modifier.None
+    }
+    return keyCode + ":" + modifiers
+  }
+  this.setDefault = function(callback) {
+    defaultBinding = callback
+  };
+  this.bind = function(keyCode, modifiers, callback) {
+    var keyCombo = getKeyCombo(keyCode, modifiers);
+    runtime.assert(bindings.hasOwnProperty(keyCombo) === false, "tried to overwrite the callback handler of key combo: " + keyCombo);
+    bindings[keyCombo] = callback
+  };
+  this.unbind = function(keyCode, modifiers) {
+    var keyCombo = getKeyCombo(keyCode, modifiers);
+    delete bindings[keyCombo]
+  };
+  this.reset = function() {
+    defaultBinding = null;
+    bindings = {}
+  };
+  this.handleEvent = function(e) {
+    var keyCombo = getKeyCombo(e.keyCode, getModifiers(e)), callback = bindings[keyCombo], handled = false;
+    if(callback) {
+      handled = callback()
+    }else {
+      if(defaultBinding !== null) {
+        handled = defaultBinding(e)
+      }
+    }
+    if(handled) {
+      if(e.preventDefault) {
+        e.preventDefault()
+      }else {
+        e.returnValue = false
+      }
+    }
+  }
+};
+gui.KeyboardHandler.Modifier = {None:0, Meta:1, Ctrl:2, Alt:4, CtrlAlt:6, Shift:8, MetaShift:9, CtrlShift:10, AltShift:12};
+gui.KeyboardHandler.KeyCode = {Backspace:8, Tab:9, Clear:12, Enter:13, End:35, Home:36, Left:37, Up:38, Right:39, Down:40, Delete:46, A:65, B:66, C:67, D:68, E:69, F:70, G:71, H:72, I:73, J:74, K:75, L:76, M:77, N:78, O:79, P:80, Q:81, R:82, S:83, T:84, U:85, V:86, W:87, X:88, Y:89, Z:90};
+(function() {
+  return gui.KeyboardHandler
+})();
+runtime.loadClass("odf.Namespaces");
+runtime.loadClass("odf.ObjectNameGenerator");
+gui.ImageManager = function ImageManager(session, inputMemberId, objectNameGenerator) {
+  var cmPerPixel = 0.0264583333333334, fileExtensionByMimetype = {"image/gif":".gif", "image/jpeg":".jpg", "image/png":".png"}, textns = odf.Namespaces.textns, odtDocument = session.getOdtDocument(), formatting = odtDocument.getFormatting(), paragraphStyleToPageContentSizeMap = {};
+  function createAddGraphicsStyleOp(name) {
+    var op = new ops.OpAddStyle;
+    op.init({memberid:inputMemberId, styleName:name, styleFamily:"graphic", isAutomaticStyle:false, setProperties:{"style:graphic-properties":{"text:anchor-type":"paragraph", "svg:x":"0cm", "svg:y":"0cm", "style:wrap":"dynamic", "style:number-wrapped-paragraphs":"no-limit", "style:wrap-contour":"false", "style:vertical-pos":"top", "style:vertical-rel":"paragraph", "style:horizontal-pos":"center", "style:horizontal-rel":"paragraph"}}});
+    return op
+  }
+  function createAddFrameStyleOp(styleName, parentStyleName) {
+    var op = new ops.OpAddStyle;
+    op.init({memberid:inputMemberId, styleName:styleName, styleFamily:"graphic", isAutomaticStyle:true, setProperties:{"style:parent-style-name":parentStyleName, "style:graphic-properties":{"style:vertical-pos":"top", "style:vertical-rel":"baseline", "style:horizontal-pos":"center", "style:horizontal-rel":"paragraph", "fo:background-color":"transparent", "style:background-transparency":"100%", "style:shadow":"none", "style:mirror":"none", "fo:clip":"rect(0cm, 0cm, 0cm, 0cm)", "draw:luminance":"0%", 
+    "draw:contrast":"0%", "draw:red":"0%", "draw:green":"0%", "draw:blue":"0%", "draw:gamma":"100%", "draw:color-inversion":"false", "draw:image-opacity":"100%", "draw:color-mode":"standard"}}});
+    return op
+  }
+  function getFileExtension(mimetype) {
+    mimetype = mimetype.toLowerCase();
+    return fileExtensionByMimetype.hasOwnProperty(mimetype) ? fileExtensionByMimetype[mimetype] : null
+  }
+  function insertImageInternal(mimetype, content, widthInCm, heightInCm) {
+    var graphicsStyleName = "Graphics", stylesElement = odtDocument.getOdfCanvas().odfContainer().rootElement.styles, fileExtension = getFileExtension(mimetype), fileName, graphicsStyleElement, frameStyleName, op, operations = [];
+    runtime.assert(fileExtension !== null, "Image type is not supported: " + mimetype);
+    fileName = "Pictures/" + objectNameGenerator.generateImageName() + fileExtension;
+    op = new ops.OpSetBlob;
+    op.init({memberid:inputMemberId, filename:fileName, mimetype:mimetype, content:content});
+    operations.push(op);
+    graphicsStyleElement = formatting.getStyleElement(graphicsStyleName, "graphic", [stylesElement]);
+    if(!graphicsStyleElement) {
+      op = createAddGraphicsStyleOp(graphicsStyleName);
+      operations.push(op)
+    }
+    frameStyleName = objectNameGenerator.generateStyleName();
+    op = createAddFrameStyleOp(frameStyleName, graphicsStyleName);
+    operations.push(op);
+    op = new ops.OpInsertImage;
+    op.init({memberid:inputMemberId, position:odtDocument.getCursorPosition(inputMemberId), filename:fileName, frameWidth:widthInCm + "cm", frameHeight:heightInCm + "cm", frameStyleName:frameStyleName, frameName:objectNameGenerator.generateFrameName()});
+    operations.push(op);
+    session.enqueue(operations)
+  }
+  function trimmedSize(originalSize, pageContentSize) {
+    var widthRatio = 1, heightRatio = 1, ratio;
+    if(originalSize.width > pageContentSize.width) {
+      widthRatio = pageContentSize.width / originalSize.width
+    }
+    if(originalSize.height > pageContentSize.height) {
+      heightRatio = pageContentSize.height / originalSize.height
+    }
+    ratio = Math.min(widthRatio, heightRatio);
+    return{width:originalSize.width * ratio, height:originalSize.height * ratio}
+  }
+  this.insertImage = function(mimetype, content, widthInPx, heightInPx) {
+    var paragraphElement, styleName, pageContentSize, originalSize, newSize;
+    runtime.assert(widthInPx > 0 && heightInPx > 0, "Both width and height of the image should be greater than 0px.");
+    paragraphElement = odtDocument.getParagraphElement(odtDocument.getCursor(inputMemberId).getNode());
+    styleName = paragraphElement.getAttributeNS(textns, "style-name");
+    if(!paragraphStyleToPageContentSizeMap.hasOwnProperty(styleName)) {
+      paragraphStyleToPageContentSizeMap[styleName] = formatting.getContentSize(styleName, "paragraph")
+    }
+    pageContentSize = paragraphStyleToPageContentSizeMap[styleName];
+    originalSize = {width:widthInPx * cmPerPixel, height:heightInPx * cmPerPixel};
+    newSize = trimmedSize(originalSize, pageContentSize);
+    insertImageInternal(mimetype, content, newSize.width, newSize.height)
+  }
+};
+runtime.loadClass("odf.Namespaces");
+gui.ImageSelector = function ImageSelector(odfCanvas) {
+  var svgns = odf.Namespaces.svgns, imageSelectorId = "imageSelector", selectorBorderWidth = 1, squareClassNames = ["topLeft", "topRight", "bottomRight", "bottomLeft", "topMiddle", "rightMiddle", "bottomMiddle", "leftMiddle"], document = odfCanvas.getElement().ownerDocument, hasSelection = false;
+  function createSelectorElement() {
+    var sizerElement = odfCanvas.getSizer(), selectorElement, squareElement;
+    selectorElement = document.createElement("div");
+    selectorElement.id = "imageSelector";
+    selectorElement.style.borderWidth = selectorBorderWidth + "px";
+    sizerElement.appendChild(selectorElement);
+    squareClassNames.forEach(function(className) {
+      squareElement = document.createElement("div");
+      squareElement.className = className;
+      selectorElement.appendChild(squareElement)
+    });
+    return selectorElement
+  }
+  function getPosition(element, referenceElement) {
+    var rect = element.getBoundingClientRect(), refRect = referenceElement.getBoundingClientRect(), zoomLevel = odfCanvas.getZoomLevel();
+    return{left:(rect.left - refRect.left) / zoomLevel - selectorBorderWidth, top:(rect.top - refRect.top) / zoomLevel - selectorBorderWidth}
+  }
+  this.select = function(frameElement) {
+    var selectorElement = document.getElementById(imageSelectorId), position;
+    if(!selectorElement) {
+      selectorElement = createSelectorElement()
+    }
+    hasSelection = true;
+    position = getPosition(frameElement, (selectorElement.parentNode));
+    selectorElement.style.display = "block";
+    selectorElement.style.left = position.left + "px";
+    selectorElement.style.top = position.top + "px";
+    selectorElement.style.width = frameElement.getAttributeNS(svgns, "width");
+    selectorElement.style.height = frameElement.getAttributeNS(svgns, "height")
+  };
+  this.clearSelection = function() {
+    var selectorElement;
+    if(hasSelection) {
+      selectorElement = document.getElementById(imageSelectorId);
+      if(selectorElement) {
+        selectorElement.style.display = "none"
+      }
+    }
+    hasSelection = false
+  };
+  this.isSelectorElement = function(node) {
+    var selectorElement = document.getElementById(imageSelectorId);
+    if(!selectorElement) {
+      return false
+    }
+    return node === selectorElement || node.parentNode === selectorElement
+  }
+};
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+gui.TextManipulator = function TextManipulator(session, inputMemberId, directStyleOp) {
   var odtDocument = session.getOdtDocument();
   function createOpRemoveSelection(selection) {
     var op = new ops.OpRemoveText;
@@ -12896,14 +13915,15 @@ gui.TextManipulator = function TextManipulator(session, inputMemberId) {
     return selection
   }
   this.enqueueParagraphSplittingOps = function() {
-    var selection = toForwardSelection(odtDocument.getCursorSelection(inputMemberId)), op;
+    var selection = toForwardSelection(odtDocument.getCursorSelection(inputMemberId)), op, operations = [];
     if(selection.length > 0) {
       op = createOpRemoveSelection(selection);
-      session.enqueue(op)
+      operations.push(op)
     }
     op = new ops.OpSplitParagraph;
     op.init({memberid:inputMemberId, position:selection.position});
-    session.enqueue(op);
+    operations.push(op);
+    session.enqueue(operations);
     return true
   };
   this.removeTextByBackspaceKey = function() {
@@ -12912,11 +13932,11 @@ gui.TextManipulator = function TextManipulator(session, inputMemberId) {
       if(selection.position > 0 && odtDocument.getPositionInTextNode(selection.position - 1)) {
         op = new ops.OpRemoveText;
         op.init({memberid:inputMemberId, position:selection.position - 1, length:1});
-        session.enqueue(op)
+        session.enqueue([op])
       }
     }else {
       op = createOpRemoveSelection(selection);
-      session.enqueue(op)
+      session.enqueue([op])
     }
     return op !== null
   };
@@ -12926,11 +13946,11 @@ gui.TextManipulator = function TextManipulator(session, inputMemberId) {
       if(odtDocument.getPositionInTextNode(selection.position + 1)) {
         op = new ops.OpRemoveText;
         op.init({memberid:inputMemberId, position:selection.position, length:1});
-        session.enqueue(op)
+        session.enqueue([op])
       }
     }else {
       op = createOpRemoveSelection(selection);
-      session.enqueue(op)
+      session.enqueue([op])
     }
     return op !== null
   };
@@ -12938,73 +13958,296 @@ gui.TextManipulator = function TextManipulator(session, inputMemberId) {
     var selection = toForwardSelection(odtDocument.getCursorSelection(inputMemberId)), op;
     if(selection.length !== 0) {
       op = createOpRemoveSelection(selection);
-      session.enqueue(op)
+      session.enqueue([op])
     }
     return true
   };
   function insertText(text) {
-    var selection = toForwardSelection(odtDocument.getCursorSelection(inputMemberId)), op = null;
+    var selection = toForwardSelection(odtDocument.getCursorSelection(inputMemberId)), op, stylingOp, operations = [];
     if(selection.length > 0) {
       op = createOpRemoveSelection(selection);
-      session.enqueue(op)
+      operations.push(op)
     }
     op = new ops.OpInsertText;
     op.init({memberid:inputMemberId, position:selection.position, text:text});
-    session.enqueue(op)
+    operations.push(op);
+    if(directStyleOp) {
+      stylingOp = directStyleOp(selection.position, text.length);
+      if(stylingOp) {
+        operations.push(stylingOp)
+      }
+    }
+    session.enqueue(operations)
   }
   this.insertText = insertText
 };
 (function() {
   return gui.TextManipulator
 })();
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("core.EventNotifier");
+runtime.loadClass("core.PositionFilter");
+runtime.loadClass("ops.OpAddAnnotation");
+runtime.loadClass("ops.OpRemoveAnnotation");
+runtime.loadClass("gui.SelectionMover");
+gui.AnnotationManager = function AnnotationManager(session, inputMemberId) {
+  var odtDocument = session.getOdtDocument(), baseFilter = odtDocument.getPositionFilter(), isAnnotatable = false, eventNotifier = new core.EventNotifier([gui.AnnotationManager.annotatableChanged]), officens = odf.Namespaces.officens, FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT;
+  function isWithinAnnotation(node, container) {
+    while(node && node !== container) {
+      if(node.namespaceURI === officens && node.localName === "annotation") {
+        return true
+      }
+      node = node.parentNode
+    }
+    return false
+  }
+  function updatedCachedValues() {
+    var cursor = odtDocument.getCursor(inputMemberId), cursorNode = cursor && cursor.getNode(), newIsAnnotatable = cursorNode && !isWithinAnnotation(cursorNode, odtDocument.getRootNode());
+    if(newIsAnnotatable !== isAnnotatable) {
+      isAnnotatable = newIsAnnotatable;
+      eventNotifier.emit(gui.AnnotationManager.annotatableChanged, isAnnotatable)
+    }
+  }
+  function onCursorAdded(cursor) {
+    if(cursor.getMemberId() === inputMemberId) {
+      updatedCachedValues()
+    }
+  }
+  function onCursorRemoved(memberId) {
+    if(memberId === inputMemberId) {
+      updatedCachedValues()
+    }
+  }
+  function onCursorMoved(cursor) {
+    if(cursor.getMemberId() === inputMemberId) {
+      updatedCachedValues()
+    }
+  }
+  function getWalkableNodeLength(node) {
+    var length = 0, iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), inside = false;
+    iterator.setUnfilteredPosition(node, 0);
+    do {
+      inside = Boolean(node.compareDocumentPosition(iterator.container()) & Node.DOCUMENT_POSITION_CONTAINED_BY);
+      if(!inside && node !== iterator.container()) {
+        break
+      }
+      if(baseFilter.acceptPosition(iterator) === FILTER_ACCEPT) {
+        length += 1
+      }
+    }while(iterator.nextPosition());
+    return length
+  }
+  function getFirstWalkablePositionInNode(node) {
+    var position = 0, iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), watch = new core.LoopWatchDog(1E3), inside = false;
+    while(iterator.nextPosition()) {
+      watch.check();
+      inside = Boolean(node.compareDocumentPosition(iterator.container()) & Node.DOCUMENT_POSITION_CONTAINED_BY);
+      if(baseFilter.acceptPosition(iterator) === FILTER_ACCEPT) {
+        if(inside) {
+          break
+        }
+        position += 1
+      }
+    }
+    return position
+  }
+  this.isAnnotatable = function() {
+    return isAnnotatable
+  };
+  this.addAnnotation = function() {
+    var op = new ops.OpAddAnnotation, selection = odtDocument.getCursorSelection(inputMemberId), length = selection.length, position = selection.position;
+    if(!isAnnotatable) {
+      return
+    }
+    position = length >= 0 ? position : position + length;
+    length = Math.abs(length);
+    op.init({memberid:inputMemberId, position:position, length:length, name:inputMemberId + Date.now()});
+    session.enqueue([op])
+  };
+  this.removeAnnotation = function(annotationNode) {
+    var position, length, op, moveCursor;
+    position = getFirstWalkablePositionInNode(annotationNode);
+    length = getWalkableNodeLength(annotationNode);
+    op = new ops.OpRemoveAnnotation;
+    op.init({memberid:inputMemberId, position:position, length:length});
+    moveCursor = new ops.OpMoveCursor;
+    moveCursor.init({memberid:inputMemberId, position:position - 1, length:0});
+    session.enqueue([op, moveCursor])
+  };
+  this.subscribe = function(eventid, cb) {
+    eventNotifier.subscribe(eventid, cb)
+  };
+  this.unsubscribe = function(eventid, cb) {
+    eventNotifier.unsubscribe(eventid, cb)
+  };
+  this.destroy = function(callback) {
+    odtDocument.unsubscribe(ops.OdtDocument.signalCursorAdded, onCursorAdded);
+    odtDocument.unsubscribe(ops.OdtDocument.signalCursorRemoved, onCursorRemoved);
+    odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
+    callback()
+  };
+  function init() {
+    odtDocument.subscribe(ops.OdtDocument.signalCursorAdded, onCursorAdded);
+    odtDocument.subscribe(ops.OdtDocument.signalCursorRemoved, onCursorRemoved);
+    odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
+    updatedCachedValues()
+  }
+  init()
+};
+gui.AnnotationManager.annotatableChanged = "annotatable/changed";
+(function() {
+  return gui.AnnotationManager
+})();
+gui.EventManager = function EventManager(odtDocument) {
+  var canvasElement = odtDocument.getOdfCanvas().getElement(), window = runtime.getWindow(), bindToDirectHandler = {"beforecut":true, "beforepaste":true}, bindToWindow = {"mousedown":true, "mouseup":true};
+  function WindowScrollState(window) {
+    var x = window.scrollX, y = window.scrollY;
+    this.restore = function() {
+      if(window.scrollX !== x || window.scrollY !== y) {
+        window.scrollTo(x, y)
+      }
+    }
+  }
+  function ElementScrollState(element) {
+    var top = element.scrollTop, left = element.scrollLeft;
+    this.restore = function() {
+      if(element.scrollTop !== top || element.scrollLeft !== left) {
+        element.scrollTop = top;
+        element.scrollLeft = left
+      }
+    }
+  }
+  function listenEvent(eventTarget, eventType, eventHandler) {
+    var onVariant = "on" + eventType, bound = false;
+    if(eventTarget.attachEvent) {
+      bound = eventTarget.attachEvent(onVariant, eventHandler)
+    }
+    if(!bound && eventTarget.addEventListener) {
+      eventTarget.addEventListener(eventType, eventHandler, false);
+      bound = true
+    }
+    if((!bound || bindToDirectHandler[eventType]) && eventTarget.hasOwnProperty(onVariant)) {
+      eventTarget[onVariant] = eventHandler
+    }
+  }
+  function removeEvent(eventTarget, eventType, eventHandler) {
+    var onVariant = "on" + eventType;
+    if(eventTarget.detachEvent) {
+      eventTarget.detachEvent(onVariant, eventHandler)
+    }
+    if(eventTarget.removeEventListener) {
+      eventTarget.removeEventListener(eventType, eventHandler, false)
+    }
+    if(eventTarget[onVariant] === eventHandler) {
+      eventTarget[onVariant] = null
+    }
+  }
+  this.subscribe = function(eventName, handler) {
+    var element = canvasElement;
+    if(bindToWindow[eventName] && window) {
+      element = window
+    }
+    listenEvent(element, eventName, handler)
+  };
+  this.unsubscribe = function(eventName, handler) {
+    var element = canvasElement;
+    if(bindToWindow[eventName] && window) {
+      element = window
+    }
+    removeEvent(element, eventName, handler)
+  };
+  function hasFocus() {
+    var activeElement = odtDocument.getDOM().activeElement;
+    return activeElement === canvasElement
+  }
+  this.hasFocus = hasFocus;
+  function findScrollableParent(element) {
+    while(element && (!element.scrollTop && !element.scrollLeft)) {
+      element = (element.parentNode)
+    }
+    if(element) {
+      return new ElementScrollState(element)
+    }
+    if(window) {
+      return new WindowScrollState(window)
+    }
+    return null
+  }
+  this.focus = function() {
+    var scrollParent;
+    if(!hasFocus()) {
+      scrollParent = findScrollableParent(canvasElement);
+      canvasElement.focus();
+      if(scrollParent) {
+        scrollParent.restore()
+      }
+    }
+  }
+};
 runtime.loadClass("core.DomUtils");
-runtime.loadClass("core.Utils");
+runtime.loadClass("core.Async");
+runtime.loadClass("core.ScheduledTask");
 runtime.loadClass("odf.OdfUtils");
+runtime.loadClass("odf.ObjectNameGenerator");
+runtime.loadClass("ops.OdtCursor");
 runtime.loadClass("ops.OpAddCursor");
 runtime.loadClass("ops.OpRemoveCursor");
-runtime.loadClass("ops.OpMoveCursor");
-runtime.loadClass("ops.OpInsertText");
-runtime.loadClass("ops.OpRemoveText");
-runtime.loadClass("ops.OpSplitParagraph");
-runtime.loadClass("ops.OpSetParagraphStyle");
-runtime.loadClass("ops.OpRemoveAnnotation");
 runtime.loadClass("gui.Clipboard");
-runtime.loadClass("gui.KeyboardHandler");
 runtime.loadClass("gui.DirectTextStyler");
 runtime.loadClass("gui.DirectParagraphStyler");
+runtime.loadClass("gui.KeyboardHandler");
+runtime.loadClass("gui.ImageManager");
+runtime.loadClass("gui.ImageSelector");
 runtime.loadClass("gui.TextManipulator");
+runtime.loadClass("gui.AnnotationManager");
+runtime.loadClass("gui.EventManager");
 gui.SessionController = function() {
   var FILTER_ACCEPT = core.PositionFilter.FilterResult.FILTER_ACCEPT;
-  gui.SessionController = function SessionController(session, inputMemberId, args) {
-    var window = (runtime.getWindow()), odtDocument = session.getOdtDocument(), utils = new core.Utils, domUtils = new core.DomUtils, odfUtils = new odf.OdfUtils, clipboard = new gui.Clipboard, keyDownHandler = new gui.KeyboardHandler, keyPressHandler = new gui.KeyboardHandler, keyboardMovementsFilter = new core.PositionFilterChain, baseFilter = odtDocument.getPositionFilter(), clickStartedWithinContainer = false, styleNameGenerator = new odf.StyleNameGenerator("auto" + utils.hashString(inputMemberId) + 
-    "_", odtDocument.getFormatting()), undoManager = null, textManipulator = new gui.TextManipulator(session, inputMemberId), directTextStyler = args && args.directStylingEnabled ? new gui.DirectTextStyler(session, inputMemberId) : null, directParagraphStyler = args && args.directStylingEnabled ? new gui.DirectParagraphStyler(session, inputMemberId, styleNameGenerator) : null;
+  gui.SessionController = function SessionController(session, inputMemberId, shadowCursor, args) {
+    var window = (runtime.getWindow()), odtDocument = session.getOdtDocument(), async = new core.Async, domUtils = new core.DomUtils, odfUtils = new odf.OdfUtils, clipboard = new gui.Clipboard, keyDownHandler = new gui.KeyboardHandler, keyPressHandler = new gui.KeyboardHandler, keyboardMovementsFilter = new core.PositionFilterChain, baseFilter = odtDocument.getPositionFilter(), clickStartedWithinContainer = false, objectNameGenerator = new odf.ObjectNameGenerator(odtDocument.getOdfCanvas().odfContainer(), 
+    inputMemberId), isMouseMoved = false, mouseDownRootFilter = null, undoManager = null, eventManager = new gui.EventManager(odtDocument), annotationManager = new gui.AnnotationManager(session, inputMemberId), directTextStyler = args && args.directStylingEnabled ? new gui.DirectTextStyler(session, inputMemberId) : null, directParagraphStyler = args && args.directStylingEnabled ? new gui.DirectParagraphStyler(session, inputMemberId, objectNameGenerator) : null, createCursorStyleOp = (directTextStyler && 
+    directTextStyler.createCursorStyleOp), textManipulator = new gui.TextManipulator(session, inputMemberId, createCursorStyleOp), imageManager = new gui.ImageManager(session, inputMemberId, objectNameGenerator), imageSelector = new gui.ImageSelector(odtDocument.getOdfCanvas()), shadowCursorIterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), drawShadowCursorTask;
     runtime.assert(window !== null, "Expected to be run in an environment which has a global window, like a browser.");
     keyboardMovementsFilter.addFilter("BaseFilter", baseFilter);
     keyboardMovementsFilter.addFilter("RootFilter", odtDocument.createRootFilter(inputMemberId));
-    function listenEvent(eventTarget, eventType, eventHandler, includeDirect) {
-      var onVariant = "on" + eventType, bound = false;
-      if(eventTarget.attachEvent) {
-        bound = eventTarget.attachEvent(onVariant, eventHandler)
-      }
-      if(!bound && eventTarget.addEventListener) {
-        eventTarget.addEventListener(eventType, eventHandler, false);
-        bound = true
-      }
-      if((!bound || includeDirect) && eventTarget.hasOwnProperty(onVariant)) {
-        eventTarget[onVariant] = eventHandler
-      }
-    }
-    function removeEvent(eventTarget, eventType, eventHandler) {
-      var onVariant = "on" + eventType;
-      if(eventTarget.detachEvent) {
-        eventTarget.detachEvent(onVariant, eventHandler)
-      }
-      if(eventTarget.removeEventListener) {
-        eventTarget.removeEventListener(eventType, eventHandler, false)
-      }
-      if(eventTarget[onVariant] === eventHandler) {
-        eventTarget[onVariant] = null
-      }
+    function getTarget(e) {
+      return e.target || e.srcElement
     }
     function cancelEvent(event) {
       if(event.preventDefault) {
@@ -13016,32 +14259,10 @@ gui.SessionController = function() {
     function dummyHandler(e) {
       cancelEvent(e)
     }
-    function createOpMoveCursor(position, length) {
+    function createOpMoveCursor(position, length, selectionType) {
       var op = new ops.OpMoveCursor;
-      op.init({memberid:inputMemberId, position:position, length:length || 0});
+      op.init({memberid:inputMemberId, position:position, length:length || 0, selectionType:selectionType});
       return op
-    }
-    function countStepsToNode(targetNode, targetOffset) {
-      var iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), canvasElement = odtDocument.getOdfCanvas().getElement(), node;
-      node = targetNode;
-      if(!node) {
-        return null
-      }
-      while(node !== canvasElement) {
-        if(node.namespaceURI === "urn:webodf:names:cursor" && node.localName === "cursor" || node.namespaceURI === "urn:webodf:names:editinfo" && node.localName === "editinfo") {
-          break
-        }
-        node = node.parentNode;
-        if(!node) {
-          return null
-        }
-      }
-      if(node !== canvasElement && targetNode !== node) {
-        targetNode = node.parentNode;
-        targetOffset = Array.prototype.indexOf.call(targetNode.childNodes, node)
-      }
-      iterator.setUnfilteredPosition(targetNode, targetOffset);
-      return odtDocument.getDistanceFromCursor(inputMemberId, iterator.container(), iterator.unfilteredDomOffset())
     }
     function caretPositionFromPoint(x, y) {
       var doc = odtDocument.getDOM(), result;
@@ -13066,9 +14287,6 @@ gui.SessionController = function() {
       }
       return{node:newNode, offset:newOffset}
     }
-    function isTextSpan(node) {
-      return node.namespaceURI === odf.Namespaces.textns && node.localName === "span"
-    }
     function expandToWordBoundaries(selection) {
       var alphaNumeric = /[A-Za-z0-9]/, iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), isForwardSelection = domUtils.comparePoints(selection.anchorNode, selection.anchorOffset, selection.focusNode, selection.focusOffset) > 0, startPoint, endPoint, currentNode, c;
       if(isForwardSelection) {
@@ -13087,7 +14305,7 @@ gui.SessionController = function() {
             break
           }
         }else {
-          if(!isTextSpan(currentNode)) {
+          if(!odfUtils.isTextSpan(currentNode)) {
             break
           }
         }
@@ -13103,7 +14321,7 @@ gui.SessionController = function() {
             break
           }
         }else {
-          if(!isTextSpan(currentNode)) {
+          if(!odfUtils.isTextSpan(currentNode)) {
             break
           }
         }
@@ -13133,111 +14351,73 @@ gui.SessionController = function() {
         selection.focusOffset = focusParagraph.childNodes.length
       }
     }
-    function mutableSelection(selection) {
-      return{anchorNode:selection.anchorNode, anchorOffset:selection.anchorOffset, focusNode:selection.focusNode, focusOffset:selection.focusOffset}
+    function selectImage(frameNode) {
+      var stepsToAnchor = odtDocument.getDistanceFromCursor(inputMemberId, frameNode, 0), stepsToFocus = stepsToAnchor !== null ? stepsToAnchor + 1 : null, oldPosition, op;
+      if(stepsToFocus || stepsToAnchor) {
+        oldPosition = odtDocument.getCursorPosition(inputMemberId);
+        op = createOpMoveCursor(oldPosition + stepsToAnchor, stepsToFocus - stepsToAnchor, ops.OdtCursor.RegionSelection);
+        session.enqueue([op])
+      }
+      eventManager.focus()
     }
-    function getSelection(e) {
-      var canvasElement = odtDocument.getOdfCanvas().getElement(), selection = mutableSelection(window.getSelection()), clickCount = e.detail, anchorNodeInsideCanvas, focusNodeInsideCanvas, caretPos, node;
-      if(selection.anchorNode === null && selection.focusNode === null) {
-        caretPos = caretPositionFromPoint(e.clientX, e.clientY);
+    function selectRange(selection, capturedDetails) {
+      var canvasElement = odtDocument.getOdfCanvas().getElement(), validSelection, clickCount = capturedDetails.detail, caretPos, anchorNodeInsideCanvas, focusNodeInsideCanvas, position, stepsToAnchor, stepsToFocus, oldPosition, op;
+      if(!selection) {
+        return
+      }
+      if(!selection.anchorNode && !selection.focusNode) {
+        caretPos = caretPositionFromPoint(capturedDetails.clientX, capturedDetails.clientY);
         if(!caretPos) {
-          return null
+          return
         }
         selection.anchorNode = (caretPos.container);
         selection.anchorOffset = caretPos.offset;
         selection.focusNode = selection.anchorNode;
         selection.focusOffset = selection.anchorOffset
       }
-      runtime.assert(selection.anchorNode !== null && selection.focusNode !== null, "anchorNode is null or focusNode is null");
-      anchorNodeInsideCanvas = domUtils.containsNode(canvasElement, selection.anchorNode);
-      focusNodeInsideCanvas = domUtils.containsNode(canvasElement, selection.focusNode);
+      runtime.assert(selection.anchorNode !== null && selection.focusNode !== null, "anchorNode or focusNode is null");
+      validSelection = (selection);
+      anchorNodeInsideCanvas = domUtils.containsNode(canvasElement, validSelection.anchorNode);
+      focusNodeInsideCanvas = domUtils.containsNode(canvasElement, validSelection.focusNode);
       if(!anchorNodeInsideCanvas && !focusNodeInsideCanvas) {
-        return null
+        return
       }
       if(!anchorNodeInsideCanvas) {
-        node = findClosestPosition(selection.anchorNode);
-        selection.anchorNode = node.node;
-        selection.anchorOffset = node.offset
+        position = findClosestPosition(validSelection.anchorNode);
+        validSelection.anchorNode = position.node;
+        validSelection.anchorOffset = position.offset
       }
       if(!focusNodeInsideCanvas) {
-        node = findClosestPosition(selection.focusNode);
-        selection.focusNode = node.node;
-        selection.focusOffset = node.offset
+        position = findClosestPosition(validSelection.focusNode);
+        validSelection.focusNode = position.node;
+        validSelection.focusOffset = position.offset
       }
       if(clickCount === 2) {
-        expandToWordBoundaries(selection)
+        expandToWordBoundaries(validSelection)
       }else {
         if(clickCount === 3) {
-          expandToParagraphBoundaries(selection)
+          expandToParagraphBoundaries(validSelection)
         }
       }
-      canvasElement.focus();
-      return selection
-    }
-    function getFirstWalkablePositionInNode(node) {
-      var position = 0, iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), watch = new core.LoopWatchDog(1E3), inside = false;
-      while(iterator.nextPosition()) {
-        watch.check();
-        inside = Boolean(node.compareDocumentPosition(iterator.container()) & Node.DOCUMENT_POSITION_CONTAINED_BY);
-        if(baseFilter.acceptPosition(iterator) === FILTER_ACCEPT) {
-          if(inside) {
-            break
-          }
-          position += 1
-        }
+      stepsToAnchor = odtDocument.getDistanceFromCursor(inputMemberId, validSelection.anchorNode, validSelection.anchorOffset);
+      if(validSelection.focusNode === validSelection.anchorNode && validSelection.focusOffset === validSelection.anchorOffset) {
+        stepsToFocus = stepsToAnchor
+      }else {
+        stepsToFocus = odtDocument.getDistanceFromCursor(inputMemberId, validSelection.focusNode, validSelection.focusOffset)
       }
-      return position
-    }
-    function getWalkableNodeLength(node) {
-      var length = 0, iterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), inside = false;
-      iterator.setUnfilteredPosition(node, 0);
-      do {
-        inside = Boolean(node.compareDocumentPosition(iterator.container()) & Node.DOCUMENT_POSITION_CONTAINED_BY);
-        if(!inside && node !== iterator.container()) {
-          break
-        }
-        if(baseFilter.acceptPosition(iterator) === FILTER_ACCEPT) {
-          length += 1
-        }
-      }while(iterator.nextPosition());
-      return length
-    }
-    function removeAnnotation(annotationNode) {
-      var position, length, op;
-      position = getFirstWalkablePositionInNode(annotationNode);
-      length = getWalkableNodeLength(annotationNode);
-      op = new ops.OpRemoveAnnotation;
-      op.init({memberid:inputMemberId, position:position, length:length});
-      session.enqueue(op)
-    }
-    function selectRange(e) {
-      runtime.setTimeout(function() {
-        var selection = getSelection(e), oldPosition, stepsToAnchor, stepsToFocus, op;
-        if(selection === null) {
-          return
-        }
-        stepsToAnchor = countStepsToNode(selection.anchorNode, selection.anchorOffset);
-        if(selection.focusNode === selection.anchorNode && selection.focusOffset === selection.anchorOffset) {
-          stepsToFocus = stepsToAnchor
-        }else {
-          stepsToFocus = countStepsToNode(selection.focusNode, selection.focusOffset)
-        }
-        if(stepsToFocus !== null && stepsToFocus !== 0 || stepsToAnchor !== null && stepsToAnchor !== 0) {
-          oldPosition = odtDocument.getCursorPosition(inputMemberId);
-          op = createOpMoveCursor(oldPosition + stepsToAnchor, stepsToFocus - stepsToAnchor);
-          session.enqueue(op)
-        }
-      }, 0)
-    }
-    function handleContextMenu(e) {
-      selectRange(e)
+      if(stepsToFocus || stepsToAnchor) {
+        oldPosition = odtDocument.getCursorPosition(inputMemberId);
+        op = createOpMoveCursor(oldPosition + stepsToAnchor, stepsToFocus - stepsToAnchor, ops.OdtCursor.RangeSelection);
+        session.enqueue([op])
+      }
+      eventManager.focus()
     }
     function extendCursorByAdjustment(lengthAdjust) {
       var selection = odtDocument.getCursorSelection(inputMemberId), stepCounter = odtDocument.getCursor(inputMemberId).getStepCounter(), newLength;
       if(lengthAdjust !== 0) {
         lengthAdjust = lengthAdjust > 0 ? stepCounter.convertForwardStepsBetweenFilters(lengthAdjust, keyboardMovementsFilter, baseFilter) : -stepCounter.convertBackwardStepsBetweenFilters(-lengthAdjust, keyboardMovementsFilter, baseFilter);
         newLength = selection.length + lengthAdjust;
-        session.enqueue(createOpMoveCursor(selection.position, newLength))
+        session.enqueue([createOpMoveCursor(selection.position, newLength)])
       }
     }
     function moveCursorByAdjustment(positionAdjust) {
@@ -13245,7 +14425,7 @@ gui.SessionController = function() {
       if(positionAdjust !== 0) {
         positionAdjust = positionAdjust > 0 ? stepCounter.convertForwardStepsBetweenFilters(positionAdjust, keyboardMovementsFilter, baseFilter) : -stepCounter.convertBackwardStepsBetweenFilters(-positionAdjust, keyboardMovementsFilter, baseFilter);
         position = position + positionAdjust;
-        session.enqueue(createOpMoveCursor(position, 0))
+        session.enqueue([createOpMoveCursor(position, 0)])
       }
     }
     function moveCursorToLeft() {
@@ -13378,18 +14558,43 @@ gui.SessionController = function() {
       steps = -odtDocument.getDistanceFromCursor(inputMemberId, iterator.container(), iterator.unfilteredDomOffset());
       iterator.moveToEnd();
       steps += odtDocument.getDistanceFromCursor(inputMemberId, iterator.container(), iterator.unfilteredDomOffset());
-      session.enqueue(createOpMoveCursor(0, steps));
+      session.enqueue([createOpMoveCursor(0, steps)]);
       return true
     }
     function maintainCursorSelection() {
-      var cursor = odtDocument.getCursor(inputMemberId), selection = window.getSelection();
+      var cursor = odtDocument.getCursor(inputMemberId), selection = window.getSelection(), imageElement, range;
       if(cursor) {
-        selection.removeAllRanges();
-        selection.addRange(cursor.getSelectedRange().cloneRange())
+        imageSelector.clearSelection();
+        if(cursor.getSelectionType() === ops.OdtCursor.RegionSelection) {
+          imageElement = odfUtils.getImageElements(cursor.getSelectedRange())[0];
+          if(imageElement) {
+            imageSelector.select((imageElement.parentNode))
+          }
+        }
+        if(eventManager.hasFocus()) {
+          range = cursor.getSelectedRange();
+          if(selection.extend) {
+            if(cursor.hasForwardSelection()) {
+              selection.collapse(range.startContainer, range.startOffset);
+              selection.extend(range.endContainer, range.endOffset)
+            }else {
+              selection.collapse(range.endContainer, range.endOffset);
+              selection.extend(range.startContainer, range.startOffset)
+            }
+          }else {
+            selection.removeAllRanges();
+            selection.addRange(range.cloneRange())
+          }
+        }
+      }else {
+        imageSelector.clearSelection()
       }
     }
+    function delayedMaintainCursor() {
+      runtime.setTimeout(maintainCursorSelection, 0)
+    }
     function stringFromKeyPress(event) {
-      if(event.which === null) {
+      if(event.which === null || event.which === undefined) {
         return String.fromCharCode(event.keyCode)
       }
       if(event.which !== 0 && event.charCode !== 0) {
@@ -13463,64 +14668,120 @@ gui.SessionController = function() {
       return false
     }
     function filterMouseClicks(e) {
-      clickStartedWithinContainer = e.target && domUtils.containsNode(odtDocument.getOdfCanvas().getElement(), e.target)
+      var target = getTarget(e);
+      clickStartedWithinContainer = target && domUtils.containsNode(odtDocument.getOdfCanvas().getElement(), target);
+      if(clickStartedWithinContainer) {
+        isMouseMoved = false;
+        mouseDownRootFilter = odtDocument.createRootFilter(target)
+      }
+    }
+    function cursorToSelection(cursor) {
+      var range = cursor.getSelectedRange();
+      if(cursor.hasForwardSelection()) {
+        return{anchorNode:range.startContainer, anchorOffset:range.startOffset, focusNode:range.endContainer, focusOffset:range.endOffset}
+      }
+      return{anchorNode:range.endContainer, anchorOffset:range.endOffset, focusNode:range.startContainer, focusOffset:range.startOffset}
+    }
+    function mutableSelection(selection) {
+      if(selection) {
+        return{anchorNode:selection.anchorNode, anchorOffset:selection.anchorOffset, focusNode:selection.focusNode, focusOffset:selection.focusOffset}
+      }
+      return null
+    }
+    function handleMouseClickEvent(event) {
+      var target = getTarget(event), eventDetails = {detail:event.detail, clientX:event.clientX, clientY:event.clientY, target:target};
+      drawShadowCursorTask.processRequests();
+      if(odfUtils.isImage(target) && odfUtils.isCharacterFrame(target.parentNode)) {
+        selectImage(target.parentNode)
+      }else {
+        if(clickStartedWithinContainer && !imageSelector.isSelectorElement(target)) {
+          if(isMouseMoved) {
+            selectRange(cursorToSelection(shadowCursor), event)
+          }else {
+            runtime.setTimeout(function() {
+              selectRange(mutableSelection(window.getSelection()), eventDetails)
+            }, 0)
+          }
+        }
+      }
+      clickStartedWithinContainer = false;
+      isMouseMoved = false
+    }
+    function handleContextMenu(e) {
+      handleMouseClickEvent(e)
     }
     function handleMouseUp(event) {
-      var target = event.target, annotationNode = null;
+      var target = getTarget(event), annotationNode = null;
       if(target.className === "annotationRemoveButton") {
         annotationNode = domUtils.getElementsByTagNameNS(target.parentNode, odf.Namespaces.officens, "annotation")[0];
-        removeAnnotation(annotationNode)
+        annotationManager.removeAnnotation(annotationNode)
       }else {
-        if(clickStartedWithinContainer) {
-          selectRange(event)
+        handleMouseClickEvent(event)
+      }
+    }
+    function updateShadowCursor() {
+      var selection = window.getSelection(), selectionRange, isForwardSelection;
+      if(clickStartedWithinContainer && selection.rangeCount > 0) {
+        isMouseMoved = true;
+        imageSelector.clearSelection();
+        shadowCursorIterator.setUnfilteredPosition((selection.focusNode), selection.focusOffset);
+        if(mouseDownRootFilter.acceptPosition(shadowCursorIterator) === FILTER_ACCEPT) {
+          selectionRange = selection.getRangeAt(0).cloneRange();
+          isForwardSelection = selection.anchorNode === selectionRange.startContainer && selection.anchorOffset === selectionRange.startOffset;
+          shadowCursor.setSelectedRange(selectionRange, isForwardSelection);
+          odtDocument.emit(ops.OdtDocument.signalCursorMoved, shadowCursor)
         }
       }
     }
     this.startEditing = function() {
-      var canvasElement, op;
-      canvasElement = odtDocument.getOdfCanvas().getElement();
-      listenEvent(canvasElement, "keydown", keyDownHandler.handleEvent);
-      listenEvent(canvasElement, "keypress", keyPressHandler.handleEvent);
-      listenEvent(canvasElement, "keyup", dummyHandler);
-      listenEvent(canvasElement, "beforecut", handleBeforeCut, true);
-      listenEvent(canvasElement, "cut", handleCut);
-      listenEvent(canvasElement, "copy", handleCopy);
-      listenEvent(canvasElement, "beforepaste", handleBeforePaste, true);
-      listenEvent(canvasElement, "paste", handlePaste);
-      listenEvent(window, "mousedown", filterMouseClicks);
-      listenEvent(window, "mouseup", handleMouseUp);
-      listenEvent(canvasElement, "contextmenu", handleContextMenu);
+      var op;
+      odtDocument.getOdfCanvas().getElement().classList.add("virtualSelections");
+      eventManager.subscribe("keydown", keyDownHandler.handleEvent);
+      eventManager.subscribe("keypress", keyPressHandler.handleEvent);
+      eventManager.subscribe("keyup", dummyHandler);
+      eventManager.subscribe("beforecut", handleBeforeCut);
+      eventManager.subscribe("cut", handleCut);
+      eventManager.subscribe("copy", handleCopy);
+      eventManager.subscribe("beforepaste", handleBeforePaste);
+      eventManager.subscribe("paste", handlePaste);
+      eventManager.subscribe("mousedown", filterMouseClicks);
+      eventManager.subscribe("mousemove", drawShadowCursorTask.trigger);
+      eventManager.subscribe("mouseup", handleMouseUp);
+      eventManager.subscribe("contextmenu", handleContextMenu);
+      eventManager.subscribe("focus", delayedMaintainCursor);
       odtDocument.subscribe(ops.OdtDocument.signalOperationExecuted, maintainCursorSelection);
       odtDocument.subscribe(ops.OdtDocument.signalOperationExecuted, updateUndoStack);
       op = new ops.OpAddCursor;
       op.init({memberid:inputMemberId});
-      session.enqueue(op);
+      session.enqueue([op]);
       if(undoManager) {
         undoManager.saveInitialState()
       }
     };
     this.endEditing = function() {
-      var canvasElement, op;
-      odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, updateUndoStack);
-      odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, maintainCursorSelection);
-      canvasElement = odtDocument.getOdfCanvas().getElement();
-      removeEvent(canvasElement, "keydown", keyDownHandler.handleEvent);
-      removeEvent(canvasElement, "keypress", keyPressHandler.handleEvent);
-      removeEvent(canvasElement, "keyup", dummyHandler);
-      removeEvent(canvasElement, "cut", handleCut);
-      removeEvent(canvasElement, "beforecut", handleBeforeCut);
-      removeEvent(canvasElement, "copy", handleCopy);
-      removeEvent(canvasElement, "paste", handlePaste);
-      removeEvent(canvasElement, "beforepaste", handleBeforePaste);
-      removeEvent(window, "mousedown", filterMouseClicks);
-      removeEvent(window, "mouseup", handleMouseUp);
-      removeEvent(canvasElement, "contextmenu", handleContextMenu);
+      var op;
       op = new ops.OpRemoveCursor;
       op.init({memberid:inputMemberId});
-      session.enqueue(op);
+      session.enqueue([op]);
       if(undoManager) {
         undoManager.resetInitialState()
       }
+      odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, updateUndoStack);
+      odtDocument.unsubscribe(ops.OdtDocument.signalOperationExecuted, maintainCursorSelection);
+      eventManager.unsubscribe("keydown", keyDownHandler.handleEvent);
+      eventManager.unsubscribe("keypress", keyPressHandler.handleEvent);
+      eventManager.unsubscribe("keyup", dummyHandler);
+      eventManager.unsubscribe("cut", handleCut);
+      eventManager.unsubscribe("beforecut", handleBeforeCut);
+      eventManager.unsubscribe("copy", handleCopy);
+      eventManager.unsubscribe("paste", handlePaste);
+      eventManager.unsubscribe("beforepaste", handleBeforePaste);
+      eventManager.unsubscribe("mousemove", drawShadowCursorTask.trigger);
+      eventManager.unsubscribe("mousedown", filterMouseClicks);
+      eventManager.unsubscribe("mouseup", handleMouseUp);
+      eventManager.unsubscribe("contextmenu", handleContextMenu);
+      eventManager.unsubscribe("focus", delayedMaintainCursor);
+      odtDocument.getOdfCanvas().getElement().classList.remove("virtualSelections")
     };
     this.getInputMemberId = function() {
       return inputMemberId
@@ -13544,106 +14805,136 @@ gui.SessionController = function() {
     this.getUndoManager = function() {
       return undoManager
     };
+    this.getAnnotationManager = function() {
+      return annotationManager
+    };
     this.getDirectTextStyler = function() {
       return directTextStyler
     };
     this.getDirectParagraphStyler = function() {
       return directParagraphStyler
     };
+    this.getImageManager = function() {
+      return imageManager
+    };
     this.getTextManipulator = function() {
       return textManipulator
     };
-    this.destroy = function(callback) {
-      var destroyDirectTextStyler = directTextStyler ? directTextStyler.destroy : function(cb) {
-        cb()
-      }, destroyDirectParagraphStyler = directParagraphStyler ? directParagraphStyler.destroy : function(cb) {
-        cb()
-      };
-      destroyDirectTextStyler(function(err) {
-        if(err) {
-          callback(err)
-        }else {
-          destroyDirectParagraphStyler(callback)
-        }
-      })
+    this.getEventManager = function() {
+      return eventManager
     };
+    this.getKeyboardHandlers = function() {
+      return{keydown:keyDownHandler, keypress:keyPressHandler}
+    };
+    this.destroy = function(callback) {
+      var destroyCallbacks = [drawShadowCursorTask.destroy];
+      if(directTextStyler) {
+        destroyCallbacks.push(directTextStyler.destroy)
+      }
+      if(directParagraphStyler) {
+        destroyCallbacks.push(directParagraphStyler.destroy)
+      }
+      async.destroyAll(destroyCallbacks, callback)
+    };
+    function returnTrue(fn) {
+      return function() {
+        fn();
+        return true
+      }
+    }
+    function rangeSelectionOnly(fn) {
+      return function(e) {
+        var selectionType = odtDocument.getCursor(inputMemberId).getSelectionType();
+        if(selectionType === ops.OdtCursor.RangeSelection) {
+          return fn(e)
+        }
+        return true
+      }
+    }
     function init() {
       var isMacOS = window.navigator.appVersion.toLowerCase().indexOf("mac") !== -1, modifier = gui.KeyboardHandler.Modifier, keyCode = gui.KeyboardHandler.KeyCode;
-      keyDownHandler.bind(keyCode.Tab, modifier.None, function() {
+      drawShadowCursorTask = new core.ScheduledTask(updateShadowCursor, 0);
+      keyDownHandler.bind(keyCode.Tab, modifier.None, rangeSelectionOnly(function() {
         textManipulator.insertText("\t");
         return true
-      });
-      keyDownHandler.bind(keyCode.Left, modifier.None, moveCursorToLeft);
-      keyDownHandler.bind(keyCode.Right, modifier.None, moveCursorToRight);
-      keyDownHandler.bind(keyCode.Up, modifier.None, moveCursorUp);
-      keyDownHandler.bind(keyCode.Down, modifier.None, moveCursorDown);
-      keyDownHandler.bind(keyCode.Backspace, modifier.None, textManipulator.removeTextByBackspaceKey);
+      }));
+      keyDownHandler.bind(keyCode.Left, modifier.None, rangeSelectionOnly(moveCursorToLeft));
+      keyDownHandler.bind(keyCode.Right, modifier.None, rangeSelectionOnly(moveCursorToRight));
+      keyDownHandler.bind(keyCode.Up, modifier.None, rangeSelectionOnly(moveCursorUp));
+      keyDownHandler.bind(keyCode.Down, modifier.None, rangeSelectionOnly(moveCursorDown));
+      keyDownHandler.bind(keyCode.Backspace, modifier.None, returnTrue(textManipulator.removeTextByBackspaceKey));
       keyDownHandler.bind(keyCode.Delete, modifier.None, textManipulator.removeTextByDeleteKey);
-      keyDownHandler.bind(keyCode.Left, modifier.Shift, extendSelectionToLeft);
-      keyDownHandler.bind(keyCode.Right, modifier.Shift, extendSelectionToRight);
-      keyDownHandler.bind(keyCode.Up, modifier.Shift, extendSelectionUp);
-      keyDownHandler.bind(keyCode.Down, modifier.Shift, extendSelectionDown);
-      keyDownHandler.bind(keyCode.Home, modifier.None, moveCursorToLineStart);
-      keyDownHandler.bind(keyCode.End, modifier.None, moveCursorToLineEnd);
-      keyDownHandler.bind(keyCode.Home, modifier.Ctrl, moveCursorToDocumentStart);
-      keyDownHandler.bind(keyCode.End, modifier.Ctrl, moveCursorToDocumentEnd);
-      keyDownHandler.bind(keyCode.Home, modifier.Shift, extendSelectionToLineStart);
-      keyDownHandler.bind(keyCode.End, modifier.Shift, extendSelectionToLineEnd);
-      keyDownHandler.bind(keyCode.Up, modifier.CtrlShift, extendSelectionToParagraphStart);
-      keyDownHandler.bind(keyCode.Down, modifier.CtrlShift, extendSelectionToParagraphEnd);
-      keyDownHandler.bind(keyCode.Home, modifier.CtrlShift, extendSelectionToDocumentStart);
-      keyDownHandler.bind(keyCode.End, modifier.CtrlShift, extendSelectionToDocumentEnd);
+      keyDownHandler.bind(keyCode.Left, modifier.Shift, rangeSelectionOnly(extendSelectionToLeft));
+      keyDownHandler.bind(keyCode.Right, modifier.Shift, rangeSelectionOnly(extendSelectionToRight));
+      keyDownHandler.bind(keyCode.Up, modifier.Shift, rangeSelectionOnly(extendSelectionUp));
+      keyDownHandler.bind(keyCode.Down, modifier.Shift, rangeSelectionOnly(extendSelectionDown));
+      keyDownHandler.bind(keyCode.Home, modifier.None, rangeSelectionOnly(moveCursorToLineStart));
+      keyDownHandler.bind(keyCode.End, modifier.None, rangeSelectionOnly(moveCursorToLineEnd));
+      keyDownHandler.bind(keyCode.Home, modifier.Ctrl, rangeSelectionOnly(moveCursorToDocumentStart));
+      keyDownHandler.bind(keyCode.End, modifier.Ctrl, rangeSelectionOnly(moveCursorToDocumentEnd));
+      keyDownHandler.bind(keyCode.Home, modifier.Shift, rangeSelectionOnly(extendSelectionToLineStart));
+      keyDownHandler.bind(keyCode.End, modifier.Shift, rangeSelectionOnly(extendSelectionToLineEnd));
+      keyDownHandler.bind(keyCode.Up, modifier.CtrlShift, rangeSelectionOnly(extendSelectionToParagraphStart));
+      keyDownHandler.bind(keyCode.Down, modifier.CtrlShift, rangeSelectionOnly(extendSelectionToParagraphEnd));
+      keyDownHandler.bind(keyCode.Home, modifier.CtrlShift, rangeSelectionOnly(extendSelectionToDocumentStart));
+      keyDownHandler.bind(keyCode.End, modifier.CtrlShift, rangeSelectionOnly(extendSelectionToDocumentEnd));
       if(isMacOS) {
         keyDownHandler.bind(keyCode.Clear, modifier.None, textManipulator.removeCurrentSelection);
-        keyDownHandler.bind(keyCode.Left, modifier.Meta, moveCursorToLineStart);
-        keyDownHandler.bind(keyCode.Right, modifier.Meta, moveCursorToLineEnd);
-        keyDownHandler.bind(keyCode.Home, modifier.Meta, moveCursorToDocumentStart);
-        keyDownHandler.bind(keyCode.End, modifier.Meta, moveCursorToDocumentEnd);
-        keyDownHandler.bind(keyCode.Left, modifier.MetaShift, extendSelectionToLineStart);
-        keyDownHandler.bind(keyCode.Right, modifier.MetaShift, extendSelectionToLineEnd);
-        keyDownHandler.bind(keyCode.Up, modifier.AltShift, extendSelectionToParagraphStart);
-        keyDownHandler.bind(keyCode.Down, modifier.AltShift, extendSelectionToParagraphEnd);
-        keyDownHandler.bind(keyCode.Up, modifier.MetaShift, extendSelectionToDocumentStart);
-        keyDownHandler.bind(keyCode.Down, modifier.MetaShift, extendSelectionToDocumentEnd);
-        keyDownHandler.bind(keyCode.A, modifier.Meta, extendSelectionToEntireDocument);
+        keyDownHandler.bind(keyCode.Left, modifier.Meta, rangeSelectionOnly(moveCursorToLineStart));
+        keyDownHandler.bind(keyCode.Right, modifier.Meta, rangeSelectionOnly(moveCursorToLineEnd));
+        keyDownHandler.bind(keyCode.Home, modifier.Meta, rangeSelectionOnly(moveCursorToDocumentStart));
+        keyDownHandler.bind(keyCode.End, modifier.Meta, rangeSelectionOnly(moveCursorToDocumentEnd));
+        keyDownHandler.bind(keyCode.Left, modifier.MetaShift, rangeSelectionOnly(extendSelectionToLineStart));
+        keyDownHandler.bind(keyCode.Right, modifier.MetaShift, rangeSelectionOnly(extendSelectionToLineEnd));
+        keyDownHandler.bind(keyCode.Up, modifier.AltShift, rangeSelectionOnly(extendSelectionToParagraphStart));
+        keyDownHandler.bind(keyCode.Down, modifier.AltShift, rangeSelectionOnly(extendSelectionToParagraphEnd));
+        keyDownHandler.bind(keyCode.Up, modifier.MetaShift, rangeSelectionOnly(extendSelectionToDocumentStart));
+        keyDownHandler.bind(keyCode.Down, modifier.MetaShift, rangeSelectionOnly(extendSelectionToDocumentEnd));
+        keyDownHandler.bind(keyCode.A, modifier.Meta, rangeSelectionOnly(extendSelectionToEntireDocument));
         if(directTextStyler) {
-          keyDownHandler.bind(keyCode.B, modifier.Meta, directTextStyler.toggleBold);
-          keyDownHandler.bind(keyCode.I, modifier.Meta, directTextStyler.toggleItalic);
-          keyDownHandler.bind(keyCode.U, modifier.Meta, directTextStyler.toggleUnderline)
+          keyDownHandler.bind(keyCode.B, modifier.Meta, rangeSelectionOnly(directTextStyler.toggleBold));
+          keyDownHandler.bind(keyCode.I, modifier.Meta, rangeSelectionOnly(directTextStyler.toggleItalic));
+          keyDownHandler.bind(keyCode.U, modifier.Meta, rangeSelectionOnly(directTextStyler.toggleUnderline))
         }
         if(directParagraphStyler) {
-          keyDownHandler.bind(keyCode.L, modifier.MetaShift, directParagraphStyler.alignParagraphLeft);
-          keyDownHandler.bind(keyCode.E, modifier.MetaShift, directParagraphStyler.alignParagraphCenter);
-          keyDownHandler.bind(keyCode.R, modifier.MetaShift, directParagraphStyler.alignParagraphRight);
-          keyDownHandler.bind(keyCode.J, modifier.MetaShift, directParagraphStyler.alignParagraphJustified)
+          keyDownHandler.bind(keyCode.L, modifier.MetaShift, rangeSelectionOnly(directParagraphStyler.alignParagraphLeft));
+          keyDownHandler.bind(keyCode.E, modifier.MetaShift, rangeSelectionOnly(directParagraphStyler.alignParagraphCenter));
+          keyDownHandler.bind(keyCode.R, modifier.MetaShift, rangeSelectionOnly(directParagraphStyler.alignParagraphRight));
+          keyDownHandler.bind(keyCode.J, modifier.MetaShift, rangeSelectionOnly(directParagraphStyler.alignParagraphJustified))
+        }
+        if(annotationManager) {
+          keyDownHandler.bind(keyCode.C, modifier.MetaShift, annotationManager.addAnnotation)
         }
         keyDownHandler.bind(keyCode.Z, modifier.Meta, undo);
         keyDownHandler.bind(keyCode.Z, modifier.MetaShift, redo)
       }else {
-        keyDownHandler.bind(keyCode.A, modifier.Ctrl, extendSelectionToEntireDocument);
+        keyDownHandler.bind(keyCode.A, modifier.Ctrl, rangeSelectionOnly(extendSelectionToEntireDocument));
         if(directTextStyler) {
-          keyDownHandler.bind(keyCode.B, modifier.Ctrl, directTextStyler.toggleBold);
-          keyDownHandler.bind(keyCode.I, modifier.Ctrl, directTextStyler.toggleItalic);
-          keyDownHandler.bind(keyCode.U, modifier.Ctrl, directTextStyler.toggleUnderline)
+          keyDownHandler.bind(keyCode.B, modifier.Ctrl, rangeSelectionOnly(directTextStyler.toggleBold));
+          keyDownHandler.bind(keyCode.I, modifier.Ctrl, rangeSelectionOnly(directTextStyler.toggleItalic));
+          keyDownHandler.bind(keyCode.U, modifier.Ctrl, rangeSelectionOnly(directTextStyler.toggleUnderline))
         }
         if(directParagraphStyler) {
-          keyDownHandler.bind(keyCode.L, modifier.CtrlShift, directParagraphStyler.alignParagraphLeft);
-          keyDownHandler.bind(keyCode.E, modifier.CtrlShift, directParagraphStyler.alignParagraphCenter);
-          keyDownHandler.bind(keyCode.R, modifier.CtrlShift, directParagraphStyler.alignParagraphRight);
-          keyDownHandler.bind(keyCode.J, modifier.CtrlShift, directParagraphStyler.alignParagraphJustified)
+          keyDownHandler.bind(keyCode.L, modifier.CtrlShift, rangeSelectionOnly(directParagraphStyler.alignParagraphLeft));
+          keyDownHandler.bind(keyCode.E, modifier.CtrlShift, rangeSelectionOnly(directParagraphStyler.alignParagraphCenter));
+          keyDownHandler.bind(keyCode.R, modifier.CtrlShift, rangeSelectionOnly(directParagraphStyler.alignParagraphRight));
+          keyDownHandler.bind(keyCode.J, modifier.CtrlShift, rangeSelectionOnly(directParagraphStyler.alignParagraphJustified))
+        }
+        if(annotationManager) {
+          keyDownHandler.bind(keyCode.C, modifier.CtrlAlt, annotationManager.addAnnotation)
         }
         keyDownHandler.bind(keyCode.Z, modifier.Ctrl, undo);
         keyDownHandler.bind(keyCode.Z, modifier.CtrlShift, redo)
       }
-      keyPressHandler.setDefault(function(e) {
+      keyPressHandler.setDefault(rangeSelectionOnly(function(e) {
         var text = stringFromKeyPress(e);
-        if(text && !(e.altKey || e.ctrlKey || e.metaKey)) {
+        if(text && !(e.altKey || (e.ctrlKey || e.metaKey))) {
           textManipulator.insertText(text);
           return true
         }
         return false
-      });
-      keyPressHandler.bind(keyCode.Enter, modifier.None, textManipulator.enqueueParagraphSplittingOps)
+      }));
+      keyPressHandler.bind(keyCode.Enter, modifier.None, rangeSelectionOnly(textManipulator.enqueueParagraphSplittingOps))
     }
     init()
   };
@@ -13660,6 +14951,9 @@ gui.SessionController = function() {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -13681,7 +14975,7 @@ gui.SessionController = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.MemberModel = function MemberModel() {
 };
@@ -13703,6 +14997,9 @@ ops.MemberModel.prototype.close = function(callback) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -13723,11 +15020,11 @@ ops.MemberModel.prototype.close = function(callback) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.TrivialMemberModel = function TrivialMemberModel() {
   this.getMemberDetailsAndUpdates = function(memberId, subscriber) {
-    subscriber(memberId, {memberid:memberId, fullname:"Unknown", color:"black", imageurl:"avatar-joe.png"})
+    subscriber(memberId, {memberid:memberId, fullname:runtime.tr("Unknown Author"), color:"black", imageurl:"avatar-joe.png"})
   };
   this.unsubscribeMemberDetailsUpdates = function(memberId, subscriber) {
   };
@@ -13747,6 +15044,9 @@ ops.TrivialMemberModel = function TrivialMemberModel() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -13767,7 +15067,7 @@ ops.TrivialMemberModel = function TrivialMemberModel() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.OperationRouter = function OperationRouter() {
 };
@@ -13775,13 +15075,9 @@ ops.OperationRouter.prototype.setOperationFactory = function(f) {
 };
 ops.OperationRouter.prototype.setPlaybackFunction = function(playback_func) {
 };
-ops.OperationRouter.prototype.push = function(op) {
+ops.OperationRouter.prototype.push = function(operations) {
 };
 ops.OperationRouter.prototype.close = function(callback) {
-};
-ops.OperationRouter.prototype.getHasLocalUnsyncedOpsAndUpdates = function(subscriber) {
-};
-ops.OperationRouter.prototype.unsubscribeHasLocalUnsyncedOpsUpdates = function(subscriber) {
 };
 /*
 
@@ -13795,6 +15091,9 @@ ops.OperationRouter.prototype.unsubscribeHasLocalUnsyncedOpsUpdates = function(s
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -13815,7 +15114,7 @@ ops.OperationRouter.prototype.unsubscribeHasLocalUnsyncedOpsUpdates = function(s
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 ops.TrivialOperationRouter = function TrivialOperationRouter() {
   var operationFactory, playbackFunction;
@@ -13825,19 +15124,16 @@ ops.TrivialOperationRouter = function TrivialOperationRouter() {
   this.setPlaybackFunction = function(playback_func) {
     playbackFunction = playback_func
   };
-  this.push = function(op) {
-    var timedOp, opspec = op.spec();
-    opspec.timestamp = (new Date).getTime();
-    timedOp = operationFactory.create(opspec);
-    playbackFunction(timedOp)
+  this.push = function(operations) {
+    operations.forEach(function(op) {
+      var timedOp, opspec = op.spec();
+      opspec.timestamp = (new Date).getTime();
+      timedOp = operationFactory.create(opspec);
+      playbackFunction(timedOp)
+    })
   };
   this.close = function(cb) {
     cb()
-  };
-  this.getHasLocalUnsyncedOpsAndUpdates = function(subscriber) {
-    subscriber(true)
-  };
-  this.unsubscribeHasLocalUnsyncedOpsUpdates = function(subscriber) {
   }
 };
 gui.EditInfoHandle = function EditInfoHandle(parentElement) {
@@ -13898,6 +15194,9 @@ gui.EditInfoHandle = function EditInfoHandle(parentElement) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -13918,19 +15217,19 @@ gui.EditInfoHandle = function EditInfoHandle(parentElement) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("ops.EditInfo");
 runtime.loadClass("gui.EditInfoHandle");
 gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
   var self = this, editInfoNode, handle, marker, editinfons = "urn:webodf:names:editinfo", decay1, decay2, decayTimeStep = 1E4;
   function applyDecay(opacity, delay) {
-    return runtime.getWindow().setTimeout(function() {
+    return runtime.setTimeout(function() {
       marker.style.opacity = opacity
     }, delay)
   }
   function deleteDecay(timer) {
-    runtime.getWindow().clearTimeout(timer)
+    runtime.clearTimeout(timer)
   }
   function setLastAuthor(memberid) {
     marker.setAttributeNS(editinfons, "editinfo:memberid", memberid)
@@ -14026,6 +15325,9 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -14046,7 +15348,7 @@ gui.EditInfoMarker = function EditInfoMarker(editInfo, initialVisibility) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("gui.Caret");
 runtime.loadClass("ops.TrivialMemberModel");
@@ -14061,13 +15363,13 @@ gui.SessionView = function() {
   function configOption(userValue, defaultValue) {
     return userValue !== undefined ? Boolean(userValue) : defaultValue
   }
-  function SessionView(viewOptions, session, caretManager) {
-    var avatarInfoStyles, editInfons = "urn:webodf:names:editinfo", editInfoMap = {}, showEditInfoMarkers = configOption(viewOptions.editInfoMarkersInitiallyVisible, true), showCaretAvatars = configOption(viewOptions.caretAvatarsInitiallyVisible, true), blinkOnRangeSelect = configOption(viewOptions.caretBlinksOnRangeSelect, true);
+  function SessionView(viewOptions, localMemberId, session, caretManager, selectionViewManager) {
+    var avatarInfoStyles, editInfons = "urn:webodf:names:editinfo", editInfoMap = {}, showEditInfoMarkers = configOption(viewOptions.editInfoMarkersInitiallyVisible, true), showCaretAvatars = configOption(viewOptions.caretAvatarsInitiallyVisible, true), blinkOnRangeSelect = configOption(viewOptions.caretBlinksOnRangeSelect, true), rerenderIntervalId, rerenderSelectionViews = false, RERENDER_INTERVAL = 200;
     function createAvatarInfoNodeMatch(nodeName, memberId, pseudoClass) {
-      return nodeName + '[editinfo|memberid^="' + memberId + '"]' + pseudoClass
+      return nodeName + '[editinfo|memberid="' + memberId + '"]' + pseudoClass
     }
     function getAvatarInfoStyle(nodeName, memberId, pseudoClass) {
-      var node = avatarInfoStyles.firstChild, nodeMatch = createAvatarInfoNodeMatch(nodeName, memberId, pseudoClass);
+      var node = avatarInfoStyles.firstChild, nodeMatch = createAvatarInfoNodeMatch(nodeName, memberId, pseudoClass) + "{";
       while(node) {
         if(node.nodeType === Node.TEXT_NODE && node.data.indexOf(nodeMatch) === 0) {
           return node
@@ -14089,7 +15391,8 @@ gui.SessionView = function() {
       setStyle("span.editInfoColor", "{ background-color: " + color + "; }", "");
       setStyle("span.editInfoAuthor", '{ content: "' + name + '"; }', ":before");
       setStyle("dc|creator", '{ content: "' + name + '"; display: none;}', ":before");
-      setStyle("dc|creator", "{ background-color: " + color + "; }", "")
+      setStyle("dc|creator", "{ background-color: " + color + "; }", "");
+      setStyle("div.selectionOverlay", "{ background-color: " + color + ";}", "")
     }
     function highlightEdit(element, memberId, timestamp) {
       var editInfo, editInfoMarker, id = "", editInfoNode = element.getElementsByTagNameNS(editInfons, "editinfo")[0];
@@ -14172,14 +15475,36 @@ gui.SessionView = function() {
         caret.setAvatarImageUrl(memberData.imageurl);
         caret.setColor(memberData.color)
       }
-      setAvatarInfoStyle(memberId, memberData.fullname, memberData.color)
+      setAvatarInfoStyle(memberId, memberData.fullname, memberData.color);
+      if(localMemberId === memberId) {
+        setAvatarInfoStyle("", memberData.fullname, memberData.color)
+      }
     }
     function onCursorAdded(cursor) {
       var memberId = cursor.getMemberId(), memberModel = session.getMemberModel();
       caretManager.registerCursor(cursor, showCaretAvatars, blinkOnRangeSelect);
+      selectionViewManager.registerCursor(cursor, true);
       renderMemberData(memberId, null);
       memberModel.getMemberDetailsAndUpdates(memberId, renderMemberData);
       runtime.log("+++ View here +++ eagerly created an Caret for '" + memberId + "'! +++")
+    }
+    function onCursorMoved(cursor) {
+      var memberId = cursor.getMemberId(), localSelectionView = selectionViewManager.getSelectionView(localMemberId), shadowSelectionView = selectionViewManager.getSelectionView(gui.ShadowCursor.ShadowCursorMemberId), localCaret = caretManager.getCaret(localMemberId);
+      if(memberId === localMemberId) {
+        shadowSelectionView.hide();
+        localSelectionView.show();
+        if(localCaret) {
+          localCaret.show()
+        }
+      }else {
+        if(memberId === gui.ShadowCursor.ShadowCursorMemberId) {
+          shadowSelectionView.show();
+          localSelectionView.hide();
+          if(localCaret) {
+            localCaret.hide()
+          }
+        }
+      }
     }
     function onCursorRemoved(memberid) {
       var hasMemberEditInfo = false, keyname;
@@ -14189,12 +15514,27 @@ gui.SessionView = function() {
           break
         }
       }
+      selectionViewManager.removeSelectionView(memberid);
       if(!hasMemberEditInfo) {
         session.getMemberModel().unsubscribeMemberDetailsUpdates(memberid, renderMemberData)
       }
     }
     function onParagraphChanged(info) {
       highlightEdit(info.paragraphElement, info.memberId, info.timeStamp)
+    }
+    function requestRerenderOfSelectionViews() {
+      rerenderSelectionViews = true
+    }
+    function startRerenderLoop() {
+      rerenderIntervalId = runtime.getWindow().setInterval(function() {
+        if(rerenderSelectionViews) {
+          selectionViewManager.rerenderSelectionViews();
+          rerenderSelectionViews = false
+        }
+      }, RERENDER_INTERVAL)
+    }
+    function stopRerenderLoop() {
+      runtime.getWindow().clearInterval(rerenderIntervalId)
     }
     this.destroy = function(callback) {
       var odtDocument = session.getOdtDocument(), memberModel = session.getMemberModel(), editInfoArray = Object.keys(editInfoMap).map(function(keyname) {
@@ -14203,6 +15543,11 @@ gui.SessionView = function() {
       odtDocument.unsubscribe(ops.OdtDocument.signalCursorAdded, onCursorAdded);
       odtDocument.unsubscribe(ops.OdtDocument.signalCursorRemoved, onCursorRemoved);
       odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
+      odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
+      odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, requestRerenderOfSelectionViews);
+      odtDocument.unsubscribe(ops.OdtDocument.signalTableAdded, requestRerenderOfSelectionViews);
+      odtDocument.unsubscribe(ops.OdtDocument.signalParagraphStyleModified, requestRerenderOfSelectionViews);
+      stopRerenderLoop();
       caretManager.getCarets().forEach(function(caret) {
         memberModel.unsubscribeMemberDetailsUpdates(caret.getCursor().getMemberId(), renderMemberData)
       });
@@ -14226,6 +15571,11 @@ gui.SessionView = function() {
       odtDocument.subscribe(ops.OdtDocument.signalCursorAdded, onCursorAdded);
       odtDocument.subscribe(ops.OdtDocument.signalCursorRemoved, onCursorRemoved);
       odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, onParagraphChanged);
+      odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, onCursorMoved);
+      startRerenderLoop();
+      odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, requestRerenderOfSelectionViews);
+      odtDocument.subscribe(ops.OdtDocument.signalTableAdded, requestRerenderOfSelectionViews);
+      odtDocument.subscribe(ops.OdtDocument.signalParagraphStyleModified, requestRerenderOfSelectionViews);
       avatarInfoStyles = document.createElementNS(head.namespaceURI, "style");
       avatarInfoStyles.type = "text/css";
       avatarInfoStyles.media = "screen, print, handheld, projection";
@@ -14249,6 +15599,9 @@ gui.SessionView = function() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -14269,11 +15622,11 @@ gui.SessionView = function() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("gui.Caret");
 gui.CaretManager = function CaretManager(sessionController) {
-  var carets = {}, window = runtime.getWindow();
+  var carets = {}, window = runtime.getWindow(), scrollIntoViewScheduled = false;
   function getCaret(memberId) {
     return carets.hasOwnProperty(memberId) ? carets[memberId] : null
   }
@@ -14300,13 +15653,26 @@ gui.CaretManager = function CaretManager(sessionController) {
       }
     }
   }
-  function ensureLocalCaretVisible(info) {
-    var caret;
-    if(info.memberId === sessionController.getInputMemberId()) {
-      caret = getCaret(info.memberId);
-      if(caret) {
-        caret.ensureVisible()
+  function executeEnsureCaretVisible() {
+    var caret = getCaret(sessionController.getInputMemberId());
+    scrollIntoViewScheduled = false;
+    if(caret) {
+      caret.ensureVisible()
+    }
+  }
+  function scheduleCaretVisibilityCheck() {
+    var caret = getCaret(sessionController.getInputMemberId());
+    if(caret) {
+      caret.handleUpdate();
+      if(!scrollIntoViewScheduled) {
+        scrollIntoViewScheduled = true;
+        runtime.setTimeout(executeEnsureCaretVisible, 50)
       }
+    }
+  }
+  function ensureLocalCaretVisible(info) {
+    if(info.memberId === sessionController.getInputMemberId()) {
+      scheduleCaretVisibilityCheck()
     }
   }
   function focusLocalCaret() {
@@ -14334,25 +15700,27 @@ gui.CaretManager = function CaretManager(sessionController) {
     }
   }
   this.registerCursor = function(cursor, caretAvatarInitiallyVisible, blinkOnRangeSelect) {
-    var memberid = cursor.getMemberId(), canvasElement = getCanvasElement(), caret = new gui.Caret(cursor, caretAvatarInitiallyVisible, blinkOnRangeSelect);
+    var memberid = cursor.getMemberId(), caret = new gui.Caret(cursor, caretAvatarInitiallyVisible, blinkOnRangeSelect);
     carets[memberid] = caret;
     if(memberid === sessionController.getInputMemberId()) {
       runtime.log("Starting to track input on new cursor of " + memberid);
-      cursor.handleUpdate = caret.ensureVisible;
-      canvasElement.setAttribute("tabindex", 0);
-      canvasElement.focus()
+      cursor.handleUpdate = scheduleCaretVisibilityCheck;
+      getCanvasElement().setAttribute("tabindex", -1);
+      sessionController.getEventManager().focus()
+    }else {
+      cursor.handleUpdate = caret.handleUpdate
     }
     return caret
   };
   this.getCaret = getCaret;
   this.getCarets = getCarets;
   this.destroy = function(callback) {
-    var odtDocument = sessionController.getSession().getOdtDocument(), canvasElement = getCanvasElement(), caretArray = getCarets();
+    var odtDocument = sessionController.getSession().getOdtDocument(), eventManager = sessionController.getEventManager(), caretArray = getCarets();
     odtDocument.unsubscribe(ops.OdtDocument.signalParagraphChanged, ensureLocalCaretVisible);
     odtDocument.unsubscribe(ops.OdtDocument.signalCursorMoved, refreshLocalCaretBlinking);
     odtDocument.unsubscribe(ops.OdtDocument.signalCursorRemoved, removeCaret);
-    canvasElement.removeEventListener("focus", focusLocalCaret, false);
-    canvasElement.removeEventListener("blur", blurLocalCaret, false);
+    eventManager.unsubscribe("focus", focusLocalCaret);
+    eventManager.unsubscribe("blur", blurLocalCaret);
     window.removeEventListener("focus", showLocalCaret, false);
     window.removeEventListener("blur", hideLocalCaret, false);
     (function destroyCaret(i, err) {
@@ -14367,381 +15735,20 @@ gui.CaretManager = function CaretManager(sessionController) {
           callback()
         }
       }
-    })(0, undefined)
+    })(0, undefined);
+    carets = {}
   };
   function init() {
-    var odtDocument = sessionController.getSession().getOdtDocument(), canvasElement = getCanvasElement();
+    var odtDocument = sessionController.getSession().getOdtDocument(), eventManager = sessionController.getEventManager();
     odtDocument.subscribe(ops.OdtDocument.signalParagraphChanged, ensureLocalCaretVisible);
     odtDocument.subscribe(ops.OdtDocument.signalCursorMoved, refreshLocalCaretBlinking);
     odtDocument.subscribe(ops.OdtDocument.signalCursorRemoved, removeCaret);
-    canvasElement.addEventListener("focus", focusLocalCaret, false);
-    canvasElement.addEventListener("blur", blurLocalCaret, false);
+    eventManager.subscribe("focus", focusLocalCaret);
+    eventManager.subscribe("blur", blurLocalCaret);
     window.addEventListener("focus", showLocalCaret, false);
     window.addEventListener("blur", hideLocalCaret, false)
   }
   init()
-};
-runtime.loadClass("xmldom.XPath");
-runtime.loadClass("odf.Namespaces");
-gui.PresenterUI = function() {
-  var xpath = new xmldom.XPath, window = runtime.getWindow();
-  return function PresenterUI(odf_element) {
-    var self = this;
-    self.setInitialSlideMode = function() {
-      self.startSlideMode("single")
-    };
-    self.keyDownHandler = function(ev) {
-      if(ev.target.isContentEditable) {
-        return
-      }
-      if(ev.target.nodeName === "input") {
-        return
-      }
-      switch(ev.keyCode) {
-        case 84:
-          self.toggleToolbar();
-          break;
-        case 37:
-        ;
-        case 8:
-          self.prevSlide();
-          break;
-        case 39:
-        ;
-        case 32:
-          self.nextSlide();
-          break;
-        case 36:
-          self.firstSlide();
-          break;
-        case 35:
-          self.lastSlide();
-          break
-      }
-    };
-    self.root = function() {
-      return self.odf_canvas.odfContainer().rootElement
-    };
-    self.firstSlide = function() {
-      self.slideChange(function(old, pc) {
-        return 0
-      })
-    };
-    self.lastSlide = function() {
-      self.slideChange(function(old, pc) {
-        return pc - 1
-      })
-    };
-    self.nextSlide = function() {
-      self.slideChange(function(old, pc) {
-        return old + 1 < pc ? old + 1 : -1
-      })
-    };
-    self.prevSlide = function() {
-      self.slideChange(function(old, pc) {
-        return old < 1 ? -1 : old - 1
-      })
-    };
-    self.slideChange = function(indexChanger) {
-      var pages = self.getPages(self.odf_canvas.odfContainer().rootElement), last = -1, i = 0, newidx, pagelist;
-      pages.forEach(function(tuple) {
-        var node = tuple[1];
-        if(node.hasAttribute("slide_current")) {
-          last = i;
-          node.removeAttribute("slide_current")
-        }
-        i += 1
-      });
-      newidx = indexChanger(last, pages.length);
-      if(newidx === -1) {
-        newidx = last
-      }
-      pages[newidx][1].setAttribute("slide_current", "1");
-      pagelist = document.getElementById("pagelist");
-      pagelist.selectedIndex = newidx;
-      if(self.slide_mode === "cont") {
-        window.scrollBy(0, pages[newidx][1].getBoundingClientRect().top - 30)
-      }
-    };
-    self.selectSlide = function(idx) {
-      self.slideChange(function(old, pc) {
-        if(idx >= pc) {
-          return-1
-        }
-        if(idx < 0) {
-          return-1
-        }
-        return idx
-      })
-    };
-    self.scrollIntoContView = function(idx) {
-      var pages = self.getPages(self.odf_canvas.odfContainer().rootElement);
-      if(pages.length === 0) {
-        return
-      }
-      window.scrollBy(0, pages[idx][1].getBoundingClientRect().top - 30)
-    };
-    self.getPages = function(root) {
-      var pagenodes = root.getElementsByTagNameNS(odf.Namespaces.drawns, "page"), pages = [], i;
-      for(i = 0;i < pagenodes.length;i += 1) {
-        pages.push([pagenodes[i].getAttribute("draw:name"), pagenodes[i]])
-      }
-      return pages
-    };
-    self.fillPageList = function(odfdom_root, html_select) {
-      var pages = self.getPages(odfdom_root), i, html_option, res, page_denom;
-      while(html_select.firstChild) {
-        html_select.removeChild(html_select.firstChild)
-      }
-      for(i = 0;i < pages.length;i += 1) {
-        html_option = document.createElement("option");
-        res = xpath.getODFElementsWithXPath(pages[i][1], './draw:frame[@presentation:class="title"]//draw:text-box/text:p', xmldom.XPath);
-        page_denom = res.length > 0 ? res[0].textContent : pages[i][0];
-        html_option.textContent = i + 1 + ": " + page_denom;
-        html_select.appendChild(html_option)
-      }
-    };
-    self.startSlideMode = function(mode) {
-      var pagelist = document.getElementById("pagelist"), css = self.odf_canvas.slidevisibilitycss().sheet;
-      self.slide_mode = mode;
-      while(css.cssRules.length > 0) {
-        css.deleteRule(0)
-      }
-      self.selectSlide(0);
-      if(self.slide_mode === "single") {
-        css.insertRule("draw|page { position:fixed; left:0px;top:30px; z-index:1; }", 0);
-        css.insertRule("draw|page[slide_current]  { z-index:2;}", 1);
-        css.insertRule("draw|page  { -webkit-transform: scale(1);}", 2);
-        self.fitToWindow();
-        window.addEventListener("resize", self.fitToWindow, false)
-      }else {
-        if(self.slide_mode === "cont") {
-          window.removeEventListener("resize", self.fitToWindow, false)
-        }
-      }
-      self.fillPageList(self.odf_canvas.odfContainer().rootElement, pagelist)
-    };
-    self.toggleToolbar = function() {
-      var css, found, i;
-      css = self.odf_canvas.slidevisibilitycss().sheet;
-      found = -1;
-      for(i = 0;i < css.cssRules.length;i += 1) {
-        if(css.cssRules[i].cssText.substring(0, 8) === ".toolbar") {
-          found = i;
-          break
-        }
-      }
-      if(found > -1) {
-        css.deleteRule(found)
-      }else {
-        css.insertRule(".toolbar { position:fixed; left:0px;top:-200px; z-index:0; }", 0)
-      }
-    };
-    self.fitToWindow = function() {
-      function ruleByFactor(f) {
-        return"draw|page { \n" + "-moz-transform: scale(" + f + "); \n" + "-moz-transform-origin: 0% 0%; " + "-webkit-transform-origin: 0% 0%; -webkit-transform: scale(" + f + "); " + "-o-transform-origin: 0% 0%; -o-transform: scale(" + f + "); " + "-ms-transform-origin: 0% 0%; -ms-transform: scale(" + f + "); " + "}"
-      }
-      var pages = self.getPages(self.root()), factorVert = (window.innerHeight - 40) / pages[0][1].clientHeight, factorHoriz = (window.innerWidth - 10) / pages[0][1].clientWidth, factor = factorVert < factorHoriz ? factorVert : factorHoriz, css = self.odf_canvas.slidevisibilitycss().sheet;
-      css.deleteRule(2);
-      css.insertRule(ruleByFactor(factor), 2)
-    };
-    self.load = function(url) {
-      self.odf_canvas.load(url)
-    };
-    self.odf_element = odf_element;
-    self.odf_canvas = new odf.OdfCanvas(self.odf_element);
-    self.odf_canvas.addListener("statereadychange", self.setInitialSlideMode);
-    self.slide_mode = "undefined";
-    document.addEventListener("keydown", self.keyDownHandler, false)
-  }
-}();
-runtime.loadClass("core.PositionIterator");
-runtime.loadClass("core.Cursor");
-gui.XMLEdit = function XMLEdit(element, stylesheet) {
-  var simplecss, cssprefix, documentElement, walker = null;
-  if(!element.id) {
-    element.id = "xml" + String(Math.random()).substring(2)
-  }
-  cssprefix = "#" + element.id + " ";
-  simplecss = cssprefix + "*," + cssprefix + ":visited, " + cssprefix + ":link {display:block; margin: 0px; margin-left: 10px; font-size: medium; color: black; background: white; font-variant: normal; font-weight: normal; font-style: normal; font-family: sans-serif; text-decoration: none; white-space: pre-wrap; height: auto; width: auto}\n" + cssprefix + ":before {color: blue; content: '<' attr(customns_name) attr(customns_atts) '>';}\n" + cssprefix + ":after {color: blue; content: '</' attr(customns_name) '>';}\n" + 
-  cssprefix + "{overflow: auto;}\n";
-  function listenEvent(eventTarget, eventType, eventHandler) {
-    if(eventTarget.addEventListener) {
-      eventTarget.addEventListener(eventType, eventHandler, false)
-    }else {
-      if(eventTarget.attachEvent) {
-        eventType = "on" + eventType;
-        eventTarget.attachEvent(eventType, eventHandler)
-      }else {
-        eventTarget["on" + eventType] = eventHandler
-      }
-    }
-  }
-  function cancelEvent(event) {
-    if(event.preventDefault) {
-      event.preventDefault()
-    }else {
-      event.returnValue = false
-    }
-  }
-  function isCaretMoveCommand(charCode) {
-    if(charCode >= 16 && charCode <= 20) {
-      return true
-    }
-    if(charCode >= 33 && charCode <= 40) {
-      return true
-    }
-    return false
-  }
-  function syncSelectionWithWalker() {
-    var sel = element.ownerDocument.defaultView.getSelection(), r;
-    if(!sel || sel.rangeCount <= 0 || !walker) {
-      return
-    }
-    r = sel.getRangeAt(0);
-    walker.setPoint(r.startContainer, r.startOffset)
-  }
-  function syncWalkerWithSelection() {
-    var sel = element.ownerDocument.defaultView.getSelection(), n, r;
-    sel.removeAllRanges();
-    if(!walker || !walker.node()) {
-      return
-    }
-    n = walker.node();
-    r = n.ownerDocument.createRange();
-    r.setStart(n, walker.position());
-    r.collapse(true);
-    sel.addRange(r)
-  }
-  function handleKeyDown(event) {
-    var charCode = event.charCode || event.keyCode;
-    walker = null;
-    if(walker && charCode === 39) {
-      syncSelectionWithWalker();
-      walker.stepForward();
-      syncWalkerWithSelection()
-    }else {
-      if(walker && charCode === 37) {
-        syncSelectionWithWalker();
-        walker.stepBackward();
-        syncWalkerWithSelection()
-      }else {
-        if(isCaretMoveCommand(charCode)) {
-          return
-        }
-      }
-    }
-    cancelEvent(event)
-  }
-  function handleClick(event) {
-    cancelEvent(event)
-  }
-  function initElement(element) {
-    listenEvent(element, "click", handleClick);
-    listenEvent(element, "keydown", handleKeyDown);
-    listenEvent(element, "drop", cancelEvent);
-    listenEvent(element, "dragend", cancelEvent);
-    listenEvent(element, "beforepaste", cancelEvent);
-    listenEvent(element, "paste", cancelEvent)
-  }
-  function cleanWhitespace(node) {
-    var n = node.firstChild, p, re = /^\s*$/;
-    while(n && n !== node) {
-      p = n;
-      n = n.nextSibling || n.parentNode;
-      if(p.nodeType === Node.TEXT_NODE && re.test(p.nodeValue)) {
-        p.parentNode.removeChild(p)
-      }
-    }
-  }
-  function setCssHelperAttributes(node) {
-    var atts, attsv, a, i;
-    atts = node.attributes;
-    attsv = "";
-    for(i = atts.length - 1;i >= 0;i -= 1) {
-      a = atts.item(i);
-      attsv = attsv + " " + a.nodeName + '="' + a.nodeValue + '"'
-    }
-    node.setAttribute("customns_name", node.nodeName);
-    node.setAttribute("customns_atts", attsv)
-  }
-  function addExplicitAttributes(node) {
-    var n = node.firstChild;
-    while(n && n !== node) {
-      if(n.nodeType === Node.ELEMENT_NODE) {
-        addExplicitAttributes(n)
-      }
-      n = n.nextSibling || n.parentNode
-    }
-    setCssHelperAttributes(node);
-    cleanWhitespace(node)
-  }
-  function getNamespacePrefixes(node, prefixes) {
-    var n = node.firstChild, atts, att, i;
-    while(n && n !== node) {
-      if(n.nodeType === Node.ELEMENT_NODE) {
-        getNamespacePrefixes(n, prefixes);
-        atts = n.attributes;
-        for(i = atts.length - 1;i >= 0;i -= 1) {
-          att = atts.item(i);
-          if(att.namespaceURI === "http://www.w3.org/2000/xmlns/") {
-            if(!prefixes[att.nodeValue]) {
-              prefixes[att.nodeValue] = att.localName
-            }
-          }
-        }
-      }
-      n = n.nextSibling || n.parentNode
-    }
-  }
-  function generateUniquePrefixes(prefixes) {
-    var taken = {}, ns, p, n = 0;
-    for(ns in prefixes) {
-      if(prefixes.hasOwnProperty(ns) && ns) {
-        p = prefixes[ns];
-        if(!p || taken.hasOwnProperty(p) || p === "xmlns") {
-          do {
-            p = "ns" + n;
-            n += 1
-          }while(taken.hasOwnProperty(p));
-          prefixes[ns] = p
-        }
-        taken[p] = true
-      }
-    }
-  }
-  function createCssFromXmlInstance(node) {
-    var prefixes = {}, css = "@namespace customns url(customns);\n";
-    getNamespacePrefixes(node, prefixes);
-    generateUniquePrefixes(prefixes);
-    return css
-  }
-  function updateCSS() {
-    var css = element.ownerDocument.createElement("style"), text = createCssFromXmlInstance(element);
-    css.type = "text/css";
-    text = text + simplecss;
-    css.appendChild(element.ownerDocument.createTextNode(text));
-    stylesheet = stylesheet.parentNode.replaceChild(css, stylesheet)
-  }
-  function getXML() {
-    return documentElement
-  }
-  function setXML(xml) {
-    var node = xml.documentElement || xml;
-    node = element.ownerDocument.importNode(node, true);
-    documentElement = node;
-    addExplicitAttributes(node);
-    while(element.lastChild) {
-      element.removeChild(element.lastChild)
-    }
-    element.appendChild(node);
-    updateCSS();
-    walker = new core.PositionIterator(node)
-  }
-  initElement(element);
-  this.updateCSS = updateCSS;
-  this.setXML = setXML;
-  this.getXML = getXML
 };
 /*
 
@@ -14754,6 +15761,9 @@ gui.XMLEdit = function XMLEdit(element, stylesheet) {
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -14775,7 +15785,7 @@ gui.XMLEdit = function XMLEdit(element, stylesheet) {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 gui.UndoManager = function UndoManager() {
 };
@@ -14819,6 +15829,9 @@ gui.UndoManager.signalUndoStateModified = "undoStateModified";
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -14839,7 +15852,7 @@ gui.UndoManager.signalUndoStateModified = "undoStateModified";
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 gui.UndoStateRules = function UndoStateRules() {
   function getOpType(op) {
@@ -14911,6 +15924,9 @@ gui.UndoStateRules = function UndoStateRules() {
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -14931,7 +15947,7 @@ gui.UndoStateRules = function UndoStateRules() {
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("gui.UndoManager");
@@ -15094,9 +16110,286 @@ gui.TrivialUndoManager.signalDocumentRootReplaced = "documentRootReplaced";
 (function() {
   return gui.TrivialUndoManager
 })();
+runtime.loadClass("core.DomUtils");
+runtime.loadClass("odf.OdfUtils");
+runtime.loadClass("odf.OdfNodeFilter");
+runtime.loadClass("gui.SelectionMover");
+gui.SelectionView = function SelectionView(cursor) {
+  var odtDocument = cursor.getOdtDocument(), root = odtDocument.getRootNode().parentNode.parentNode, doc = odtDocument.getDOM(), overlayTop = doc.createElement("div"), overlayMiddle = doc.createElement("div"), overlayBottom = doc.createElement("div"), odfUtils = new odf.OdfUtils, domUtils = new core.DomUtils, isVisible = true, clientRectRange = doc.createRange(), positionIterator = gui.SelectionMover.createPositionIterator(odtDocument.getRootNode()), areRangeClientRectsScaled = domUtils.areRangeRectanglesTransformed(doc), 
+  FILTER_ACCEPT = NodeFilter.FILTER_ACCEPT, FILTER_REJECT = NodeFilter.FILTER_REJECT;
+  function getBoundingClientRect(node) {
+    if(areRangeClientRectsScaled && node.nodeType === Node.ELEMENT_NODE) {
+      return node.getBoundingClientRect()
+    }
+    clientRectRange.selectNode(node);
+    return clientRectRange.getBoundingClientRect()
+  }
+  function setRect(div, rect) {
+    div.style.left = rect.left + "px";
+    div.style.top = rect.top + "px";
+    div.style.width = rect.width + "px";
+    div.style.height = rect.height + "px"
+  }
+  function showOverlays(choice) {
+    var display;
+    isVisible = choice;
+    display = choice === true ? "block" : "none";
+    overlayTop.style.display = overlayMiddle.style.display = overlayBottom.style.display = display
+  }
+  function translateRect(rect) {
+    var rootRect = getBoundingClientRect(root), zoomLevel = odtDocument.getOdfCanvas().getZoomLevel(), resultRect = {};
+    resultRect.top = domUtils.adaptRangeDifferenceToZoomLevel(rect.top - rootRect.top, zoomLevel);
+    resultRect.left = domUtils.adaptRangeDifferenceToZoomLevel(rect.left - rootRect.left, zoomLevel);
+    resultRect.bottom = domUtils.adaptRangeDifferenceToZoomLevel(rect.bottom - rootRect.top, zoomLevel);
+    resultRect.right = domUtils.adaptRangeDifferenceToZoomLevel(rect.right - rootRect.left, zoomLevel);
+    resultRect.width = domUtils.adaptRangeDifferenceToZoomLevel(rect.width, zoomLevel);
+    resultRect.height = domUtils.adaptRangeDifferenceToZoomLevel(rect.height, zoomLevel);
+    return resultRect
+  }
+  function isRangeVisible(range) {
+    var bcr = range.getBoundingClientRect();
+    return Boolean(bcr && bcr.height !== 0)
+  }
+  function lastVisibleRect(range, nodes) {
+    var nextNodeIndex = nodes.length - 1, node = nodes[nextNodeIndex], startOffset = range.endContainer === node ? range.endOffset : node.length || node.childNodes.length, endOffset = startOffset;
+    range.setStart(node, startOffset);
+    range.setEnd(node, endOffset);
+    while(!isRangeVisible(range)) {
+      if(node.nodeType === Node.ELEMENT_NODE && startOffset > 0) {
+        startOffset = 0
+      }else {
+        if(node.nodeType === Node.TEXT_NODE && startOffset > 0) {
+          startOffset -= 1
+        }else {
+          if(nodes[nextNodeIndex]) {
+            node = nodes[nextNodeIndex];
+            nextNodeIndex -= 1;
+            startOffset = endOffset = node.length || node.childNodes.length
+          }else {
+            return false
+          }
+        }
+      }
+      range.setStart(node, startOffset);
+      range.setEnd(node, endOffset)
+    }
+    return true
+  }
+  function firstVisibleRect(range, nodes) {
+    var nextNodeIndex = 0, node = nodes[nextNodeIndex], startOffset = range.startContainer === node ? range.startOffset : 0, endOffset = startOffset;
+    range.setStart(node, startOffset);
+    range.setEnd(node, endOffset);
+    while(!isRangeVisible(range)) {
+      if(node.nodeType === Node.ELEMENT_NODE && endOffset < node.childNodes.length) {
+        endOffset = node.childNodes.length
+      }else {
+        if(node.nodeType === Node.TEXT_NODE && endOffset < node.length) {
+          endOffset += 1
+        }else {
+          if(nodes[nextNodeIndex]) {
+            node = nodes[nextNodeIndex];
+            nextNodeIndex += 1;
+            startOffset = endOffset = 0
+          }else {
+            return false
+          }
+        }
+      }
+      range.setStart(node, startOffset);
+      range.setEnd(node, endOffset)
+    }
+    return true
+  }
+  function getExtremeRanges(range) {
+    var nodes = odfUtils.getTextElements(range, true, false), firstRange = (range.cloneRange()), lastRange = (range.cloneRange()), fillerRange = range.cloneRange();
+    if(!nodes.length) {
+      return null
+    }
+    if(!firstVisibleRect(firstRange, nodes)) {
+      return null
+    }
+    if(!lastVisibleRect(lastRange, nodes)) {
+      return null
+    }
+    fillerRange.setStart(firstRange.startContainer, firstRange.startOffset);
+    fillerRange.setEnd(lastRange.endContainer, lastRange.endOffset);
+    return{firstRange:firstRange, lastRange:lastRange, fillerRange:fillerRange}
+  }
+  function getBoundingRect(rect1, rect2) {
+    var resultRect = {};
+    resultRect.top = Math.min(rect1.top, rect2.top);
+    resultRect.left = Math.min(rect1.left, rect2.left);
+    resultRect.right = Math.max(rect1.right, rect2.right);
+    resultRect.bottom = Math.max(rect1.bottom, rect2.bottom);
+    resultRect.width = resultRect.right - resultRect.left;
+    resultRect.height = resultRect.bottom - resultRect.top;
+    return resultRect
+  }
+  function checkAndGrowOrCreateRect(originalRect, newRect) {
+    if(newRect && (newRect.width > 0 && newRect.height > 0)) {
+      if(!originalRect) {
+        originalRect = newRect
+      }else {
+        originalRect = getBoundingRect(originalRect, newRect)
+      }
+    }
+    return originalRect
+  }
+  function getFillerRect(fillerRange) {
+    var containerNode = fillerRange.commonAncestorContainer, firstNode = fillerRange.startContainer, lastNode = fillerRange.endContainer, firstOffset = fillerRange.startOffset, lastOffset = fillerRange.endOffset, currentNode, lastMeasuredNode, firstSibling, lastSibling, grownRect = null, currentRect, range = doc.createRange(), rootFilter, odfNodeFilter = new odf.OdfNodeFilter, treeWalker;
+    function acceptNode(node) {
+      positionIterator.setUnfilteredPosition(node, 0);
+      if(odfNodeFilter.acceptNode(node) === FILTER_ACCEPT && rootFilter.acceptPosition(positionIterator) === FILTER_ACCEPT) {
+        return FILTER_ACCEPT
+      }
+      return FILTER_REJECT
+    }
+    function getRectFromNodeAfterFiltering(node) {
+      var rect = null;
+      if(acceptNode(node) === FILTER_ACCEPT) {
+        rect = getBoundingClientRect(node)
+      }
+      return rect
+    }
+    if(firstNode === containerNode || lastNode === containerNode) {
+      range = fillerRange.cloneRange();
+      grownRect = range.getBoundingClientRect();
+      range.detach();
+      return grownRect
+    }
+    firstSibling = firstNode;
+    while(firstSibling.parentNode !== containerNode) {
+      firstSibling = firstSibling.parentNode
+    }
+    lastSibling = lastNode;
+    while(lastSibling.parentNode !== containerNode) {
+      lastSibling = lastSibling.parentNode
+    }
+    rootFilter = odtDocument.createRootFilter(firstNode);
+    currentNode = firstSibling.nextSibling;
+    while(currentNode && currentNode !== lastSibling) {
+      currentRect = getRectFromNodeAfterFiltering(currentNode);
+      grownRect = checkAndGrowOrCreateRect(grownRect, currentRect);
+      currentNode = currentNode.nextSibling
+    }
+    if(odfUtils.isParagraph(firstSibling)) {
+      grownRect = checkAndGrowOrCreateRect(grownRect, getBoundingClientRect(firstSibling))
+    }else {
+      treeWalker = doc.createTreeWalker(firstSibling, NodeFilter.SHOW_TEXT, acceptNode);
+      currentNode = treeWalker.currentNode = firstNode;
+      while(currentNode && currentNode !== lastNode) {
+        range.setStart(currentNode, firstOffset);
+        range.setEnd(currentNode, currentNode.length);
+        currentRect = range.getBoundingClientRect();
+        grownRect = checkAndGrowOrCreateRect(grownRect, currentRect);
+        lastMeasuredNode = currentNode;
+        firstOffset = 0;
+        currentNode = treeWalker.nextNode()
+      }
+    }
+    if(!lastMeasuredNode) {
+      lastMeasuredNode = firstNode
+    }
+    if(odfUtils.isParagraph(lastSibling)) {
+      grownRect = checkAndGrowOrCreateRect(grownRect, getBoundingClientRect(firstSibling))
+    }else {
+      treeWalker = doc.createTreeWalker(lastSibling, NodeFilter.SHOW_TEXT, acceptNode);
+      currentNode = treeWalker.currentNode = lastNode;
+      while(currentNode && currentNode !== lastMeasuredNode) {
+        range.setStart(currentNode, 0);
+        range.setEnd(currentNode, lastOffset);
+        currentRect = range.getBoundingClientRect();
+        grownRect = checkAndGrowOrCreateRect(grownRect, currentRect);
+        currentNode = treeWalker.previousNode();
+        if(currentNode) {
+          lastOffset = currentNode.length
+        }
+      }
+    }
+    return grownRect
+  }
+  function getCollapsedRectOfTextRange(range, useRightEdge) {
+    var clientRect = range.getBoundingClientRect(), collapsedRect = {};
+    collapsedRect.width = 0;
+    collapsedRect.top = clientRect.top;
+    collapsedRect.bottom = clientRect.bottom;
+    collapsedRect.height = clientRect.height;
+    collapsedRect.left = collapsedRect.right = useRightEdge ? clientRect.right : clientRect.left;
+    return collapsedRect
+  }
+  function repositionOverlays(selectedRange) {
+    var extremes = getExtremeRanges(selectedRange), firstRange, lastRange, fillerRange, firstRect, fillerRect, lastRect;
+    if(selectedRange.collapsed || !extremes) {
+      showOverlays(false)
+    }else {
+      showOverlays(true);
+      firstRange = extremes.firstRange;
+      lastRange = extremes.lastRange;
+      fillerRange = extremes.fillerRange;
+      firstRect = translateRect(getCollapsedRectOfTextRange(firstRange, false));
+      lastRect = translateRect(getCollapsedRectOfTextRange(lastRange, true));
+      fillerRect = getFillerRect(fillerRange);
+      if(!fillerRect) {
+        fillerRect = getBoundingRect(firstRect, lastRect)
+      }else {
+        fillerRect = translateRect(fillerRect)
+      }
+      setRect(overlayTop, {left:firstRect.left, top:firstRect.top, width:Math.max(0, fillerRect.width - (firstRect.left - fillerRect.left)), height:firstRect.height});
+      if(lastRect.top === firstRect.top || lastRect.bottom === firstRect.bottom) {
+        overlayMiddle.style.display = overlayBottom.style.display = "none"
+      }else {
+        setRect(overlayBottom, {left:fillerRect.left, top:lastRect.top, width:Math.max(0, lastRect.right - fillerRect.left), height:lastRect.height});
+        setRect(overlayMiddle, {left:fillerRect.left, top:firstRect.top + firstRect.height, width:Math.max(0, parseFloat(overlayTop.style.left) + parseFloat(overlayTop.style.width) - parseFloat(overlayBottom.style.left)), height:Math.max(0, lastRect.top - firstRect.bottom)})
+      }
+      firstRange.detach();
+      lastRange.detach();
+      fillerRange.detach()
+    }
+  }
+  function rerender() {
+    if(cursor.getSelectionType() === ops.OdtCursor.RangeSelection) {
+      showOverlays(true);
+      repositionOverlays(cursor.getSelectedRange())
+    }else {
+      showOverlays(false)
+    }
+  }
+  this.rerender = rerender;
+  this.show = rerender;
+  this.hide = function() {
+    showOverlays(false)
+  };
+  this.visible = function() {
+    return isVisible
+  };
+  function handleCursorMove(movedCursor) {
+    if(movedCursor === cursor) {
+      rerender()
+    }
+  }
+  this.destroy = function(callback) {
+    root.removeChild(overlayTop);
+    root.removeChild(overlayMiddle);
+    root.removeChild(overlayBottom);
+    cursor.getOdtDocument().unsubscribe(ops.OdtDocument.signalCursorMoved, handleCursorMove);
+    callback()
+  };
+  function init() {
+    var editinfons = "urn:webodf:names:editinfo", memberid = cursor.getMemberId();
+    root.appendChild(overlayTop);
+    root.appendChild(overlayMiddle);
+    root.appendChild(overlayBottom);
+    overlayTop.setAttributeNS(editinfons, "editinfo:memberid", memberid);
+    overlayMiddle.setAttributeNS(editinfons, "editinfo:memberid", memberid);
+    overlayBottom.setAttributeNS(editinfons, "editinfo:memberid", memberid);
+    overlayTop.className = overlayMiddle.className = overlayBottom.className = "selectionOverlay";
+    cursor.getOdtDocument().subscribe(ops.OdtDocument.signalCursorMoved, handleCursorMove)
+  }
+  init()
+};
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -15105,6 +16398,9 @@ gui.TrivialUndoManager.signalDocumentRootReplaced = "documentRootReplaced";
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -15126,14 +16422,117 @@ gui.TrivialUndoManager.signalDocumentRootReplaced = "documentRootReplaced";
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("gui.SelectionView");
+gui.SelectionViewManager = function SelectionViewManager() {
+  var selectionViews = {};
+  function getSelectionView(memberId) {
+    return selectionViews.hasOwnProperty(memberId) ? selectionViews[memberId] : null
+  }
+  this.getSelectionView = getSelectionView;
+  function getSelectionViews() {
+    return Object.keys(selectionViews).map(function(memberid) {
+      return selectionViews[memberid]
+    })
+  }
+  this.getSelectionViews = getSelectionViews;
+  function removeSelectionView(memberId) {
+    if(selectionViews.hasOwnProperty(memberId)) {
+      selectionViews[memberId].destroy(function() {
+      });
+      delete selectionViews[memberId]
+    }
+  }
+  this.removeSelectionView = removeSelectionView;
+  function hideSelectionView(memberId) {
+    if(selectionViews.hasOwnProperty(memberId)) {
+      selectionViews[memberId].hide()
+    }
+  }
+  this.hideSelectionView = hideSelectionView;
+  function showSelectionView(memberId) {
+    if(selectionViews.hasOwnProperty(memberId)) {
+      selectionViews[memberId].show()
+    }
+  }
+  this.showSelectionView = showSelectionView;
+  this.rerenderSelectionViews = function() {
+    Object.keys(selectionViews).forEach(function(memberId) {
+      if(selectionViews[memberId].visible()) {
+        selectionViews[memberId].rerender()
+      }
+    })
+  };
+  this.registerCursor = function(cursor, virtualSelectionsInitiallyVisible) {
+    var memberId = cursor.getMemberId(), selectionView = new gui.SelectionView(cursor);
+    if(virtualSelectionsInitiallyVisible) {
+      selectionView.show()
+    }else {
+      selectionView.hide()
+    }
+    selectionViews[memberId] = selectionView;
+    return selectionView
+  };
+  this.destroy = function(callback) {
+    var selectionViewArray = getSelectionViews();
+    (function destroySelectionView(i, err) {
+      if(err) {
+        callback(err)
+      }else {
+        if(i < selectionViewArray.length) {
+          selectionViewArray[i].destroy(function(err) {
+            destroySelectionView(i + 1, err)
+          })
+        }else {
+          callback()
+        }
+      }
+    })(0, undefined)
+  }
+};
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("core.EventNotifier");
 runtime.loadClass("core.DomUtils");
 runtime.loadClass("odf.OdfUtils");
 runtime.loadClass("odf.Namespaces");
 runtime.loadClass("gui.SelectionMover");
-runtime.loadClass("gui.StyleHelper");
 runtime.loadClass("core.PositionFilterChain");
 ops.OdtDocument = function OdtDocument(odfCanvas) {
   var self = this, odfUtils, domUtils, cursors = {}, eventNotifier = new core.EventNotifier([ops.OdtDocument.signalCursorAdded, ops.OdtDocument.signalCursorRemoved, ops.OdtDocument.signalCursorMoved, ops.OdtDocument.signalParagraphChanged, ops.OdtDocument.signalParagraphStyleModified, ops.OdtDocument.signalCommonStyleCreated, ops.OdtDocument.signalCommonStyleDeleted, ops.OdtDocument.signalTableAdded, ops.OdtDocument.signalOperationExecuted, ops.OdtDocument.signalUndoStackChanged]), FILTER_ACCEPT = 
@@ -15143,7 +16542,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     runtime.assert(localName === "text", "Unsupported content element type '" + localName + "'for OdtDocument");
     return element
   }
-  function RootFilter(memberId) {
+  function RootFilter(anchor) {
     function isRoot(node) {
       if(node.namespaceURI === odf.Namespaces.officens && node.localName === "text" || node.namespaceURI === odf.Namespaces.officens && node.localName === "annotation") {
         return true
@@ -15151,14 +16550,19 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
       return false
     }
     function getRoot(node) {
-      while(!isRoot(node)) {
+      while(node && !isRoot(node)) {
         node = (node.parentNode)
       }
       return node
     }
     this.acceptPosition = function(iterator) {
-      var node = iterator.container(), cursorNode = cursors[memberId].getNode();
-      if(getRoot(node) === getRoot(cursorNode)) {
+      var node = iterator.container(), anchorNode;
+      if(typeof anchor === "string") {
+        anchorNode = cursors[anchor].getNode()
+      }else {
+        anchorNode = anchor
+      }
+      if(getRoot(node) === getRoot(anchorNode)) {
         return FILTER_ACCEPT
       }
       return FILTER_REJECT
@@ -15305,9 +16709,9 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     if(lastTextNode === null) {
       return null
     }
-    if(memberid && cursors[memberid] && self.getCursorPosition(memberid) === originalPosition) {
+    if(memberid && (cursors[memberid] && self.getCursorPosition(memberid) === originalPosition)) {
       cursorNode = cursors[memberid].getNode();
-      while(nodeOffset === 0 && cursorNode.nextSibling && cursorNode.nextSibling.localName === "cursor") {
+      while(nodeOffset === 0 && (cursorNode.nextSibling && cursorNode.nextSibling.localName === "cursor")) {
         cursorNode.parentNode.insertBefore(cursorNode, cursorNode.nextSibling.nextSibling)
       }
       if(lastTextNode.length > 0) {
@@ -15315,7 +16719,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
         nodeOffset = 0;
         cursorNode.parentNode.insertBefore(lastTextNode, cursorNode.nextSibling)
       }
-      while(nodeOffset === 0 && lastTextNode.previousSibling && lastTextNode.previousSibling.localName === "cursor") {
+      while(nodeOffset === 0 && (lastTextNode.previousSibling && lastTextNode.previousSibling.localName === "cursor")) {
         node = lastTextNode.previousSibling;
         if(lastTextNode.length > 0) {
           lastTextNode = getRootNode().ownerDocument.createTextNode("")
@@ -15369,7 +16773,7 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
     for(i = -1;i <= 1;i += 1) {
       container = iterator.container();
       offset = iterator.unfilteredDomOffset();
-      if(container.nodeType === Node.TEXT_NODE && container.data[offset] === " " && odfUtils.isSignificantWhitespace(container, offset)) {
+      if(container.nodeType === Node.TEXT_NODE && (container.data[offset] === " " && odfUtils.isSignificantWhitespace(container, offset))) {
         container = upgradeWhitespaceToElement((container), offset);
         iterator.moveToEndOfNode(container)
       }
@@ -15402,28 +16806,40 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
   this.getParagraphElement = getParagraphElement;
   this.getParagraphStyleAttributes = getParagraphStyleAttributes;
   this.getPositionInTextNode = getPositionInTextNode;
-  this.fixCursorPositions = function(localMemberId) {
-    var memberId, cursor, stepCounter, steps, rootConstrainedFilter = new core.PositionFilterChain;
-    rootConstrainedFilter.addFilter("BaseFilter", self.getPositionFilter());
-    for(memberId in cursors) {
-      if(cursors.hasOwnProperty(memberId)) {
-        rootConstrainedFilter.addFilter("RootFilter", self.createRootFilter(memberId));
-        cursor = cursors[memberId];
-        stepCounter = cursor.getStepCounter();
-        if(!stepCounter.isPositionWalkable(rootConstrainedFilter)) {
-          steps = stepCounter.countStepsToValidPosition(rootConstrainedFilter);
-          cursor.move(steps);
-          if(memberId === localMemberId) {
-            self.emit(ops.OdtDocument.signalCursorMoved, cursor)
+  this.fixCursorPositions = function() {
+    var rootConstrainedFilter = new core.PositionFilterChain;
+    rootConstrainedFilter.addFilter("BaseFilter", filter);
+    Object.keys(cursors).forEach(function(memberId) {
+      var cursor = cursors[memberId], stepCounter = cursor.getStepCounter(), stepsSelectionLength, positionsToAdjustFocus, positionsToAdjustAnchor, positionsToAnchor, cursorMoved = false;
+      rootConstrainedFilter.addFilter("RootFilter", self.createRootFilter(memberId));
+      stepsSelectionLength = stepCounter.countStepsToPosition(cursor.getAnchorNode(), 0, rootConstrainedFilter);
+      if(!stepCounter.isPositionWalkable(rootConstrainedFilter)) {
+        cursorMoved = true;
+        positionsToAdjustFocus = stepCounter.countPositionsToNearestStep(cursor.getNode(), 0, rootConstrainedFilter);
+        positionsToAdjustAnchor = stepCounter.countPositionsToNearestStep(cursor.getAnchorNode(), 0, rootConstrainedFilter);
+        cursor.move(positionsToAdjustFocus);
+        if(stepsSelectionLength !== 0) {
+          if(positionsToAdjustAnchor > 0) {
+            stepsSelectionLength += 1
           }
-        }else {
-          if(self.getCursorSelection(memberId).length === 0) {
-            cursor.move(0)
+          if(positionsToAdjustFocus > 0) {
+            stepsSelectionLength -= 1
           }
+          positionsToAnchor = stepCounter.countSteps(stepsSelectionLength, rootConstrainedFilter);
+          cursor.move(positionsToAnchor);
+          cursor.move(-positionsToAnchor, true)
         }
-        rootConstrainedFilter.removeFilter("RootFilter")
+      }else {
+        if(stepsSelectionLength === 0) {
+          cursorMoved = true;
+          cursor.move(0)
+        }
       }
-    }
+      if(cursorMoved) {
+        self.emit(ops.OdtDocument.signalCursorMoved, cursor)
+      }
+      rootConstrainedFilter.removeFilter("RootFilter")
+    })
   };
   this.getWalkableParagraphLength = function(paragraph) {
     var iterator = getIteratorAtPosition(0), length = 0;
@@ -15483,8 +16899,8 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
   };
   this.addCursor = function(cursor) {
     runtime.assert(Boolean(cursor), "OdtDocument::addCursor without cursor");
-    var distanceToFirstTextNode = cursor.getStepCounter().countForwardSteps(1, filter), memberid = cursor.getMemberId();
-    runtime.assert(Boolean(memberid), "OdtDocument::addCursor has cursor without memberid");
+    var distanceToFirstTextNode = cursor.getStepCounter().countSteps(1, filter), memberid = cursor.getMemberId();
+    runtime.assert(typeof memberid === "string", "OdtDocument::addCursor has cursor without memberid");
     runtime.assert(!cursors[memberid], "OdtDocument::addCursor is adding a duplicate cursor with memberid " + memberid);
     cursor.move(distanceToFirstTextNode);
     cursors[memberid] = cursor
@@ -15516,12 +16932,6 @@ ops.OdtDocument = function OdtDocument(odfCanvas) {
   };
   this.getFormatting = function() {
     return odfCanvas.getFormatting()
-  };
-  this.getTextElements = function(range, includeInsignificantWhitespace) {
-    return odfUtils.getTextElements(range, includeInsignificantWhitespace)
-  };
-  this.getParagraphElements = function(range) {
-    return odfUtils.getParagraphElements(range)
   };
   this.emit = function(eventid, args) {
     eventNotifier.emit(eventid, args)
@@ -15573,6 +16983,9 @@ ops.OdtDocument.signalUndoStackChanged = "undo/changed";
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -15593,7 +17006,7 @@ ops.OdtDocument.signalUndoStackChanged = "undo/changed";
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("ops.TrivialMemberModel");
 runtime.loadClass("ops.TrivialOperationRouter");
@@ -15627,8 +17040,8 @@ ops.Session = function Session(odfCanvas) {
   this.getOdtDocument = function() {
     return odtDocument
   };
-  this.enqueue = function(operation) {
-    operationRouter.push(operation)
+  this.enqueue = function(ops) {
+    operationRouter.push(ops)
   };
   this.close = function(callback) {
     operationRouter.close(function(err) {
@@ -15653,5 +17066,5 @@ ops.Session = function Session(odfCanvas) {
   }
   init()
 };
-var webodf_css = "@namespace draw url(urn:oasis:names:tc:opendocument:xmlns:drawing:1.0);\n@namespace fo url(urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0);\n@namespace office url(urn:oasis:names:tc:opendocument:xmlns:office:1.0);\n@namespace presentation url(urn:oasis:names:tc:opendocument:xmlns:presentation:1.0);\n@namespace style url(urn:oasis:names:tc:opendocument:xmlns:style:1.0);\n@namespace svg url(urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0);\n@namespace table url(urn:oasis:names:tc:opendocument:xmlns:table:1.0);\n@namespace text url(urn:oasis:names:tc:opendocument:xmlns:text:1.0);\n@namespace runtimens url(urn:webodf); /* namespace for runtime only */\n@namespace cursor url(urn:webodf:names:cursor);\n@namespace editinfo url(urn:webodf:names:editinfo);\n@namespace annotation url(urn:webodf:names:annotation);\n@namespace dc url(http://purl.org/dc/elements/1.1/);\n\noffice|document > *, office|document-content > * {\n  display: none;\n}\noffice|body, office|document {\n  display: inline-block;\n  position: relative;\n}\n\ntext|p, text|h {\n  display: block;\n  padding: 0;\n  margin: 0;\n  line-height: normal;\n  position: relative;\n  min-height: 1.3em; /* prevent empty paragraphs and headings from collapsing if they are empty */\n}\n*[runtimens|containsparagraphanchor] {\n  position: relative;\n}\ntext|s {\n    white-space: pre;\n}\ntext|tab {\n  display: inline;\n  white-space: pre;\n}\ntext|line-break {\n  content: \" \";\n  display: block;\n}\ntext|tracked-changes {\n  /*Consumers that do not support change tracking, should ignore changes.*/\n  display: none;\n}\noffice|binary-data {\n  display: none;\n}\noffice|text {\n  display: block;\n  text-align: left;\n  overflow: visible;\n  word-wrap: break-word;\n}\n\noffice|text::selection {\n    /** Let's not draw selection highlight that overflows into the office|text\n     * node when selecting content across several paragraphs\n     */\n    background: transparent;\n}\noffice|text * draw|text-box {\n    /** only for text documents */\n    display: block;\n    border: 1px solid #d3d3d3;\n}\noffice|spreadsheet {\n  display: block;\n  border-collapse: collapse;\n  empty-cells: show;\n  font-family: sans-serif;\n  font-size: 10pt;\n  text-align: left;\n  page-break-inside: avoid;\n  overflow: hidden;\n}\noffice|presentation {\n  display: inline-block;\n  text-align: left;\n}\n#shadowContent {\n  display: inline-block;\n  text-align: left;\n}\ndraw|page {\n  display: block;\n  position: relative;\n  overflow: hidden;\n}\npresentation|notes, presentation|footer-decl, presentation|date-time-decl {\n    display: none;\n}\n@media print {\n  draw|page {\n    border: 1pt solid black;\n    page-break-inside: avoid;\n  }\n  presentation|notes {\n    /*TODO*/\n  }\n}\noffice|spreadsheet text|p {\n  border: 0px;\n  padding: 1px;\n  margin: 0px;\n}\noffice|spreadsheet table|table {\n  margin: 3px;\n}\noffice|spreadsheet table|table:after {\n  /* show sheet name the end of the sheet */\n  /*content: attr(table|name);*/ /* gives parsing error in opera */\n}\noffice|spreadsheet table|table-row {\n  counter-increment: row;\n}\noffice|spreadsheet table|table-row:before {\n  width: 3em;\n  background: #cccccc;\n  border: 1px solid black;\n  text-align: center;\n  content: counter(row);\n  display: table-cell;\n}\noffice|spreadsheet table|table-cell {\n  border: 1px solid #cccccc;\n}\ntable|table {\n  display: table;\n}\ndraw|frame table|table {\n  width: 100%;\n  height: 100%;\n  background: white;\n}\ntable|table-header-rows {\n  display: table-header-group;\n}\ntable|table-row {\n  display: table-row;\n}\ntable|table-column {\n  display: table-column;\n}\ntable|table-cell {\n  width: 0.889in;\n  display: table-cell;\n  word-break: break-all; /* prevent long words from extending out the table cell */\n}\ndraw|frame {\n  display: block;\n}\ndraw|image {\n  display: block;\n  width: 100%;\n  height: 100%;\n  top: 0px;\n  left: 0px;\n  background-repeat: no-repeat;\n  background-size: 100% 100%;\n  -moz-background-size: 100% 100%;\n}\n/* only show the first image in frame */\ndraw|frame > draw|image:nth-of-type(n+2) {\n  display: none;\n}\ntext|list:before {\n    display: none;\n    content:\"\";\n}\ntext|list {\n    counter-reset: list;\n}\ntext|list-item {\n    display: block;\n}\ntext|number {\n    display:none;\n}\n\ntext|a {\n    color: blue;\n    text-decoration: underline;\n    cursor: pointer;\n}\ntext|note-citation {\n    vertical-align: super;\n    font-size: smaller;\n}\ntext|note-body {\n    display: none;\n}\ntext|note:hover text|note-citation {\n    background: #dddddd;\n}\ntext|note:hover text|note-body {\n    display: block;\n    left:1em;\n    max-width: 80%;\n    position: absolute;\n    background: #ffffaa;\n}\nsvg|title, svg|desc {\n    display: none;\n}\nvideo {\n    width: 100%;\n    height: 100%\n}\n\n/* below set up the cursor */\ncursor|cursor {\n    display: inline;\n    width: 0px;\n    height: 1em;\n    /* making the position relative enables the avatar to use\n       the cursor as reference for its absolute position */\n    position: relative;\n    z-index: 1;\n}\ncursor|cursor > span {\n    display: inline;\n    position: absolute;\n    top: 5%; /* push down the caret; 0px can do the job, 5% looks better, 10% is a bit over */\n    height: 1em;\n    border-left: 2px solid black;\n    outline: none;\n}\n\ncursor|cursor > div {\n    padding: 3px;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    border: none !important;\n    border-radius: 5px;\n    opacity: 0.3;\n}\n\ncursor|cursor > div > img {\n    border-radius: 5px;\n}\n\ncursor|cursor > div.active {\n    opacity: 0.8;\n}\n\ncursor|cursor > div:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 43%;\n}\n\n\n.editInfoMarker {\n    position: absolute;\n    width: 10px;\n    height: 100%;\n    left: -20px;\n    opacity: 0.8;\n    top: 0;\n    border-radius: 5px;\n    background-color: transparent;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n}\n.editInfoMarker:hover {\n    box-shadow: 0px 0px 8px rgba(0, 0, 0, 1);\n}\n\n.editInfoHandle {\n    position: absolute;\n    background-color: black;\n    padding: 5px;\n    border-radius: 5px;\n    opacity: 0.8;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    bottom: 100%;\n    margin-bottom: 10px;\n    z-index: 3;\n    left: -25px;\n}\n.editInfoHandle:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 5px;\n}\n.editInfo {\n    font-family: sans-serif;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    color: white;\n    width: 100%;\n    height: 12pt;\n}\n.editInfoColor {\n    float: left;\n    width: 10pt;\n    height: 10pt;\n    border: 1px solid white;\n}\n.editInfoAuthor {\n    float: left;\n    margin-left: 5pt;\n    font-size: 10pt;\n    text-align: left;\n    height: 12pt;\n    line-height: 12pt;\n}\n.editInfoTime {\n    float: right;\n    margin-left: 30pt;\n    font-size: 8pt;\n    font-style: italic;\n    color: yellow;\n    height: 12pt;\n    line-height: 12pt;\n}\n\n.annotationWrapper {\n    display: inline;\n    position: relative;\n}\n\n.annotationRemoveButton:before {\n    content: '\u00d7';\n    color: white;\n    padding: 5px;\n    line-height: 1em;\n}\n\n.annotationRemoveButton {\n    width: 20px;\n    height: 20px;\n    border-radius: 10px;\n    background-color: black;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    position: absolute;\n    top: -10px;\n    left: -10px;\n    z-index: 3;\n    text-align: center;\n    font-family: sans-serif;\n    font-style: normal;\n    font-weight: normal;\n    text-decoration: none;\n    font-size: 15px;\n}\n.annotationRemoveButton:hover {\n    cursor: pointer;\n    box-shadow: 0px 0px 5px rgba(0, 0, 0, 1);\n}\n\n.annotationNote {\n    width: 4cm;\n    position: absolute;\n    display: inline;\n    z-index: 10;\n}\n.annotationNote > office|annotation {\n    display: block;\n    text-align: left;\n}\n\n.annotationConnector {\n    position: absolute;\n    display: inline;\n    z-index: 2;\n    border-top: 1px dashed brown;\n}\n.annotationConnector.angular {\n    -moz-transform-origin: left top;\n    -webkit-transform-origin: left top;\n    -ms-transform-origin: left top;\n    transform-origin: left top;\n}\n.annotationConnector.horizontal {\n    left: 0;\n}\n.annotationConnector.horizontal:before {\n    content: '';\n    display: inline;\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: brown transparent transparent transparent;\n    top: -1px;\n    left: -5px;\n}\n\noffice|annotation {\n    width: 100%;\n    height: 100%;\n    display: none;\n    background: rgb(198, 238, 184);\n    background: -moz-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -webkit-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -o-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -ms-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: linear-gradient(180deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    box-shadow: 0 3px 4px -3px #ccc;\n}\n\noffice|annotation > dc|creator {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    color: white;\n    background-color: brown;\n    padding: 4px;\n}\noffice|annotation > dc|date {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    border: 4px solid transparent;\n}\noffice|annotation > text|list {\n    display: block;\n    padding: 5px;\n}\n\n/* This is very temporary CSS. This must go once\n * we start bundling webodf-default ODF styles for annotations.\n */\noffice|annotation text|p {\n    font-size: 10pt;\n    color: black;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    font-family: sans-serif;\n}\n\ndc|*::selection {\n    background: transparent;\n}\ndc|*::-moz-selection {\n    background: transparent;\n}\n\n#annotationsPane {\n    background-color: #EAEAEA;\n    width: 4cm;\n    height: 100%;\n    display: none;\n    position: absolute;\n    outline: 1px solid #ccc;\n}\n\n.annotationHighlight {\n    background-color: yellow;\n    position: relative;\n}\n";
+var webodf_css = "@namespace draw url(urn:oasis:names:tc:opendocument:xmlns:drawing:1.0);\n@namespace fo url(urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0);\n@namespace office url(urn:oasis:names:tc:opendocument:xmlns:office:1.0);\n@namespace presentation url(urn:oasis:names:tc:opendocument:xmlns:presentation:1.0);\n@namespace style url(urn:oasis:names:tc:opendocument:xmlns:style:1.0);\n@namespace svg url(urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0);\n@namespace table url(urn:oasis:names:tc:opendocument:xmlns:table:1.0);\n@namespace text url(urn:oasis:names:tc:opendocument:xmlns:text:1.0);\n@namespace webodfhelper url(urn:webodf:names:helper);\n@namespace cursor url(urn:webodf:names:cursor);\n@namespace editinfo url(urn:webodf:names:editinfo);\n@namespace annotation url(urn:webodf:names:annotation);\n@namespace dc url(http://purl.org/dc/elements/1.1/);\n\noffice|document > *, office|document-content > * {\n  display: none;\n}\noffice|body, office|document {\n  display: inline-block;\n  position: relative;\n}\n\ntext|p, text|h {\n  display: block;\n  padding: 0;\n  margin: 0;\n  line-height: normal;\n  position: relative;\n  min-height: 1.3em; /* prevent empty paragraphs and headings from collapsing if they are empty */\n}\n*[webodfhelper|containsparagraphanchor] {\n  position: relative;\n}\ntext|s {\n    white-space: pre;\n}\ntext|tab {\n  display: inline;\n  white-space: pre;\n}\ntext|tracked-changes {\n  /*Consumers that do not support change tracking, should ignore changes.*/\n  display: none;\n}\noffice|binary-data {\n  display: none;\n}\noffice|text {\n  display: block;\n  text-align: left;\n  overflow: visible;\n  word-wrap: break-word;\n}\n\noffice|text::selection {\n  /** Let's not draw selection highlight that overflows into the office|text\n   * node when selecting content across several paragraphs\n   */\n  background: transparent;\n}\n\n.virtualSelections office|document *::selection {\n  background: transparent;\n}\n.virtualSelections office|document *::-moz-selection {\n  background: transparent;\n}\n\noffice|text * draw|text-box {\n/** only for text documents */\n    display: block;\n    border: 1px solid #d3d3d3;\n}\noffice|spreadsheet {\n  display: block;\n  border-collapse: collapse;\n  empty-cells: show;\n  font-family: sans-serif;\n  font-size: 10pt;\n  text-align: left;\n  page-break-inside: avoid;\n  overflow: hidden;\n}\noffice|presentation {\n  display: inline-block;\n  text-align: left;\n}\n#shadowContent {\n  display: inline-block;\n  text-align: left;\n}\ndraw|page {\n  display: block;\n  position: relative;\n  overflow: hidden;\n}\npresentation|notes, presentation|footer-decl, presentation|date-time-decl {\n    display: none;\n}\n@media print {\n  draw|page {\n    border: 1pt solid black;\n    page-break-inside: avoid;\n  }\n  presentation|notes {\n    /*TODO*/\n  }\n}\noffice|spreadsheet text|p {\n  border: 0px;\n  padding: 1px;\n  margin: 0px;\n}\noffice|spreadsheet table|table {\n  margin: 3px;\n}\noffice|spreadsheet table|table:after {\n  /* show sheet name the end of the sheet */\n  /*content: attr(table|name);*/ /* gives parsing error in opera */\n}\noffice|spreadsheet table|table-row {\n  counter-increment: row;\n}\noffice|spreadsheet table|table-row:before {\n  width: 3em;\n  background: #cccccc;\n  border: 1px solid black;\n  text-align: center;\n  content: counter(row);\n  display: table-cell;\n}\noffice|spreadsheet table|table-cell {\n  border: 1px solid #cccccc;\n}\ntable|table {\n  display: table;\n}\ndraw|frame table|table {\n  width: 100%;\n  height: 100%;\n  background: white;\n}\ntable|table-header-rows {\n  display: table-header-group;\n}\ntable|table-row {\n  display: table-row;\n}\ntable|table-column {\n  display: table-column;\n}\ntable|table-cell {\n  width: 0.889in;\n  display: table-cell;\n  word-break: break-all; /* prevent long words from extending out the table cell */\n}\ndraw|frame {\n  display: block;\n}\ndraw|image {\n  display: block;\n  width: 100%;\n  height: 100%;\n  top: 0px;\n  left: 0px;\n  background-repeat: no-repeat;\n  background-size: 100% 100%;\n  -moz-background-size: 100% 100%;\n}\n/* only show the first image in frame */\ndraw|frame > draw|image:nth-of-type(n+2) {\n  display: none;\n}\ntext|list:before {\n    display: none;\n    content:\"\";\n}\ntext|list {\n    counter-reset: list;\n}\ntext|list-item {\n    display: block;\n}\ntext|number {\n    display:none;\n}\n\ntext|a {\n    color: blue;\n    text-decoration: underline;\n    cursor: pointer;\n}\ntext|note-citation {\n    vertical-align: super;\n    font-size: smaller;\n}\ntext|note-body {\n    display: none;\n}\ntext|note:hover text|note-citation {\n    background: #dddddd;\n}\ntext|note:hover text|note-body {\n    display: block;\n    left:1em;\n    max-width: 80%;\n    position: absolute;\n    background: #ffffaa;\n}\nsvg|title, svg|desc {\n    display: none;\n}\nvideo {\n    width: 100%;\n    height: 100%\n}\n\n/* below set up the cursor */\ncursor|cursor {\n    display: inline;\n    width: 0px;\n    height: 1em;\n    /* making the position relative enables the avatar to use\n       the cursor as reference for its absolute position */\n    position: relative;\n    z-index: 1;\n}\ncursor|cursor > span {\n    /* IMPORTANT: when changing these values ensure DEFAULT_CARET_TOP and DEFAULT_CARET_HEIGHT\n        in Caret.js remain in sync */\n    display: inline;\n    position: absolute;\n    top: 5%; /* push down the caret; 0px can do the job, 5% looks better, 10% is a bit over */\n    height: 1em;\n    border-left: 2px solid black;\n    outline: none;\n}\n\ncursor|cursor > div {\n    padding: 3px;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    border: none !important;\n    border-radius: 5px;\n    opacity: 0.3;\n}\n\ncursor|cursor > div > img {\n    border-radius: 5px;\n}\n\ncursor|cursor > div.active {\n    opacity: 0.8;\n}\n\ncursor|cursor > div:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 43%;\n}\n\n\n.editInfoMarker {\n    position: absolute;\n    width: 10px;\n    height: 100%;\n    left: -20px;\n    opacity: 0.8;\n    top: 0;\n    border-radius: 5px;\n    background-color: transparent;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n}\n.editInfoMarker:hover {\n    box-shadow: 0px 0px 8px rgba(0, 0, 0, 1);\n}\n\n.editInfoHandle {\n    position: absolute;\n    background-color: black;\n    padding: 5px;\n    border-radius: 5px;\n    opacity: 0.8;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    bottom: 100%;\n    margin-bottom: 10px;\n    z-index: 3;\n    left: -25px;\n}\n.editInfoHandle:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 5px;\n}\n.editInfo {\n    font-family: sans-serif;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    color: white;\n    width: 100%;\n    height: 12pt;\n}\n.editInfoColor {\n    float: left;\n    width: 10pt;\n    height: 10pt;\n    border: 1px solid white;\n}\n.editInfoAuthor {\n    float: left;\n    margin-left: 5pt;\n    font-size: 10pt;\n    text-align: left;\n    height: 12pt;\n    line-height: 12pt;\n}\n.editInfoTime {\n    float: right;\n    margin-left: 30pt;\n    font-size: 8pt;\n    font-style: italic;\n    color: yellow;\n    height: 12pt;\n    line-height: 12pt;\n}\n\n.annotationWrapper {\n    display: inline;\n    position: relative;\n}\n\n.annotationRemoveButton:before {\n    content: '\u00d7';\n    color: white;\n    padding: 5px;\n    line-height: 1em;\n}\n\n.annotationRemoveButton {\n    width: 20px;\n    height: 20px;\n    border-radius: 10px;\n    background-color: black;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    position: absolute;\n    top: -10px;\n    left: -10px;\n    z-index: 3;\n    text-align: center;\n    font-family: sans-serif;\n    font-style: normal;\n    font-weight: normal;\n    text-decoration: none;\n    font-size: 15px;\n}\n.annotationRemoveButton:hover {\n    cursor: pointer;\n    box-shadow: 0px 0px 5px rgba(0, 0, 0, 1);\n}\n\n.annotationNote {\n    width: 4cm;\n    position: absolute;\n    display: inline;\n    z-index: 10;\n}\n.annotationNote > office|annotation {\n    display: block;\n    text-align: left;\n}\n\n.annotationConnector {\n    position: absolute;\n    display: inline;\n    z-index: 2;\n    border-top: 1px dashed brown;\n}\n.annotationConnector.angular {\n    -moz-transform-origin: left top;\n    -webkit-transform-origin: left top;\n    -ms-transform-origin: left top;\n    transform-origin: left top;\n}\n.annotationConnector.horizontal {\n    left: 0;\n}\n.annotationConnector.horizontal:before {\n    content: '';\n    display: inline;\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: brown transparent transparent transparent;\n    top: -1px;\n    left: -5px;\n}\n\noffice|annotation {\n    width: 100%;\n    height: 100%;\n    display: none;\n    background: rgb(198, 238, 184);\n    background: -moz-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -webkit-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -o-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -ms-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: linear-gradient(180deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    box-shadow: 0 3px 4px -3px #ccc;\n}\n\noffice|annotation > dc|creator {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    color: white;\n    background-color: brown;\n    padding: 4px;\n}\noffice|annotation > dc|date {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    border: 4px solid transparent;\n}\noffice|annotation > text|list {\n    display: block;\n    padding: 5px;\n}\n\n/* This is very temporary CSS. This must go once\n * we start bundling webodf-default ODF styles for annotations.\n */\noffice|annotation text|p {\n    font-size: 10pt;\n    color: black;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    font-family: sans-serif;\n}\n\ndc|*::selection {\n    background: transparent;\n}\ndc|*::-moz-selection {\n    background: transparent;\n}\n\n#annotationsPane {\n    background-color: #EAEAEA;\n    width: 4cm;\n    height: 100%;\n    display: none;\n    position: absolute;\n    outline: 1px solid #ccc;\n}\n\n.annotationHighlight {\n    background-color: yellow;\n    position: relative;\n}\n\n.selectionOverlay {\n    position: absolute;\n    z-index: 15;\n    opacity: 0.2;\n    pointer-events: none;\n    top: 0;\n    left: 0;\n    width: 0;\n    height: 0;\n}\n\n#imageSelector {\n    display: none;\n    position: absolute;\n    border-style: solid;\n    border-color: black;\n}\n\n#imageSelector > div {\n    width: 5px;\n    height: 5px;\n    display: block;\n    position: absolute;\n    border: 1px solid black;\n    background-color: #ffffff;\n}\n\n#imageSelector > .topLeft {\n    top: -4px;\n    left: -4px;\n}\n\n#imageSelector > .topRight {\n    top: -4px;\n    right: -4px;\n}\n\n#imageSelector > .bottomRight {\n    right: -4px;\n    bottom: -4px;\n}\n\n#imageSelector > .bottomLeft {\n    bottom: -4px;\n    left: -4px;\n}\n\n#imageSelector > .topMiddle {\n    top: -4px;\n    left: 50%;\n    margin-left: -2.5px; /* half of the width defined in #imageSelector > div */\n}\n\n#imageSelector > .rightMiddle {\n    top: 50%;\n    right: -4px;\n    margin-top: -2.5px; /* half of the height defined in #imageSelector > div */\n}\n\n#imageSelector > .bottomMiddle {\n    bottom: -4px;\n    left: 50%;\n    margin-left: -2.5px; /* half of the width defined in #imageSelector > div */\n}\n\n#imageSelector > .leftMiddle {\n    top: 50%;\n    left: -4px;\n    margin-top: -2.5px; /* half of the height defined in #imageSelector > div */\n}\n";
 

--- a/js/3rdparty/webodf/webodf.js
+++ b/js/3rdparty/webodf/webodf.js
@@ -12,6 +12,9 @@
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -32,83 +35,83 @@
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
 var core={},gui={},xmldom={},odf={},ops={};
 // Input 1
-function Runtime(){}Runtime.ByteArray=function(h){};Runtime.prototype.getVariable=function(h){};Runtime.prototype.toJson=function(h){};Runtime.prototype.fromJson=function(h){};Runtime.ByteArray.prototype.slice=function(h,m){};Runtime.ByteArray.prototype.length=0;Runtime.prototype.byteArrayFromArray=function(h){};Runtime.prototype.byteArrayFromString=function(h,m){};Runtime.prototype.byteArrayToString=function(h,m){};Runtime.prototype.concatByteArrays=function(h,m){};
-Runtime.prototype.read=function(h,m,f,a){};Runtime.prototype.readFile=function(h,m,f){};Runtime.prototype.readFileSync=function(h,m){};Runtime.prototype.loadXML=function(h,m){};Runtime.prototype.writeFile=function(h,m,f){};Runtime.prototype.isFile=function(h,m){};Runtime.prototype.getFileSize=function(h,m){};Runtime.prototype.deleteFile=function(h,m){};Runtime.prototype.log=function(h,m){};Runtime.prototype.setTimeout=function(h,m){};Runtime.prototype.clearTimeout=function(h){};
-Runtime.prototype.libraryPaths=function(){};Runtime.prototype.type=function(){};Runtime.prototype.getDOMImplementation=function(){};Runtime.prototype.parseXML=function(h){};Runtime.prototype.getWindow=function(){};Runtime.prototype.assert=function(h,m,f){};var IS_COMPILED_CODE=!0;
-Runtime.byteArrayToString=function(h,m){function f(a){var b="",k,c=a.length;for(k=0;k<c;k+=1)b+=String.fromCharCode(a[k]&255);return b}function a(a){var b="",k,c=a.length,e,s,n,g;for(k=0;k<c;k+=1)e=a[k],128>e?b+=String.fromCharCode(e):(k+=1,s=a[k],194<=e&&224>e?b+=String.fromCharCode((e&31)<<6|s&63):(k+=1,n=a[k],224<=e&&240>e?b+=String.fromCharCode((e&15)<<12|(s&63)<<6|n&63):(k+=1,g=a[k],240<=e&&245>e&&(e=(e&7)<<18|(s&63)<<12|(n&63)<<6|g&63,e-=65536,b+=String.fromCharCode((e>>10)+55296,(e&1023)+56320)))));
-return b}var c;"utf8"===m?c=a(h):("binary"!==m&&this.log("Unsupported encoding: "+m),c=f(h));return c};Runtime.getVariable=function(h){try{return eval(h)}catch(m){}};Runtime.toJson=function(h){return JSON.stringify(h)};Runtime.fromJson=function(h){return JSON.parse(h)};Runtime.getFunctionName=function(h){return void 0===h.name?(h=/function\s+(\w+)/.exec(h))&&h[1]:h.name};
-function BrowserRuntime(h){function m(b,k){var a,e,c;void 0!==k?c=b:k=b;h?(e=h.ownerDocument,c&&(a=e.createElement("span"),a.className=c,a.appendChild(e.createTextNode(c)),h.appendChild(a),h.appendChild(e.createTextNode(" "))),a=e.createElement("span"),0<k.length&&"<"===k[0]?a.innerHTML=k:a.appendChild(e.createTextNode(k)),h.appendChild(a),h.appendChild(e.createElement("br"))):console&&console.log(k);"alert"===c&&alert(k)}function f(b,k,p){function e(){var e;4===d.readyState&&(0!==d.status||d.responseText?
-200===d.status||0===d.status?(e="binary"===k?null!==d.responseBody&&"undefined"!==String(typeof VBArray)?(new VBArray(d.responseBody)).toArray():a.byteArrayFromString(d.responseText,"binary"):d.responseText,c[b]=e,p(null,e)):p(d.responseText||d.statusText):p("File "+b+" is empty."))}if(c.hasOwnProperty(b))p(null,c[b]);else{var d=new XMLHttpRequest;d.open("GET",b,!0);d.onreadystatechange=e;d.overrideMimeType&&("binary"!==k?d.overrideMimeType("text/plain; charset="+k):d.overrideMimeType("text/plain; charset=x-user-defined"));
-try{d.send(null)}catch(n){p(n.message)}}}var a=this,c={},d=window.ArrayBuffer&&window.Uint8Array;d&&(Uint8Array.prototype.slice=function(b,k){void 0===k&&(void 0===b&&(b=0),k=this.length);var a=this.subarray(b,k),e,c;k-=b;e=new Uint8Array(new ArrayBuffer(k));for(c=0;c<k;c+=1)e[c]=a[c];return e});this.ByteArray=d?function(b){return new Uint8Array(new ArrayBuffer(b))}:function(b){var k=[];k.length=b;return k};this.concatByteArrays=d?function(b,k){var a,e=b.length,c=k.length,n=new this.ByteArray(e+c);
-for(a=0;a<e;a+=1)n[a]=b[a];for(a=0;a<c;a+=1)n[a+e]=k[a];return n}:function(b,k){return b.concat(k)};this.byteArrayFromArray=function(b){return b.slice()};this.byteArrayFromString=function(b,k){var c;if("utf8"===k){c=b.length;var e,d,n,g=0;for(d=0;d<c;d+=1)n=b.charCodeAt(d),g+=1+(128<n)+(2048<n);e=new a.ByteArray(g);for(d=g=0;d<c;d+=1)n=b.charCodeAt(d),128>n?(e[g]=n,g+=1):2048>n?(e[g]=192|n>>>6,e[g+1]=128|n&63,g+=2):(e[g]=224|n>>>12&15,e[g+1]=128|n>>>6&63,e[g+2]=128|n&63,g+=3)}else for("binary"!==
-k&&a.log("unknown encoding: "+k),c=b.length,e=new a.ByteArray(c),d=0;d<c;d+=1)e[d]=b.charCodeAt(d)&255;return c=e};this.byteArrayToString=Runtime.byteArrayToString;this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.readFile=f;this.read=function(b,k,d,e){function f(){var g;4===n.readyState&&(0!==n.status||n.responseText?200===n.status||0===n.status?(n.response?(g=n.response,g=new Uint8Array(g)):g=null!==n.responseBody&&"undefined"!==String(typeof VBArray)?
-(new VBArray(n.responseBody)).toArray():a.byteArrayFromString(n.responseText,"binary"),c[b]=g,e(null,g.slice(k,k+d))):e(n.responseText||n.statusText):e("File "+b+" is empty."))}if(c.hasOwnProperty(b))e(null,c[b].slice(k,k+d));else{var n=new XMLHttpRequest;n.open("GET",b,!0);n.onreadystatechange=f;n.overrideMimeType&&n.overrideMimeType("text/plain; charset=x-user-defined");n.responseType="arraybuffer";try{n.send(null)}catch(g){e(g.message)}}};this.readFileSync=function(b,k){var a=new XMLHttpRequest,
-e;a.open("GET",b,!1);a.overrideMimeType&&("binary"!==k?a.overrideMimeType("text/plain; charset="+k):a.overrideMimeType("text/plain; charset=x-user-defined"));try{if(a.send(null),200===a.status||0===a.status)e=a.responseText}catch(c){}return e};this.writeFile=function(b,k,d){c[b]=k;var e=new XMLHttpRequest;e.open("PUT",b,!0);e.onreadystatechange=function(){4===e.readyState&&(0!==e.status||e.responseText?200<=e.status&&300>e.status||0===e.status?d(null):d("Status "+String(e.status)+": "+e.responseText||
-e.statusText):d("File "+b+" is empty."))};k=k.buffer&&!e.sendAsBinary?k.buffer:a.byteArrayToString(k,"binary");try{e.sendAsBinary?e.sendAsBinary(k):e.send(k)}catch(f){a.log("HUH? "+f+" "+k),d(f.message)}};this.deleteFile=function(b,k){delete c[b];var a=new XMLHttpRequest;a.open("DELETE",b,!0);a.onreadystatechange=function(){4===a.readyState&&(200>a.status&&300<=a.status?k(a.responseText):k(null))};a.send(null)};this.loadXML=function(b,k){var a=new XMLHttpRequest;a.open("GET",b,!0);a.overrideMimeType&&
-a.overrideMimeType("text/xml");a.onreadystatechange=function(){4===a.readyState&&(0!==a.status||a.responseText?200===a.status||0===a.status?k(null,a.responseXML):k(a.responseText):k("File "+b+" is empty."))};try{a.send(null)}catch(e){k(e.message)}};this.isFile=function(b,k){a.getFileSize(b,function(b){k(-1!==b)})};this.getFileSize=function(b,a){var c=new XMLHttpRequest;c.open("HEAD",b,!0);c.onreadystatechange=function(){if(4===c.readyState){var e=c.getResponseHeader("Content-Length");e?a(parseInt(e,
-10)):f(b,"binary",function(e,b){e?a(-1):a(b.length)})}};c.send(null)};this.log=m;this.assert=function(b,a,c){if(!b)throw m("alert","ASSERTION FAILED:\n"+a),c&&c(),a;};this.setTimeout=function(b,a){return setTimeout(function(){b()},a)};this.clearTimeout=function(a){clearTimeout(a)};this.libraryPaths=function(){return["lib"]};this.setCurrentDirectory=function(){};this.type=function(){return"BrowserRuntime"};this.getDOMImplementation=function(){return window.document.implementation};this.parseXML=function(a){return(new DOMParser).parseFromString(a,
-"text/xml")};this.exit=function(a){m("Calling exit with code "+String(a)+", but exit() is not implemented.")};this.getWindow=function(){return window}}
-function NodeJSRuntime(){function h(b,d,e){b=a.resolve(c,b);"binary"!==d?f.readFile(b,d,e):f.readFile(b,null,e)}var m=this,f=require("fs"),a=require("path"),c="",d,b;this.ByteArray=function(a){return new Buffer(a)};this.byteArrayFromArray=function(a){var b=new Buffer(a.length),e,c=a.length;for(e=0;e<c;e+=1)b[e]=a[e];return b};this.concatByteArrays=function(a,b){var e=new Buffer(a.length+b.length);a.copy(e,0,0);b.copy(e,a.length,0);return e};this.byteArrayFromString=function(a,b){return new Buffer(a,
-b)};this.byteArrayToString=function(a,b){return a.toString(b)};this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.readFile=h;this.loadXML=function(a,b){h(a,"utf-8",function(e,a){if(e)return b(e);b(null,m.parseXML(a))})};this.writeFile=function(b,d,e){b=a.resolve(c,b);f.writeFile(b,d,"binary",function(a){e(a||null)})};this.deleteFile=function(b,d){b=a.resolve(c,b);f.unlink(b,d)};this.read=function(b,d,e,h){b=a.resolve(c,b);f.open(b,"r+",666,function(a,
-b){if(a)h(a);else{var c=new Buffer(e);f.read(b,c,0,e,d,function(e){f.close(b);h(e,c)})}})};this.readFileSync=function(a,b){return b?"binary"===b?f.readFileSync(a,null):f.readFileSync(a,b):""};this.isFile=function(b,d){b=a.resolve(c,b);f.stat(b,function(e,b){d(!e&&b.isFile())})};this.getFileSize=function(b,d){b=a.resolve(c,b);f.stat(b,function(e,b){e?d(-1):d(b.size)})};this.log=function(b,a){var e;void 0!==a?e=b:a=b;"alert"===e&&process.stderr.write("\n!!!!! ALERT !!!!!\n");process.stderr.write(a+
-"\n");"alert"===e&&process.stderr.write("!!!!! ALERT !!!!!\n")};this.assert=function(b,a,e){b||(process.stderr.write("ASSERTION FAILED: "+a),e&&e())};this.setTimeout=function(b,a){return setTimeout(function(){b()},a)};this.clearTimeout=function(b){clearTimeout(b)};this.libraryPaths=function(){return[__dirname]};this.setCurrentDirectory=function(b){c=b};this.currentDirectory=function(){return c};this.type=function(){return"NodeJSRuntime"};this.getDOMImplementation=function(){return b};this.parseXML=
-function(b){return d.parseFromString(b,"text/xml")};this.exit=process.exit;this.getWindow=function(){return null};d=new (require("xmldom").DOMParser);b=m.parseXML("<a/>").implementation}
-function RhinoRuntime(){function h(b,a){var c;void 0!==a?c=b:a=b;"alert"===c&&print("\n!!!!! ALERT !!!!!");print(a);"alert"===c&&print("!!!!! ALERT !!!!!")}var m=this,f=Packages.javax.xml.parsers.DocumentBuilderFactory.newInstance(),a,c,d="";f.setValidating(!1);f.setNamespaceAware(!0);f.setExpandEntityReferences(!1);f.setSchema(null);c=Packages.org.xml.sax.EntityResolver({resolveEntity:function(b,a){var c=new Packages.java.io.FileReader(a);return new Packages.org.xml.sax.InputSource(c)}});a=f.newDocumentBuilder();
-a.setEntityResolver(c);this.ByteArray=function(b){return[b]};this.byteArrayFromArray=function(b){return b};this.byteArrayFromString=function(b,a){var c=[],e,d=b.length;for(e=0;e<d;e+=1)c[e]=b.charCodeAt(e)&255;return c};this.byteArrayToString=Runtime.byteArrayToString;this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.concatByteArrays=function(b,a){return b.concat(a)};this.loadXML=function(b,c){var d=new Packages.java.io.File(b),e;try{e=a.parse(d)}catch(f){print(f);
-c(f);return}c(null,e)};this.readFile=function(b,a,c){d&&(b=d+"/"+b);var e=new Packages.java.io.File(b),f="binary"===a?"latin1":a;e.isFile()?(b=readFile(b,f),"binary"===a&&(b=m.byteArrayFromString(b,"binary")),c(null,b)):c(b+" is not a file.")};this.writeFile=function(b,a,c){d&&(b=d+"/"+b);b=new Packages.java.io.FileOutputStream(b);var e,f=a.length;for(e=0;e<f;e+=1)b.write(a[e]);b.close();c(null)};this.deleteFile=function(a,c){d&&(a=d+"/"+a);(new Packages.java.io.File(a))["delete"]()?c(null):c("Could not delete "+
-a)};this.read=function(a,c,f,e){d&&(a=d+"/"+a);var h;h=a;var n="binary";(new Packages.java.io.File(h)).isFile()?("binary"===n&&(n="latin1"),h=readFile(h,n)):h=null;h?e(null,this.byteArrayFromString(h.substring(c,c+f),"binary")):e("Cannot read "+a)};this.readFileSync=function(a,c){return c?readFile(a,c):""};this.isFile=function(a,c){d&&(a=d+"/"+a);var f=new Packages.java.io.File(a);c(f.isFile())};this.getFileSize=function(a,c){d&&(a=d+"/"+a);var f=new Packages.java.io.File(a);c(f.length())};this.log=
-h;this.assert=function(a,c,d){a||(h("alert","ASSERTION FAILED: "+c),d&&d())};this.setTimeout=function(a){a();return 0};this.clearTimeout=function(){};this.libraryPaths=function(){return["lib"]};this.setCurrentDirectory=function(a){d=a};this.currentDirectory=function(){return d};this.type=function(){return"RhinoRuntime"};this.getDOMImplementation=function(){return a.getDOMImplementation()};this.parseXML=function(b){return a.parse(b)};this.exit=quit;this.getWindow=function(){return null}}
+function Runtime(){}Runtime.ByteArray=function(e){};Runtime.prototype.getVariable=function(e){};Runtime.prototype.toJson=function(e){};Runtime.prototype.fromJson=function(e){};Runtime.ByteArray.prototype.slice=function(e,h){};Runtime.ByteArray.prototype.length=0;Runtime.prototype.byteArrayFromArray=function(e){};Runtime.prototype.byteArrayFromString=function(e,h){};Runtime.prototype.byteArrayToString=function(e,h){};Runtime.prototype.concatByteArrays=function(e,h){};
+Runtime.prototype.read=function(e,h,f,n){};Runtime.prototype.readFile=function(e,h,f){};Runtime.prototype.readFileSync=function(e,h){};Runtime.prototype.loadXML=function(e,h){};Runtime.prototype.writeFile=function(e,h,f){};Runtime.prototype.isFile=function(e,h){};Runtime.prototype.getFileSize=function(e,h){};Runtime.prototype.deleteFile=function(e,h){};Runtime.prototype.log=function(e,h){};Runtime.prototype.setTimeout=function(e,h){};Runtime.prototype.clearTimeout=function(e){};
+Runtime.prototype.libraryPaths=function(){};Runtime.prototype.type=function(){};Runtime.prototype.getDOMImplementation=function(){};Runtime.prototype.parseXML=function(e){};Runtime.prototype.getWindow=function(){};Runtime.prototype.assert=function(e,h,f){};var IS_COMPILED_CODE=!0;
+Runtime.byteArrayToString=function(e,h){function f(f){var c="",b,a=f.length;for(b=0;b<a;b+=1)c+=String.fromCharCode(f[b]&255);return c}function n(f){var c="",b,a=f.length,d,k,g,q;for(b=0;b<a;b+=1)d=f[b],128>d?c+=String.fromCharCode(d):(b+=1,k=f[b],194<=d&&224>d?c+=String.fromCharCode((d&31)<<6|k&63):(b+=1,g=f[b],224<=d&&240>d?c+=String.fromCharCode((d&15)<<12|(k&63)<<6|g&63):(b+=1,q=f[b],240<=d&&245>d&&(d=(d&7)<<18|(k&63)<<12|(g&63)<<6|q&63,d-=65536,c+=String.fromCharCode((d>>10)+55296,(d&1023)+56320)))));
+return c}var m;"utf8"===h?m=n(e):("binary"!==h&&this.log("Unsupported encoding: "+h),m=f(e));return m};Runtime.getVariable=function(e){try{return eval(e)}catch(h){}};Runtime.toJson=function(e){return JSON.stringify(e)};Runtime.fromJson=function(e){return JSON.parse(e)};Runtime.getFunctionName=function(e){return void 0===e.name?(e=/function\s+(\w+)/.exec(e))&&e[1]:e.name};
+function BrowserRuntime(e){function h(c,b){var a,d,k;void 0!==b?k=c:b=c;e?(d=e.ownerDocument,k&&(a=d.createElement("span"),a.className=k,a.appendChild(d.createTextNode(k)),e.appendChild(a),e.appendChild(d.createTextNode(" "))),a=d.createElement("span"),0<b.length&&"<"===b[0]?a.innerHTML=b:a.appendChild(d.createTextNode(b)),e.appendChild(a),e.appendChild(d.createElement("br"))):console&&console.log(b);"alert"===k&&alert(b)}function f(c,b,a){function d(){var d;4===k.readyState&&(0!==k.status||k.responseText?
+200===k.status||0===k.status?(d="binary"===b?null!==k.responseBody&&"undefined"!==String(typeof VBArray)?(new VBArray(k.responseBody)).toArray():n.byteArrayFromString(k.responseText,"binary"):k.responseText,m[c]=d,a(null,d)):a(k.responseText||k.statusText):a("File "+c+" is empty."))}if(m.hasOwnProperty(c))a(null,m[c]);else{var k=new XMLHttpRequest;k.open("GET",c,!0);k.onreadystatechange=d;k.overrideMimeType&&("binary"!==b?k.overrideMimeType("text/plain; charset="+b):k.overrideMimeType("text/plain; charset=x-user-defined"));
+try{k.send(null)}catch(g){a(g.message)}}}var n=this,m={},p=window.ArrayBuffer&&window.Uint8Array;p&&(Uint8Array.prototype.slice=function(c,b){void 0===b&&(void 0===c&&(c=0),b=this.length);var a=this.subarray(c,b),d,k;b-=c;d=new Uint8Array(new ArrayBuffer(b));for(k=0;k<b;k+=1)d[k]=a[k];return d});this.ByteArray=p?function(c){return new Uint8Array(new ArrayBuffer(c))}:function(c){var b=[];b.length=c;return b};this.concatByteArrays=p?function(c,b){var a,d=c.length,k=b.length,g=new this.ByteArray(d+k);
+for(a=0;a<d;a+=1)g[a]=c[a];for(a=0;a<k;a+=1)g[a+d]=b[a];return g}:function(c,b){return c.concat(b)};this.byteArrayFromArray=function(c){return c.slice()};this.byteArrayFromString=function(c,b){var a;if("utf8"===b){a=c.length;var d,k,g,q=0;for(k=0;k<a;k+=1)g=c.charCodeAt(k),q+=1+(128<g)+(2048<g);d=new n.ByteArray(q);for(k=q=0;k<a;k+=1)g=c.charCodeAt(k),128>g?(d[q]=g,q+=1):2048>g?(d[q]=192|g>>>6,d[q+1]=128|g&63,q+=2):(d[q]=224|g>>>12&15,d[q+1]=128|g>>>6&63,d[q+2]=128|g&63,q+=3)}else for("binary"!==
+b&&n.log("unknown encoding: "+b),a=c.length,d=new n.ByteArray(a),k=0;k<a;k+=1)d[k]=c.charCodeAt(k)&255;return a=d};this.byteArrayToString=Runtime.byteArrayToString;this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.readFile=f;this.read=function(c,b,a,d){function k(){var k;4===g.readyState&&(0!==g.status||g.responseText?200===g.status||0===g.status?(g.response?(k=g.response,k=new Uint8Array(k)):k=null!==g.responseBody&&"undefined"!==String(typeof VBArray)?
+(new VBArray(g.responseBody)).toArray():n.byteArrayFromString(g.responseText,"binary"),m[c]=k,d(null,k.slice(b,b+a))):d(g.responseText||g.statusText):d("File "+c+" is empty."))}if(m.hasOwnProperty(c))d(null,m[c].slice(b,b+a));else{var g=new XMLHttpRequest;g.open("GET",c,!0);g.onreadystatechange=k;g.overrideMimeType&&g.overrideMimeType("text/plain; charset=x-user-defined");g.responseType="arraybuffer";try{g.send(null)}catch(q){d(q.message)}}};this.readFileSync=function(c,b){var a=new XMLHttpRequest,
+d;a.open("GET",c,!1);a.overrideMimeType&&("binary"!==b?a.overrideMimeType("text/plain; charset="+b):a.overrideMimeType("text/plain; charset=x-user-defined"));try{if(a.send(null),200===a.status||0===a.status)d=a.responseText}catch(k){}return d};this.writeFile=function(c,b,a){m[c]=b;var d=new XMLHttpRequest;d.open("PUT",c,!0);d.onreadystatechange=function(){4===d.readyState&&(0!==d.status||d.responseText?200<=d.status&&300>d.status||0===d.status?a(null):a("Status "+String(d.status)+": "+d.responseText||
+d.statusText):a("File "+c+" is empty."))};b=b.buffer&&!d.sendAsBinary?b.buffer:n.byteArrayToString(b,"binary");try{d.sendAsBinary?d.sendAsBinary(b):d.send(b)}catch(k){n.log("HUH? "+k+" "+b),a(k.message)}};this.deleteFile=function(c,b){delete m[c];var a=new XMLHttpRequest;a.open("DELETE",c,!0);a.onreadystatechange=function(){4===a.readyState&&(200>a.status&&300<=a.status?b(a.responseText):b(null))};a.send(null)};this.loadXML=function(c,b){var a=new XMLHttpRequest;a.open("GET",c,!0);a.overrideMimeType&&
+a.overrideMimeType("text/xml");a.onreadystatechange=function(){4===a.readyState&&(0!==a.status||a.responseText?200===a.status||0===a.status?b(null,a.responseXML):b(a.responseText):b("File "+c+" is empty."))};try{a.send(null)}catch(d){b(d.message)}};this.isFile=function(c,b){n.getFileSize(c,function(a){b(-1!==a)})};this.getFileSize=function(c,b){var a=new XMLHttpRequest;a.open("HEAD",c,!0);a.onreadystatechange=function(){if(4===a.readyState){var d=a.getResponseHeader("Content-Length");d?b(parseInt(d,
+10)):f(c,"binary",function(a,d){a?b(-1):b(d.length)})}};a.send(null)};this.log=h;this.assert=function(c,b,a){if(!c)throw h("alert","ASSERTION FAILED:\n"+b),a&&a(),b;};this.setTimeout=function(c,b){return setTimeout(function(){c()},b)};this.clearTimeout=function(c){clearTimeout(c)};this.libraryPaths=function(){return["lib"]};this.setCurrentDirectory=function(){};this.type=function(){return"BrowserRuntime"};this.getDOMImplementation=function(){return window.document.implementation};this.parseXML=function(c){return(new DOMParser).parseFromString(c,
+"text/xml")};this.exit=function(c){h("Calling exit with code "+String(c)+", but exit() is not implemented.")};this.getWindow=function(){return window}}
+function NodeJSRuntime(){function e(b,a,d){b=n.resolve(m,b);"binary"!==a?f.readFile(b,a,d):f.readFile(b,null,d)}var h=this,f=require("fs"),n=require("path"),m="",p,c;this.ByteArray=function(b){return new Buffer(b)};this.byteArrayFromArray=function(b){var a=new Buffer(b.length),d,c=b.length;for(d=0;d<c;d+=1)a[d]=b[d];return a};this.concatByteArrays=function(b,a){var d=new Buffer(b.length+a.length);b.copy(d,0,0);a.copy(d,b.length,0);return d};this.byteArrayFromString=function(b,a){return new Buffer(b,
+a)};this.byteArrayToString=function(b,a){return b.toString(a)};this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.readFile=e;this.loadXML=function(b,a){e(b,"utf-8",function(d,b){if(d)return a(d);a(null,h.parseXML(b))})};this.writeFile=function(b,a,d){b=n.resolve(m,b);f.writeFile(b,a,"binary",function(a){d(a||null)})};this.deleteFile=function(b,a){b=n.resolve(m,b);f.unlink(b,a)};this.read=function(b,a,d,c){b=n.resolve(m,b);f.open(b,"r+",666,function(g,
+b){if(g)c(g);else{var l=new Buffer(d);f.read(b,l,0,d,a,function(a){f.close(b);c(a,l)})}})};this.readFileSync=function(b,a){return a?"binary"===a?f.readFileSync(b,null):f.readFileSync(b,a):""};this.isFile=function(b,a){b=n.resolve(m,b);f.stat(b,function(d,b){a(!d&&b.isFile())})};this.getFileSize=function(b,a){b=n.resolve(m,b);f.stat(b,function(d,b){d?a(-1):a(b.size)})};this.log=function(b,a){var d;void 0!==a?d=b:a=b;"alert"===d&&process.stderr.write("\n!!!!! ALERT !!!!!\n");process.stderr.write(a+
+"\n");"alert"===d&&process.stderr.write("!!!!! ALERT !!!!!\n")};this.assert=function(b,a,d){b||(process.stderr.write("ASSERTION FAILED: "+a),d&&d())};this.setTimeout=function(b,a){return setTimeout(function(){b()},a)};this.clearTimeout=function(b){clearTimeout(b)};this.libraryPaths=function(){return[__dirname]};this.setCurrentDirectory=function(b){m=b};this.currentDirectory=function(){return m};this.type=function(){return"NodeJSRuntime"};this.getDOMImplementation=function(){return c};this.parseXML=
+function(b){return p.parseFromString(b,"text/xml")};this.exit=process.exit;this.getWindow=function(){return null};p=new (require("xmldom").DOMParser);c=h.parseXML("<a/>").implementation}
+function RhinoRuntime(){function e(c,b){var a;void 0!==b?a=c:b=c;"alert"===a&&print("\n!!!!! ALERT !!!!!");print(b);"alert"===a&&print("!!!!! ALERT !!!!!")}var h=this,f=Packages.javax.xml.parsers.DocumentBuilderFactory.newInstance(),n,m,p="";f.setValidating(!1);f.setNamespaceAware(!0);f.setExpandEntityReferences(!1);f.setSchema(null);m=Packages.org.xml.sax.EntityResolver({resolveEntity:function(c,b){var a=new Packages.java.io.FileReader(b);return new Packages.org.xml.sax.InputSource(a)}});n=f.newDocumentBuilder();
+n.setEntityResolver(m);this.ByteArray=function(c){return[c]};this.byteArrayFromArray=function(c){return c};this.byteArrayFromString=function(c,b){var a=[],d,k=c.length;for(d=0;d<k;d+=1)a[d]=c.charCodeAt(d)&255;return a};this.byteArrayToString=Runtime.byteArrayToString;this.getVariable=Runtime.getVariable;this.fromJson=Runtime.fromJson;this.toJson=Runtime.toJson;this.concatByteArrays=function(c,b){return c.concat(b)};this.loadXML=function(c,b){var a=new Packages.java.io.File(c),d;try{d=n.parse(a)}catch(k){print(k);
+b(k);return}b(null,d)};this.readFile=function(c,b,a){p&&(c=p+"/"+c);var d=new Packages.java.io.File(c),k="binary"===b?"latin1":b;d.isFile()?(c=readFile(c,k),"binary"===b&&(c=h.byteArrayFromString(c,"binary")),a(null,c)):a(c+" is not a file.")};this.writeFile=function(c,b,a){p&&(c=p+"/"+c);c=new Packages.java.io.FileOutputStream(c);var d,k=b.length;for(d=0;d<k;d+=1)c.write(b[d]);c.close();a(null)};this.deleteFile=function(c,b){p&&(c=p+"/"+c);(new Packages.java.io.File(c))["delete"]()?b(null):b("Could not delete "+
+c)};this.read=function(c,b,a,d){p&&(c=p+"/"+c);var k;k=c;var g="binary";(new Packages.java.io.File(k)).isFile()?("binary"===g&&(g="latin1"),k=readFile(k,g)):k=null;k?d(null,this.byteArrayFromString(k.substring(b,b+a),"binary")):d("Cannot read "+c)};this.readFileSync=function(c,b){return b?readFile(c,b):""};this.isFile=function(c,b){p&&(c=p+"/"+c);var a=new Packages.java.io.File(c);b(a.isFile())};this.getFileSize=function(c,b){p&&(c=p+"/"+c);var a=new Packages.java.io.File(c);b(a.length())};this.log=
+e;this.assert=function(c,b,a){c||(e("alert","ASSERTION FAILED: "+b),a&&a())};this.setTimeout=function(c){c();return 0};this.clearTimeout=function(){};this.libraryPaths=function(){return["lib"]};this.setCurrentDirectory=function(c){p=c};this.currentDirectory=function(){return p};this.type=function(){return"RhinoRuntime"};this.getDOMImplementation=function(){return n.getDOMImplementation()};this.parseXML=function(c){return n.parse(c)};this.exit=quit;this.getWindow=function(){return null}}
 var runtime=function(){return"undefined"!==String(typeof window)?new BrowserRuntime(window.document.getElementById("logoutput")):"undefined"!==String(typeof require)?new NodeJSRuntime:new RhinoRuntime}();
-(function(){function h(a){var c=a[0],d;d=eval("if (typeof "+c+" === 'undefined') {eval('"+c+" = {};');}"+c);for(c=1;c<a.length-1;c+=1)d=d.hasOwnProperty(a[c])?d[a[c]]:d[a[c]]={};return d[a[a.length-1]]}var m={},f={};runtime.loadClass=function(a){function c(a){a=a.replace(/\./g,"/")+".js";var e=runtime.libraryPaths(),b,c,g;runtime.currentDirectory&&e.push(runtime.currentDirectory());for(b=0;b<e.length;b+=1){c=e[b];if(!f.hasOwnProperty(c))try{g=runtime.readFileSync(e[b]+"/manifest.js","utf8"),f[c]=
-g&&g.length?eval(g):null}catch(l){f[c]=null,runtime.log("Cannot load manifest for "+c+".")}g=null;if((c=f[c])&&c.indexOf&&-1!==c.indexOf(a))return e[b]+"/"+a}return null}function d(a){var e,b;b=c(a);if(!b)throw a+" is not listed in any manifest.js.";try{e=runtime.readFileSync(b,"utf8")}catch(n){throw runtime.log("Error loading "+a+" "+n),n;}if(void 0===e)throw"Cannot load class "+a;e=e+("\n//# sourceURL="+b)+("\n//@ sourceURL="+b);try{e=eval(a+" = eval(code);")}catch(g){throw runtime.log("Error loading "+
-a+" "+g),g;}return e}if(!IS_COMPILED_CODE&&!m.hasOwnProperty(a)){var b=a.split("."),k;k=h(b);if(!k&&(k=d(a),!k||Runtime.getFunctionName(k)!==b[b.length-1]))throw runtime.log("Loaded code is not for "+b[b.length-1]),"Loaded code is not for "+b[b.length-1];m[a]=!0}}})();
-(function(h){function m(f){if(f.length){var a=f[0];runtime.readFile(a,"utf8",function(c,d){function b(){var a;(a=eval(h))&&runtime.exit(a)}var k="",h=d;-1!==a.indexOf("/")&&(k=a.substring(0,a.indexOf("/")));runtime.setCurrentDirectory(k);c||null===h?(runtime.log(c),runtime.exit(1)):b.apply(null,f)})}}h=h?Array.prototype.slice.call(h):[];"NodeJSRuntime"===runtime.type()?m(process.argv.slice(2)):"RhinoRuntime"===runtime.type()?m(h):m(h.slice(1))})("undefined"!==String(typeof arguments)&&arguments);
+(function(){function e(f){var e=f[0],h;h=eval("if (typeof "+e+" === 'undefined') {eval('"+e+" = {};');}"+e);for(e=1;e<f.length-1;e+=1)h=h.hasOwnProperty(f[e])?h[f[e]]:h[f[e]]={};return h[f[f.length-1]]}var h={},f={};runtime.loadClass=function(n){function m(a){a=a.replace(/\./g,"/")+".js";var d=runtime.libraryPaths(),b,g,c;runtime.currentDirectory&&d.push(runtime.currentDirectory());for(b=0;b<d.length;b+=1){g=d[b];if(!f.hasOwnProperty(g))try{c=runtime.readFileSync(d[b]+"/manifest.js","utf8"),f[g]=
+c&&c.length?eval(c):null}catch(l){f[g]=null,runtime.log("Cannot load manifest for "+g+".")}c=null;if((g=f[g])&&g.indexOf&&-1!==g.indexOf(a))return d[b]+"/"+a}return null}function p(a){var d,b;b=m(a);if(!b)throw a+" is not listed in any manifest.js.";try{d=runtime.readFileSync(b,"utf8")}catch(g){throw runtime.log("Error loading "+a+" "+g),g;}if(void 0===d)throw"Cannot load class "+a;d=d+("\n//# sourceURL="+b)+("\n//@ sourceURL="+b);try{d=eval(a+" = eval(code);")}catch(c){throw runtime.log("Error loading "+
+a+" "+c),c;}return d}if(!IS_COMPILED_CODE&&!h.hasOwnProperty(n)){var c=n.split("."),b;b=e(c);if(!b&&(b=p(n),!b||Runtime.getFunctionName(b)!==c[c.length-1]))throw runtime.log("Loaded code is not for "+c[c.length-1]),"Loaded code is not for "+c[c.length-1];h[n]=!0}}})();(function(){var e=function(){};runtime.getTranslator=function(){return e};runtime.setTranslator=function(h){e=h};runtime.tr=function(h){var f=e(h);return f&&"string"===String(typeof f)?f:h}})();
+(function(e){function h(f){if(f.length){var e=f[0];runtime.readFile(e,"utf8",function(h,p){function c(){var d;(d=eval(a))&&runtime.exit(d)}var b="",a=p;-1!==e.indexOf("/")&&(b=e.substring(0,e.indexOf("/")));runtime.setCurrentDirectory(b);h||null===a?(runtime.log(h),runtime.exit(1)):c.apply(null,f)})}}e=e?Array.prototype.slice.call(e):[];"NodeJSRuntime"===runtime.type()?h(process.argv.slice(2)):"RhinoRuntime"===runtime.type()?h(e):h(e.slice(1))})("undefined"!==String(typeof arguments)&&arguments);
 // Input 2
-core.Base64=function(){function h(a){var e=[],b,c=a.length;for(b=0;b<c;b+=1)e[b]=a.charCodeAt(b)&255;return e}function m(a){var e,b="",c,g=a.length-2;for(c=0;c<g;c+=3)e=a[c]<<16|a[c+1]<<8|a[c+2],b+=u[e>>>18],b+=u[e>>>12&63],b+=u[e>>>6&63],b+=u[e&63];c===g+1?(e=a[c]<<4,b+=u[e>>>6],b+=u[e&63],b+="=="):c===g&&(e=a[c]<<10|a[c+1]<<2,b+=u[e>>>12],b+=u[e>>>6&63],b+=u[e&63],b+="=");return b}function f(a){a=a.replace(/[^A-Za-z0-9+\/]+/g,"");var b=[],e=a.length%4,c,g=a.length,n;for(c=0;c<g;c+=4)n=(q[a.charAt(c)]||
-0)<<18|(q[a.charAt(c+1)]||0)<<12|(q[a.charAt(c+2)]||0)<<6|(q[a.charAt(c+3)]||0),b.push(n>>16,n>>8&255,n&255);b.length-=[0,0,2,1][e];return b}function a(a){var b=[],e,c=a.length,g;for(e=0;e<c;e+=1)g=a[e],128>g?b.push(g):2048>g?b.push(192|g>>>6,128|g&63):b.push(224|g>>>12&15,128|g>>>6&63,128|g&63);return b}function c(a){var b=[],e,c=a.length,g,n,l;for(e=0;e<c;e+=1)g=a[e],128>g?b.push(g):(e+=1,n=a[e],224>g?b.push((g&31)<<6|n&63):(e+=1,l=a[e],b.push((g&15)<<12|(n&63)<<6|l&63)));return b}function d(a){return m(h(a))}
-function b(a){return String.fromCharCode.apply(String,f(a))}function k(a){return c(h(a))}function p(a){a=c(a);for(var b="",e=0;e<a.length;)b+=String.fromCharCode.apply(String,a.slice(e,e+45E3)),e+=45E3;return b}function e(a,b,e){var c="",g,n,l;for(l=b;l<e;l+=1)b=a.charCodeAt(l)&255,128>b?c+=String.fromCharCode(b):(l+=1,g=a.charCodeAt(l)&255,224>b?c+=String.fromCharCode((b&31)<<6|g&63):(l+=1,n=a.charCodeAt(l)&255,c+=String.fromCharCode((b&15)<<12|(g&63)<<6|n&63)));return c}function s(a,b){function c(){var d=
-l+g;d>a.length&&(d=a.length);n+=e(a,l,d);l=d;d=l===a.length;b(n,d)&&!d&&runtime.setTimeout(c,0)}var g=1E5,n="",l=0;a.length<g?b(e(a,0,a.length),!0):("string"!==typeof a&&(a=a.slice()),c())}function n(b){return a(h(b))}function g(b){return String.fromCharCode.apply(String,a(b))}function l(b){return String.fromCharCode.apply(String,a(h(b)))}var u="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",q=function(a){var b={},e,c;e=0;for(c=a.length;e<c;e+=1)b[a.charAt(e)]=e;return b}(u),x,
-r,y=runtime.getWindow(),t,w;y&&y.btoa?(t=function(a){return y.btoa(a)},x=function(a){return t(l(a))}):(t=d,x=function(a){return m(n(a))});y&&y.atob?(w=function(a){return y.atob(a)},r=function(a){a=w(a);return e(a,0,a.length)}):(w=b,r=function(a){return p(f(a))});return function(){this.convertByteArrayToBase64=this.convertUTF8ArrayToBase64=m;this.convertBase64ToByteArray=this.convertBase64ToUTF8Array=f;this.convertUTF16ArrayToByteArray=this.convertUTF16ArrayToUTF8Array=a;this.convertByteArrayToUTF16Array=
-this.convertUTF8ArrayToUTF16Array=c;this.convertUTF8StringToBase64=d;this.convertBase64ToUTF8String=b;this.convertUTF8StringToUTF16Array=k;this.convertByteArrayToUTF16String=this.convertUTF8ArrayToUTF16String=p;this.convertUTF8StringToUTF16String=s;this.convertUTF16StringToByteArray=this.convertUTF16StringToUTF8Array=n;this.convertUTF16ArrayToUTF8String=g;this.convertUTF16StringToUTF8String=l;this.convertUTF16StringToBase64=x;this.convertBase64ToUTF16String=r;this.fromBase64=b;this.toBase64=d;this.atob=
-w;this.btoa=t;this.utob=l;this.btou=s;this.encode=x;this.encodeURI=function(a){return x(a).replace(/[+\/]/g,function(a){return"+"===a?"-":"_"}).replace(/\\=+$/,"")};this.decode=function(a){return r(a.replace(/[\-_]/g,function(a){return"-"===a?"+":"/"}))}}}();
+core.Base64=function(){function e(a){var d=[],b,g=a.length;for(b=0;b<g;b+=1)d[b]=a.charCodeAt(b)&255;return d}function h(a){var d,b="",g,c=a.length-2;for(g=0;g<c;g+=3)d=a[g]<<16|a[g+1]<<8|a[g+2],b+=r[d>>>18],b+=r[d>>>12&63],b+=r[d>>>6&63],b+=r[d&63];g===c+1?(d=a[g]<<4,b+=r[d>>>6],b+=r[d&63],b+="=="):g===c&&(d=a[g]<<10|a[g+1]<<2,b+=r[d>>>12],b+=r[d>>>6&63],b+=r[d&63],b+="=");return b}function f(a){a=a.replace(/[^A-Za-z0-9+\/]+/g,"");var d=[],b=a.length%4,g,c=a.length,k;for(g=0;g<c;g+=4)k=(t[a.charAt(g)]||
+0)<<18|(t[a.charAt(g+1)]||0)<<12|(t[a.charAt(g+2)]||0)<<6|(t[a.charAt(g+3)]||0),d.push(k>>16,k>>8&255,k&255);d.length-=[0,0,2,1][b];return d}function n(a){var d=[],b,g=a.length,c;for(b=0;b<g;b+=1)c=a[b],128>c?d.push(c):2048>c?d.push(192|c>>>6,128|c&63):d.push(224|c>>>12&15,128|c>>>6&63,128|c&63);return d}function m(a){var d=[],b,g=a.length,c,k,l;for(b=0;b<g;b+=1)c=a[b],128>c?d.push(c):(b+=1,k=a[b],224>c?d.push((c&31)<<6|k&63):(b+=1,l=a[b],d.push((c&15)<<12|(k&63)<<6|l&63)));return d}function p(a){return h(e(a))}
+function c(a){return String.fromCharCode.apply(String,f(a))}function b(a){return m(e(a))}function a(a){a=m(a);for(var d="",b=0;b<a.length;)d+=String.fromCharCode.apply(String,a.slice(b,b+45E3)),b+=45E3;return d}function d(a,d,b){var g="",c,k,l;for(l=d;l<b;l+=1)d=a.charCodeAt(l)&255,128>d?g+=String.fromCharCode(d):(l+=1,c=a.charCodeAt(l)&255,224>d?g+=String.fromCharCode((d&31)<<6|c&63):(l+=1,k=a.charCodeAt(l)&255,g+=String.fromCharCode((d&15)<<12|(c&63)<<6|k&63)));return g}function k(a,b){function g(){var q=
+k+c;q>a.length&&(q=a.length);l+=d(a,k,q);k=q;q=k===a.length;b(l,q)&&!q&&runtime.setTimeout(g,0)}var c=1E5,l="",k=0;a.length<c?b(d(a,0,a.length),!0):("string"!==typeof a&&(a=a.slice()),g())}function g(a){return n(e(a))}function q(a){return String.fromCharCode.apply(String,n(a))}function l(a){return String.fromCharCode.apply(String,n(e(a)))}var r="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",t=function(a){var d={},b,g;b=0;for(g=a.length;b<g;b+=1)d[a.charAt(b)]=b;return d}(r),w,
+v,y=runtime.getWindow(),x,u;y&&y.btoa?(x=function(a){return y.btoa(a)},w=function(a){return x(l(a))}):(x=p,w=function(a){return h(g(a))});y&&y.atob?(u=function(a){return y.atob(a)},v=function(a){a=u(a);return d(a,0,a.length)}):(u=c,v=function(d){return a(f(d))});return function(){this.convertByteArrayToBase64=this.convertUTF8ArrayToBase64=h;this.convertBase64ToByteArray=this.convertBase64ToUTF8Array=f;this.convertUTF16ArrayToByteArray=this.convertUTF16ArrayToUTF8Array=n;this.convertByteArrayToUTF16Array=
+this.convertUTF8ArrayToUTF16Array=m;this.convertUTF8StringToBase64=p;this.convertBase64ToUTF8String=c;this.convertUTF8StringToUTF16Array=b;this.convertByteArrayToUTF16String=this.convertUTF8ArrayToUTF16String=a;this.convertUTF8StringToUTF16String=k;this.convertUTF16StringToByteArray=this.convertUTF16StringToUTF8Array=g;this.convertUTF16ArrayToUTF8String=q;this.convertUTF16StringToUTF8String=l;this.convertUTF16StringToBase64=w;this.convertBase64ToUTF16String=v;this.fromBase64=c;this.toBase64=p;this.atob=
+u;this.btoa=x;this.utob=l;this.btou=k;this.encode=w;this.encodeURI=function(a){return w(a).replace(/[+\/]/g,function(a){return"+"===a?"-":"_"}).replace(/\\=+$/,"")};this.decode=function(a){return v(a.replace(/[\-_]/g,function(a){return"-"===a?"+":"/"}))}}}();
 // Input 3
-core.RawDeflate=function(){function h(){this.dl=this.fc=0}function m(){this.extra_bits=this.static_tree=this.dyn_tree=null;this.max_code=this.max_length=this.elems=this.extra_base=0}function f(a,b,e,c){this.good_length=a;this.max_lazy=b;this.nice_length=e;this.max_chain=c}function a(){this.next=null;this.len=0;this.ptr=[];this.ptr.length=c;this.off=0}var c=8192,d,b,k,p,e=null,s,n,g,l,u,q,x,r,y,t,w,v,C,J,E,K,B,N,H,L,fa,ma,M,pa,W,aa,O,R,F,G,D,T,X,Q,P,$,ca,U,V,z,ga,da,I,ia,A,na,ja,ea,oa,Y,ka,ha=[0,0,
-0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0],ba=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],La=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7],S=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],sa;sa=[new f(0,0,0,0),new f(4,4,8,4),new f(4,5,16,8),new f(4,6,32,32),new f(4,4,16,16),new f(8,16,32,32),new f(8,16,128,128),new f(8,32,128,256),new f(32,128,258,1024),new f(32,258,258,4096)];var ta=function(g){e[n+s++]=g;if(n+s===c){var l;if(0!==s){null!==d?(g=d,d=d.next):g=new a;
-g.next=null;g.len=g.off=0;null===b?b=k=g:k=k.next=g;g.len=s-n;for(l=0;l<g.len;l++)g.ptr[l]=e[n+l];s=n=0}}},Z=function(a){a&=65535;n+s<c-2?(e[n+s++]=a&255,e[n+s++]=a>>>8):(ta(a&255),ta(a>>>8))},ua=function(){w=(w<<5^l[B+3-1]&255)&8191;v=x[32768+w];x[B&32767]=v;x[32768+w]=B},la=function(a,b){y>16-b?(r|=a<<y,Z(r),r=a>>16-y,y+=b-16):(r|=a<<y,y+=b)},qa=function(a,b){la(b[a].fc,b[a].dl)},za=function(a,b,e){return a[b].fc<a[e].fc||a[b].fc===a[e].fc&&ca[b]<=ca[e]},Aa=function(a,b,e){var c;for(c=0;c<e&&ka<
-Y.length;c++)a[b+c]=Y.charCodeAt(ka++)&255;return c},wa=function(){var a,b,e=65536-L-B;if(-1===e)e--;else if(65274<=B){for(a=0;32768>a;a++)l[a]=l[a+32768];N-=32768;B-=32768;t-=32768;for(a=0;8192>a;a++)b=x[32768+a],x[32768+a]=32768<=b?b-32768:0;for(a=0;32768>a;a++)b=x[a],x[a]=32768<=b?b-32768:0;e+=32768}H||(a=Aa(l,B+L,e),0>=a?H=!0:L+=a)},Ba=function(a){var b=fa,e=B,c,g=K,n=32506<B?B-32506:0,d=B+258,k=l[e+g-1],v=l[e+g];K>=pa&&(b>>=2);do if(c=a,l[c+g]===v&&l[c+g-1]===k&&l[c]===l[e]&&l[++c]===l[e+1]){e+=
-2;c++;do++e;while(l[e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&l[++e]===l[++c]&&e<d);c=258-(d-e);e=d-258;if(c>g){N=a;g=c;if(258<=c)break;k=l[e+g-1];v=l[e+g]}a=x[a&32767]}while(a>n&&0!==--b);return g},ra=function(a,b){q[I++]=b;0===a?W[b].fc++:(a--,W[U[b]+256+1].fc++,aa[(256>a?V[a]:V[256+(a>>7)])&255].fc++,u[ia++]=a,na|=ja);ja<<=1;0===(I&7)&&(da[A++]=na,na=0,ja=1);if(2<M&&0===(I&4095)){var e=8*I,c=B-t,g;for(g=0;30>g;g++)e+=aa[g].fc*
-(5+ba[g]);e>>=3;if(ia<parseInt(I/2,10)&&e<parseInt(c/2,10))return!0}return 8191===I||8192===ia},xa=function(a,b){for(var e=Q[b],c=b<<1;c<=P;){c<P&&za(a,Q[c+1],Q[c])&&c++;if(za(a,e,Q[c]))break;Q[b]=Q[c];b=c;c<<=1}Q[b]=e},Ca=function(a,b){var e=0;do e|=a&1,a>>=1,e<<=1;while(0<--b);return e>>1},Da=function(a,b){var e=[];e.length=16;var c=0,g;for(g=1;15>=g;g++)c=c+X[g-1]<<1,e[g]=c;for(c=0;c<=b;c++)g=a[c].dl,0!==g&&(a[c].fc=Ca(e[g]++,g))},ya=function(a){var b=a.dyn_tree,e=a.static_tree,c=a.elems,g,n=-1,
-l=c;P=0;$=573;for(g=0;g<c;g++)0!==b[g].fc?(Q[++P]=n=g,ca[g]=0):b[g].dl=0;for(;2>P;)g=Q[++P]=2>n?++n:0,b[g].fc=1,ca[g]=0,ea--,null!==e&&(oa-=e[g].dl);a.max_code=n;for(g=P>>1;1<=g;g--)xa(b,g);do g=Q[1],Q[1]=Q[P--],xa(b,1),e=Q[1],Q[--$]=g,Q[--$]=e,b[l].fc=b[g].fc+b[e].fc,ca[l]=ca[g]>ca[e]+1?ca[g]:ca[e]+1,b[g].dl=b[e].dl=l,Q[1]=l++,xa(b,1);while(2<=P);Q[--$]=Q[1];l=a.dyn_tree;g=a.extra_bits;var c=a.extra_base,e=a.max_code,d=a.max_length,k=a.static_tree,v,f,q,h,m=0;for(f=0;15>=f;f++)X[f]=0;l[Q[$]].dl=
-0;for(a=$+1;573>a;a++)v=Q[a],f=l[l[v].dl].dl+1,f>d&&(f=d,m++),l[v].dl=f,v>e||(X[f]++,q=0,v>=c&&(q=g[v-c]),h=l[v].fc,ea+=h*(f+q),null!==k&&(oa+=h*(k[v].dl+q)));if(0!==m){do{for(f=d-1;0===X[f];)f--;X[f]--;X[f+1]+=2;X[d]--;m-=2}while(0<m);for(f=d;0!==f;f--)for(v=X[f];0!==v;)g=Q[--a],g>e||(l[g].dl!==f&&(ea+=(f-l[g].dl)*l[g].fc,l[g].fc=f),v--)}Da(b,n)},Ea=function(a,b){var e,c=-1,g,n=a[0].dl,l=0,d=7,k=4;0===n&&(d=138,k=3);a[b+1].dl=65535;for(e=0;e<=b;e++)g=n,n=a[e+1].dl,++l<d&&g===n||(l<k?F[g].fc+=l:0!==
-g?(g!==c&&F[g].fc++,F[16].fc++):10>=l?F[17].fc++:F[18].fc++,l=0,c=g,0===n?(d=138,k=3):g===n?(d=6,k=3):(d=7,k=4))},Fa=function(){8<y?Z(r):0<y&&ta(r);y=r=0},Ga=function(a,e){var b,c=0,g=0,n=0,l=0,d,k;if(0!==I){do 0===(c&7)&&(l=da[n++]),b=q[c++]&255,0===(l&1)?qa(b,a):(d=U[b],qa(d+256+1,a),k=ha[d],0!==k&&(b-=z[d],la(b,k)),b=u[g++],d=(256>b?V[b]:V[256+(b>>7)])&255,qa(d,e),k=ba[d],0!==k&&(b-=ga[d],la(b,k))),l>>=1;while(c<I)}qa(256,a)},Ha=function(a,b){var e,c=-1,g,n=a[0].dl,l=0,d=7,k=4;0===n&&(d=138,k=
-3);for(e=0;e<=b;e++)if(g=n,n=a[e+1].dl,!(++l<d&&g===n)){if(l<k){do qa(g,F);while(0!==--l)}else 0!==g?(g!==c&&(qa(g,F),l--),qa(16,F),la(l-3,2)):10>=l?(qa(17,F),la(l-3,3)):(qa(18,F),la(l-11,7));l=0;c=g;0===n?(d=138,k=3):g===n?(d=6,k=3):(d=7,k=4)}},Ia=function(){var a;for(a=0;286>a;a++)W[a].fc=0;for(a=0;30>a;a++)aa[a].fc=0;for(a=0;19>a;a++)F[a].fc=0;W[256].fc=1;na=I=ia=A=ea=oa=0;ja=1},va=function(a){var b,e,c,g;g=B-t;da[A]=na;ya(G);ya(D);Ea(W,G.max_code);Ea(aa,D.max_code);ya(T);for(c=18;3<=c&&0===F[S[c]].dl;c--);
-ea+=3*(c+1)+14;b=ea+3+7>>3;e=oa+3+7>>3;e<=b&&(b=e);if(g+4<=b&&0<=t)for(la(0+a,3),Fa(),Z(g),Z(~g),c=0;c<g;c++)ta(l[t+c]);else if(e===b)la(2+a,3),Ga(O,R);else{la(4+a,3);g=G.max_code+1;b=D.max_code+1;c+=1;la(g-257,5);la(b-1,5);la(c-4,4);for(e=0;e<c;e++)la(F[S[e]].dl,3);Ha(W,g-1);Ha(aa,b-1);Ga(W,aa)}Ia();0!==a&&Fa()},Ja=function(a,c,g){var l,k,v;for(l=0;null!==b&&l<g;){k=g-l;k>b.len&&(k=b.len);for(v=0;v<k;v++)a[c+l+v]=b.ptr[b.off+v];b.off+=k;b.len-=k;l+=k;0===b.len&&(k=b,b=b.next,k.next=d,d=k)}if(l===
-g)return l;if(n<s){k=g-l;k>s-n&&(k=s-n);for(v=0;v<k;v++)a[c+l+v]=e[n+v];n+=k;l+=k;s===n&&(s=n=0)}return l},Ka=function(a,e,c){var d;if(!p){if(!H){y=r=0;var k,f;if(0===R[0].dl){G.dyn_tree=W;G.static_tree=O;G.extra_bits=ha;G.extra_base=257;G.elems=286;G.max_length=15;G.max_code=0;D.dyn_tree=aa;D.static_tree=R;D.extra_bits=ba;D.extra_base=0;D.elems=30;D.max_length=15;D.max_code=0;T.dyn_tree=F;T.static_tree=null;T.extra_bits=La;T.extra_base=0;T.elems=19;T.max_length=7;for(f=k=T.max_code=0;28>f;f++)for(z[f]=
-k,d=0;d<1<<ha[f];d++)U[k++]=f;U[k-1]=f;for(f=k=0;16>f;f++)for(ga[f]=k,d=0;d<1<<ba[f];d++)V[k++]=f;for(k>>=7;30>f;f++)for(ga[f]=k<<7,d=0;d<1<<ba[f]-7;d++)V[256+k++]=f;for(d=0;15>=d;d++)X[d]=0;for(d=0;143>=d;)O[d++].dl=8,X[8]++;for(;255>=d;)O[d++].dl=9,X[9]++;for(;279>=d;)O[d++].dl=7,X[7]++;for(;287>=d;)O[d++].dl=8,X[8]++;Da(O,287);for(d=0;30>d;d++)R[d].dl=5,R[d].fc=Ca(d,5);Ia()}for(d=0;8192>d;d++)x[32768+d]=0;ma=sa[M].max_lazy;pa=sa[M].good_length;fa=sa[M].max_chain;t=B=0;L=Aa(l,0,65536);if(0>=L)H=
-!0,L=0;else{for(H=!1;262>L&&!H;)wa();for(d=w=0;2>d;d++)w=(w<<5^l[d]&255)&8191}b=null;n=s=0;3>=M?(K=2,E=0):(E=2,J=0);g=!1}p=!0;if(0===L)return g=!0,0}d=Ja(a,e,c);if(d===c)return c;if(g)return d;if(3>=M)for(;0!==L&&null===b;){ua();0!==v&&32506>=B-v&&(E=Ba(v),E>L&&(E=L));if(3<=E)if(f=ra(B-N,E-3),L-=E,E<=ma){E--;do B++,ua();while(0!==--E);B++}else B+=E,E=0,w=l[B]&255,w=(w<<5^l[B+1]&255)&8191;else f=ra(0,l[B]&255),L--,B++;f&&(va(0),t=B);for(;262>L&&!H;)wa()}else for(;0!==L&&null===b;){ua();K=E;C=N;E=2;
-0!==v&&(K<ma&&32506>=B-v)&&(E=Ba(v),E>L&&(E=L),3===E&&4096<B-N&&E--);if(3<=K&&E<=K){f=ra(B-1-C,K-3);L-=K-1;K-=2;do B++,ua();while(0!==--K);J=0;E=2;B++;f&&(va(0),t=B)}else 0!==J?ra(0,l[B-1]&255)&&(va(0),t=B):J=1,B++,L--;for(;262>L&&!H;)wa()}0===L&&(0!==J&&ra(0,l[B-1]&255),va(1),g=!0);return d+Ja(a,d+e,c-d)};this.deflate=function(a,g){var n,v;Y=a;ka=0;"undefined"===String(typeof g)&&(g=6);(n=g)?1>n?n=1:9<n&&(n=9):n=6;M=n;H=p=!1;if(null===e){d=b=k=null;e=[];e.length=c;l=[];l.length=65536;u=[];u.length=
-8192;q=[];q.length=32832;x=[];x.length=65536;W=[];W.length=573;for(n=0;573>n;n++)W[n]=new h;aa=[];aa.length=61;for(n=0;61>n;n++)aa[n]=new h;O=[];O.length=288;for(n=0;288>n;n++)O[n]=new h;R=[];R.length=30;for(n=0;30>n;n++)R[n]=new h;F=[];F.length=39;for(n=0;39>n;n++)F[n]=new h;G=new m;D=new m;T=new m;X=[];X.length=16;Q=[];Q.length=573;ca=[];ca.length=573;U=[];U.length=256;V=[];V.length=512;z=[];z.length=29;ga=[];ga.length=30;da=[];da.length=1024}var f=Array(1024),t=[],r=[];for(n=Ka(f,0,f.length);0<
-n;){r.length=n;for(v=0;v<n;v++)r[v]=String.fromCharCode(f[v]);t[t.length]=r.join("");n=Ka(f,0,f.length)}Y=null;return t.join("")}};
+core.RawDeflate=function(){function e(){this.dl=this.fc=0}function h(){this.extra_bits=this.static_tree=this.dyn_tree=null;this.max_code=this.max_length=this.elems=this.extra_base=0}function f(a,d,b,g){this.good_length=a;this.max_lazy=d;this.nice_length=b;this.max_chain=g}function n(){this.next=null;this.len=0;this.ptr=[];this.ptr.length=m;this.off=0}var m=8192,p,c,b,a,d=null,k,g,q,l,r,t,w,v,y,x,u,s,C,B,A,I,z,N,G,R,Z,ka,T,ra,$,ha,U,O,W,E,H,M,S,P,aa,na,da,V,Q,J,ea,oa,D,fa,F,ia,Y,ba,la,L,sa,pa=[0,0,
+0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0],ma=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],ya=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7],za=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],ta;ta=[new f(0,0,0,0),new f(4,4,8,4),new f(4,5,16,8),new f(4,6,32,32),new f(4,4,16,16),new f(8,16,32,32),new f(8,16,128,128),new f(8,32,128,256),new f(32,128,258,1024),new f(32,258,258,4096)];var xa=function(a){d[g+k++]=a;if(g+k===m){var l;if(0!==k){null!==p?(a=p,p=p.next):a=new n;
+a.next=null;a.len=a.off=0;null===c?c=b=a:b=b.next=a;a.len=k-g;for(l=0;l<a.len;l++)a.ptr[l]=d[g+l];k=g=0}}},ca=function(a){a&=65535;g+k<m-2?(d[g+k++]=a&255,d[g+k++]=a>>>8):(xa(a&255),xa(a>>>8))},X=function(){u=(u<<5^l[z+3-1]&255)&8191;s=w[32768+u];w[z&32767]=s;w[32768+u]=z},ga=function(a,d){y>16-d?(v|=a<<y,ca(v),v=a>>16-y,y+=d-16):(v|=a<<y,y+=d)},K=function(a,d){ga(d[a].fc,d[a].dl)},ja=function(a,d,b){return a[d].fc<a[b].fc||a[d].fc===a[b].fc&&da[d]<=da[b]},qa=function(a,d,b){var g;for(g=0;g<b&&sa<
+L.length;g++)a[d+g]=L.charCodeAt(sa++)&255;return g},Aa=function(){var a,d,b=65536-R-z;if(-1===b)b--;else if(65274<=z){for(a=0;32768>a;a++)l[a]=l[a+32768];N-=32768;z-=32768;x-=32768;for(a=0;8192>a;a++)d=w[32768+a],w[32768+a]=32768<=d?d-32768:0;for(a=0;32768>a;a++)d=w[a],w[a]=32768<=d?d-32768:0;b+=32768}G||(a=qa(l,z+R,b),0>=a?G=!0:R+=a)},va=function(a){var d=Z,b=z,g,c=I,k=32506<z?z-32506:0,q=z+258,f=l[b+c-1],e=l[b+c];I>=ra&&(d>>=2);do if(g=a,l[g+c]===e&&l[g+c-1]===f&&l[g]===l[b]&&l[++g]===l[b+1]){b+=
+2;g++;do++b;while(l[b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&l[++b]===l[++g]&&b<q);g=258-(q-b);b=q-258;if(g>c){N=a;c=g;if(258<=g)break;f=l[b+c-1];e=l[b+c]}a=w[a&32767]}while(a>k&&0!==--d);return c},wa=function(a,d){t[D++]=d;0===a?$[d].fc++:(a--,$[V[d]+256+1].fc++,ha[(256>a?Q[a]:Q[256+(a>>7)])&255].fc++,r[fa++]=a,ia|=Y);Y<<=1;0===(D&7)&&(oa[F++]=ia,ia=0,Y=1);if(2<T&&0===(D&4095)){var b=8*D,g=z-x,c;for(c=0;30>c;c++)b+=ha[c].fc*
+(5+ma[c]);b>>=3;if(fa<parseInt(D/2,10)&&b<parseInt(g/2,10))return!0}return 8191===D||8192===fa},ua=function(a,d){for(var b=P[d],g=d<<1;g<=aa;){g<aa&&ja(a,P[g+1],P[g])&&g++;if(ja(a,b,P[g]))break;P[d]=P[g];d=g;g<<=1}P[d]=b},Da=function(a,d){var b=0;do b|=a&1,a>>=1,b<<=1;while(0<--d);return b>>1},Ea=function(a,d){var b=[];b.length=16;var g=0,c;for(c=1;15>=c;c++)g=g+S[c-1]<<1,b[c]=g;for(g=0;g<=d;g++)c=a[g].dl,0!==c&&(a[g].fc=Da(b[c]++,c))},Ca=function(a){var d=a.dyn_tree,b=a.static_tree,g=a.elems,c,l=
+-1,k=g;aa=0;na=573;for(c=0;c<g;c++)0!==d[c].fc?(P[++aa]=l=c,da[c]=0):d[c].dl=0;for(;2>aa;)c=P[++aa]=2>l?++l:0,d[c].fc=1,da[c]=0,ba--,null!==b&&(la-=b[c].dl);a.max_code=l;for(c=aa>>1;1<=c;c--)ua(d,c);do c=P[1],P[1]=P[aa--],ua(d,1),b=P[1],P[--na]=c,P[--na]=b,d[k].fc=d[c].fc+d[b].fc,da[k]=da[c]>da[b]+1?da[c]:da[b]+1,d[c].dl=d[b].dl=k,P[1]=k++,ua(d,1);while(2<=aa);P[--na]=P[1];k=a.dyn_tree;c=a.extra_bits;var g=a.extra_base,b=a.max_code,q=a.max_length,f=a.static_tree,e,r,A,h,s=0;for(r=0;15>=r;r++)S[r]=
+0;k[P[na]].dl=0;for(a=na+1;573>a;a++)e=P[a],r=k[k[e].dl].dl+1,r>q&&(r=q,s++),k[e].dl=r,e>b||(S[r]++,A=0,e>=g&&(A=c[e-g]),h=k[e].fc,ba+=h*(r+A),null!==f&&(la+=h*(f[e].dl+A)));if(0!==s){do{for(r=q-1;0===S[r];)r--;S[r]--;S[r+1]+=2;S[q]--;s-=2}while(0<s);for(r=q;0!==r;r--)for(e=S[r];0!==e;)c=P[--a],c>b||(k[c].dl!==r&&(ba+=(r-k[c].dl)*k[c].fc,k[c].fc=r),e--)}Ea(d,l)},Fa=function(a,d){var b,g=-1,c,k=a[0].dl,l=0,q=7,e=4;0===k&&(q=138,e=3);a[d+1].dl=65535;for(b=0;b<=d;b++)c=k,k=a[b+1].dl,++l<q&&c===k||(l<
+e?W[c].fc+=l:0!==c?(c!==g&&W[c].fc++,W[16].fc++):10>=l?W[17].fc++:W[18].fc++,l=0,g=c,0===k?(q=138,e=3):c===k?(q=6,e=3):(q=7,e=4))},Ga=function(){8<y?ca(v):0<y&&xa(v);y=v=0},Ha=function(a,d){var b,g=0,c=0,k=0,l=0,q,e;if(0!==D){do 0===(g&7)&&(l=oa[k++]),b=t[g++]&255,0===(l&1)?K(b,a):(q=V[b],K(q+256+1,a),e=pa[q],0!==e&&(b-=J[q],ga(b,e)),b=r[c++],q=(256>b?Q[b]:Q[256+(b>>7)])&255,K(q,d),e=ma[q],0!==e&&(b-=ea[q],ga(b,e))),l>>=1;while(g<D)}K(256,a)},Ia=function(a,d){var b,g=-1,c,k=a[0].dl,l=0,q=7,e=4;0===
+k&&(q=138,e=3);for(b=0;b<=d;b++)if(c=k,k=a[b+1].dl,!(++l<q&&c===k)){if(l<e){do K(c,W);while(0!==--l)}else 0!==c?(c!==g&&(K(c,W),l--),K(16,W),ga(l-3,2)):10>=l?(K(17,W),ga(l-3,3)):(K(18,W),ga(l-11,7));l=0;g=c;0===k?(q=138,e=3):c===k?(q=6,e=3):(q=7,e=4)}},Ja=function(){var a;for(a=0;286>a;a++)$[a].fc=0;for(a=0;30>a;a++)ha[a].fc=0;for(a=0;19>a;a++)W[a].fc=0;$[256].fc=1;ia=D=fa=F=ba=la=0;Y=1},Ba=function(a){var d,b,g,c;c=z-x;oa[F]=ia;Ca(E);Ca(H);Fa($,E.max_code);Fa(ha,H.max_code);Ca(M);for(g=18;3<=g&&
+0===W[za[g]].dl;g--);ba+=3*(g+1)+14;d=ba+3+7>>3;b=la+3+7>>3;b<=d&&(d=b);if(c+4<=d&&0<=x)for(ga(0+a,3),Ga(),ca(c),ca(~c),g=0;g<c;g++)xa(l[x+g]);else if(b===d)ga(2+a,3),Ha(U,O);else{ga(4+a,3);c=E.max_code+1;d=H.max_code+1;g+=1;ga(c-257,5);ga(d-1,5);ga(g-4,4);for(b=0;b<g;b++)ga(W[za[b]].dl,3);Ia($,c-1);Ia(ha,d-1);Ha($,ha)}Ja();0!==a&&Ga()},Ka=function(a,b,l){var q,e,f;for(q=0;null!==c&&q<l;){e=l-q;e>c.len&&(e=c.len);for(f=0;f<e;f++)a[b+q+f]=c.ptr[c.off+f];c.off+=e;c.len-=e;q+=e;0===c.len&&(e=c,c=c.next,
+e.next=p,p=e)}if(q===l)return q;if(g<k){e=l-q;e>k-g&&(e=k-g);for(f=0;f<e;f++)a[b+q+f]=d[g+f];g+=e;q+=e;k===g&&(k=g=0)}return q},La=function(d,b,e){var f;if(!a){if(!G){y=v=0;var r,h;if(0===O[0].dl){E.dyn_tree=$;E.static_tree=U;E.extra_bits=pa;E.extra_base=257;E.elems=286;E.max_length=15;E.max_code=0;H.dyn_tree=ha;H.static_tree=O;H.extra_bits=ma;H.extra_base=0;H.elems=30;H.max_length=15;H.max_code=0;M.dyn_tree=W;M.static_tree=null;M.extra_bits=ya;M.extra_base=0;M.elems=19;M.max_length=7;for(h=r=M.max_code=
+0;28>h;h++)for(J[h]=r,f=0;f<1<<pa[h];f++)V[r++]=h;V[r-1]=h;for(h=r=0;16>h;h++)for(ea[h]=r,f=0;f<1<<ma[h];f++)Q[r++]=h;for(r>>=7;30>h;h++)for(ea[h]=r<<7,f=0;f<1<<ma[h]-7;f++)Q[256+r++]=h;for(f=0;15>=f;f++)S[f]=0;for(f=0;143>=f;)U[f++].dl=8,S[8]++;for(;255>=f;)U[f++].dl=9,S[9]++;for(;279>=f;)U[f++].dl=7,S[7]++;for(;287>=f;)U[f++].dl=8,S[8]++;Ea(U,287);for(f=0;30>f;f++)O[f].dl=5,O[f].fc=Da(f,5);Ja()}for(f=0;8192>f;f++)w[32768+f]=0;ka=ta[T].max_lazy;ra=ta[T].good_length;Z=ta[T].max_chain;x=z=0;R=qa(l,
+0,65536);if(0>=R)G=!0,R=0;else{for(G=!1;262>R&&!G;)Aa();for(f=u=0;2>f;f++)u=(u<<5^l[f]&255)&8191}c=null;g=k=0;3>=T?(I=2,A=0):(A=2,B=0);q=!1}a=!0;if(0===R)return q=!0,0}f=Ka(d,b,e);if(f===e)return e;if(q)return f;if(3>=T)for(;0!==R&&null===c;){X();0!==s&&32506>=z-s&&(A=va(s),A>R&&(A=R));if(3<=A)if(h=wa(z-N,A-3),R-=A,A<=ka){A--;do z++,X();while(0!==--A);z++}else z+=A,A=0,u=l[z]&255,u=(u<<5^l[z+1]&255)&8191;else h=wa(0,l[z]&255),R--,z++;h&&(Ba(0),x=z);for(;262>R&&!G;)Aa()}else for(;0!==R&&null===c;){X();
+I=A;C=N;A=2;0!==s&&I<ka&&32506>=z-s&&(A=va(s),A>R&&(A=R),3===A&&4096<z-N&&A--);if(3<=I&&A<=I){h=wa(z-1-C,I-3);R-=I-1;I-=2;do z++,X();while(0!==--I);B=0;A=2;z++;h&&(Ba(0),x=z)}else 0!==B?wa(0,l[z-1]&255)&&(Ba(0),x=z):B=1,z++,R--;for(;262>R&&!G;)Aa()}0===R&&(0!==B&&wa(0,l[z-1]&255),Ba(1),q=!0);return f+Ka(d,f+b,e-f)};this.deflate=function(g,k){var q,f;L=g;sa=0;"undefined"===String(typeof k)&&(k=6);(q=k)?1>q?q=1:9<q&&(q=9):q=6;T=q;G=a=!1;if(null===d){p=c=b=null;d=[];d.length=m;l=[];l.length=65536;r=
+[];r.length=8192;t=[];t.length=32832;w=[];w.length=65536;$=[];$.length=573;for(q=0;573>q;q++)$[q]=new e;ha=[];ha.length=61;for(q=0;61>q;q++)ha[q]=new e;U=[];U.length=288;for(q=0;288>q;q++)U[q]=new e;O=[];O.length=30;for(q=0;30>q;q++)O[q]=new e;W=[];W.length=39;for(q=0;39>q;q++)W[q]=new e;E=new h;H=new h;M=new h;S=[];S.length=16;P=[];P.length=573;da=[];da.length=573;V=[];V.length=256;Q=[];Q.length=512;J=[];J.length=29;ea=[];ea.length=30;oa=[];oa.length=1024}var A=Array(1024),s=[],n=[];for(q=La(A,0,
+A.length);0<q;){n.length=q;for(f=0;f<q;f++)n[f]=String.fromCharCode(A[f]);s[s.length]=n.join("");q=La(A,0,A.length)}L=null;return s.join("")}};
 // Input 4
-core.ByteArray=function(h){this.pos=0;this.data=h;this.readUInt32LE=function(){this.pos+=4;var h=this.data,f=this.pos;return h[--f]<<24|h[--f]<<16|h[--f]<<8|h[--f]};this.readUInt16LE=function(){this.pos+=2;var h=this.data,f=this.pos;return h[--f]<<8|h[--f]}};
+core.ByteArray=function(e){this.pos=0;this.data=e;this.readUInt32LE=function(){this.pos+=4;var e=this.data,f=this.pos;return e[--f]<<24|e[--f]<<16|e[--f]<<8|e[--f]};this.readUInt16LE=function(){this.pos+=2;var e=this.data,f=this.pos;return e[--f]<<8|e[--f]}};
 // Input 5
-core.ByteArrayWriter=function(h){var m=this,f=new runtime.ByteArray(0);this.appendByteArrayWriter=function(a){f=runtime.concatByteArrays(f,a.getByteArray())};this.appendByteArray=function(a){f=runtime.concatByteArrays(f,a)};this.appendArray=function(a){f=runtime.concatByteArrays(f,runtime.byteArrayFromArray(a))};this.appendUInt16LE=function(a){m.appendArray([a&255,a>>8&255])};this.appendUInt32LE=function(a){m.appendArray([a&255,a>>8&255,a>>16&255,a>>24&255])};this.appendString=function(a){f=runtime.concatByteArrays(f,
-runtime.byteArrayFromString(a,h))};this.getLength=function(){return f.length};this.getByteArray=function(){return f}};
+core.ByteArrayWriter=function(e){var h=this,f=new runtime.ByteArray(0);this.appendByteArrayWriter=function(e){f=runtime.concatByteArrays(f,e.getByteArray())};this.appendByteArray=function(e){f=runtime.concatByteArrays(f,e)};this.appendArray=function(e){f=runtime.concatByteArrays(f,runtime.byteArrayFromArray(e))};this.appendUInt16LE=function(f){h.appendArray([f&255,f>>8&255])};this.appendUInt32LE=function(f){h.appendArray([f&255,f>>8&255,f>>16&255,f>>24&255])};this.appendString=function(h){f=runtime.concatByteArrays(f,
+runtime.byteArrayFromString(h,e))};this.getLength=function(){return f.length};this.getByteArray=function(){return f}};
 // Input 6
-core.RawInflate=function(){var h,m,f=null,a,c,d,b,k,p,e,s,n,g,l,u,q,x,r=[0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535],y=[3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0],t=[0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99],w=[1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577],v=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],C=[16,17,18,
-0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],J=function(){this.list=this.next=null},E=function(){this.n=this.b=this.e=0;this.t=null},K=function(a,b,e,c,g,n){this.BMAX=16;this.N_MAX=288;this.status=0;this.root=null;this.m=0;var d=Array(this.BMAX+1),l,k,v,f,h,q,m,t=Array(this.BMAX+1),x,p,u,r=new E,s=Array(this.BMAX);f=Array(this.N_MAX);var y,w=Array(this.BMAX+1),B,C,K;K=this.root=null;for(h=0;h<d.length;h++)d[h]=0;for(h=0;h<t.length;h++)t[h]=0;for(h=0;h<s.length;h++)s[h]=null;for(h=0;h<f.length;h++)f[h]=
-0;for(h=0;h<w.length;h++)w[h]=0;l=256<b?a[256]:this.BMAX;x=a;p=0;h=b;do d[x[p]]++,p++;while(0<--h);if(d[0]==b)this.root=null,this.status=this.m=0;else{for(q=1;q<=this.BMAX&&0==d[q];q++);m=q;n<q&&(n=q);for(h=this.BMAX;0!=h&&0==d[h];h--);v=h;n>h&&(n=h);for(B=1<<q;q<h;q++,B<<=1)if(0>(B-=d[q])){this.status=2;this.m=n;return}if(0>(B-=d[h]))this.status=2,this.m=n;else{d[h]+=B;w[1]=q=0;x=d;p=1;for(u=2;0<--h;)w[u++]=q+=x[p++];x=a;h=p=0;do 0!=(q=x[p++])&&(f[w[q]++]=h);while(++h<b);b=w[v];w[0]=h=0;x=f;p=0;
-f=-1;y=t[0]=0;u=null;for(C=0;m<=v;m++)for(a=d[m];0<a--;){for(;m>y+t[1+f];){y+=t[1+f];f++;C=(C=v-y)>n?n:C;if((k=1<<(q=m-y))>a+1)for(k-=a+1,u=m;++q<C&&!((k<<=1)<=d[++u]);)k-=d[u];y+q>l&&y<l&&(q=l-y);C=1<<q;t[1+f]=q;u=Array(C);for(k=0;k<C;k++)u[k]=new E;K=null==K?this.root=new J:K.next=new J;K.next=null;K.list=u;s[f]=u;0<f&&(w[f]=h,r.b=t[f],r.e=16+q,r.t=u,q=(h&(1<<y)-1)>>y-t[f],s[f-1][q].e=r.e,s[f-1][q].b=r.b,s[f-1][q].n=r.n,s[f-1][q].t=r.t)}r.b=m-y;p>=b?r.e=99:x[p]<e?(r.e=256>x[p]?16:15,r.n=x[p++]):
-(r.e=g[x[p]-e],r.n=c[x[p++]-e]);k=1<<m-y;for(q=h>>y;q<C;q+=k)u[q].e=r.e,u[q].b=r.b,u[q].n=r.n,u[q].t=r.t;for(q=1<<m-1;0!=(h&q);q>>=1)h^=q;for(h^=q;(h&(1<<y)-1)!=w[f];)y-=t[f],f--}this.m=t[1];this.status=0!=B&&1!=v?1:0}}},B=function(a){for(;b<a;){var e=d,c;c=q.length==x?-1:q[x++];d=e|c<<b;b+=8}},N=function(a){return d&r[a]},H=function(a){d>>=a;b-=a},L=function(a,b,c){var d,v,f;if(0==c)return 0;for(f=0;;){B(l);v=n.list[N(l)];for(d=v.e;16<d;){if(99==d)return-1;H(v.b);d-=16;B(d);v=v.t[N(d)];d=v.e}H(v.b);
-if(16==d)m&=32767,a[b+f++]=h[m++]=v.n;else{if(15==d)break;B(d);e=v.n+N(d);H(d);B(u);v=g.list[N(u)];for(d=v.e;16<d;){if(99==d)return-1;H(v.b);d-=16;B(d);v=v.t[N(d)];d=v.e}H(v.b);B(d);s=m-v.n-N(d);for(H(d);0<e&&f<c;)e--,s&=32767,m&=32767,a[b+f++]=h[m++]=h[s++]}if(f==c)return c}k=-1;return f},fa,ma=function(a,b,e){var c,d,k,f,h,q,m,p=Array(316);for(c=0;c<p.length;c++)p[c]=0;B(5);q=257+N(5);H(5);B(5);m=1+N(5);H(5);B(4);c=4+N(4);H(4);if(286<q||30<m)return-1;for(d=0;d<c;d++)B(3),p[C[d]]=N(3),H(3);for(;19>
-d;d++)p[C[d]]=0;l=7;d=new K(p,19,19,null,null,l);if(0!=d.status)return-1;n=d.root;l=d.m;f=q+m;for(c=k=0;c<f;)if(B(l),h=n.list[N(l)],d=h.b,H(d),d=h.n,16>d)p[c++]=k=d;else if(16==d){B(2);d=3+N(2);H(2);if(c+d>f)return-1;for(;0<d--;)p[c++]=k}else{17==d?(B(3),d=3+N(3),H(3)):(B(7),d=11+N(7),H(7));if(c+d>f)return-1;for(;0<d--;)p[c++]=0;k=0}l=9;d=new K(p,q,257,y,t,l);0==l&&(d.status=1);if(0!=d.status)return-1;n=d.root;l=d.m;for(c=0;c<m;c++)p[c]=p[c+q];u=6;d=new K(p,m,0,w,v,u);g=d.root;u=d.m;return 0==u&&
-257<q||0!=d.status?-1:L(a,b,e)};this.inflate=function(r,C){null==h&&(h=Array(65536));b=d=m=0;k=-1;p=!1;e=s=0;n=null;q=r;x=0;var J=new runtime.ByteArray(C);a:{var E,O;for(E=0;E<C&&(!p||-1!=k);){if(0<e){if(0!=k)for(;0<e&&E<C;)e--,s&=32767,m&=32767,J[0+E++]=h[m++]=h[s++];else{for(;0<e&&E<C;)e--,m&=32767,B(8),J[0+E++]=h[m++]=N(8),H(8);0==e&&(k=-1)}if(E==C)break}if(-1==k){if(p)break;B(1);0!=N(1)&&(p=!0);H(1);B(2);k=N(2);H(2);n=null;e=0}switch(k){case 0:O=J;var R=0+E,F=C-E,G=void 0,G=b&7;H(G);B(16);G=N(16);
-H(16);B(16);if(G!=(~d&65535))O=-1;else{H(16);e=G;for(G=0;0<e&&G<F;)e--,m&=32767,B(8),O[R+G++]=h[m++]=N(8),H(8);0==e&&(k=-1);O=G}break;case 1:if(null!=n)O=L(J,0+E,C-E);else b:{O=J;R=0+E;F=C-E;if(null==f){for(var D=void 0,G=Array(288),D=void 0,D=0;144>D;D++)G[D]=8;for(;256>D;D++)G[D]=9;for(;280>D;D++)G[D]=7;for(;288>D;D++)G[D]=8;c=7;D=new K(G,288,257,y,t,c);if(0!=D.status){alert("HufBuild error: "+D.status);O=-1;break b}f=D.root;c=D.m;for(D=0;30>D;D++)G[D]=5;fa=5;D=new K(G,30,0,w,v,fa);if(1<D.status){f=
-null;alert("HufBuild error: "+D.status);O=-1;break b}a=D.root;fa=D.m}n=f;g=a;l=c;u=fa;O=L(O,R,F)}break;case 2:O=null!=n?L(J,0+E,C-E):ma(J,0+E,C-E);break;default:O=-1}if(-1==O)break a;E+=O}}q=null;return J}};
+core.RawInflate=function(){var e,h,f=null,n,m,p,c,b,a,d,k,g,q,l,r,t,w,v=[0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535],y=[3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0],x=[0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,99,99],u=[1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577],s=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],C=[16,17,18,
+0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],B=function(){this.list=this.next=null},A=function(){this.n=this.b=this.e=0;this.t=null},I=function(a,d,b,g,c,l){this.BMAX=16;this.N_MAX=288;this.status=0;this.root=null;this.m=0;var k=Array(this.BMAX+1),q,f,e,r,h,s,t,m=Array(this.BMAX+1),p,n,N,w=new A,G=Array(this.BMAX);r=Array(this.N_MAX);var z,u=Array(this.BMAX+1),I,v,R;R=this.root=null;for(h=0;h<k.length;h++)k[h]=0;for(h=0;h<m.length;h++)m[h]=0;for(h=0;h<G.length;h++)G[h]=null;for(h=0;h<r.length;h++)r[h]=
+0;for(h=0;h<u.length;h++)u[h]=0;q=256<d?a[256]:this.BMAX;p=a;n=0;h=d;do k[p[n]]++,n++;while(0<--h);if(k[0]==d)this.root=null,this.status=this.m=0;else{for(s=1;s<=this.BMAX&&0==k[s];s++);t=s;l<s&&(l=s);for(h=this.BMAX;0!=h&&0==k[h];h--);e=h;l>h&&(l=h);for(I=1<<s;s<h;s++,I<<=1)if(0>(I-=k[s])){this.status=2;this.m=l;return}if(0>(I-=k[h]))this.status=2,this.m=l;else{k[h]+=I;u[1]=s=0;p=k;n=1;for(N=2;0<--h;)u[N++]=s+=p[n++];p=a;h=n=0;do 0!=(s=p[n++])&&(r[u[s]++]=h);while(++h<d);d=u[e];u[0]=h=0;p=r;n=0;
+r=-1;z=m[0]=0;N=null;for(v=0;t<=e;t++)for(a=k[t];0<a--;){for(;t>z+m[1+r];){z+=m[1+r];r++;v=(v=e-z)>l?l:v;if((f=1<<(s=t-z))>a+1)for(f-=a+1,N=t;++s<v&&!((f<<=1)<=k[++N]);)f-=k[N];z+s>q&&z<q&&(s=q-z);v=1<<s;m[1+r]=s;N=Array(v);for(f=0;f<v;f++)N[f]=new A;R=null==R?this.root=new B:R.next=new B;R.next=null;R.list=N;G[r]=N;0<r&&(u[r]=h,w.b=m[r],w.e=16+s,w.t=N,s=(h&(1<<z)-1)>>z-m[r],G[r-1][s].e=w.e,G[r-1][s].b=w.b,G[r-1][s].n=w.n,G[r-1][s].t=w.t)}w.b=t-z;n>=d?w.e=99:p[n]<b?(w.e=256>p[n]?16:15,w.n=p[n++]):
+(w.e=c[p[n]-b],w.n=g[p[n++]-b]);f=1<<t-z;for(s=h>>z;s<v;s+=f)N[s].e=w.e,N[s].b=w.b,N[s].n=w.n,N[s].t=w.t;for(s=1<<t-1;0!=(h&s);s>>=1)h^=s;for(h^=s;(h&(1<<z)-1)!=u[r];)z-=m[r],r--}this.m=m[1];this.status=0!=I&&1!=e?1:0}}},z=function(a){for(;c<a;){var d=p,b;b=t.length==w?-1:t[w++];p=d|b<<c;c+=8}},N=function(a){return p&v[a]},G=function(a){p>>=a;c-=a},R=function(a,c,f){var s,A,t;if(0==f)return 0;for(t=0;;){z(l);A=g.list[N(l)];for(s=A.e;16<s;){if(99==s)return-1;G(A.b);s-=16;z(s);A=A.t[N(s)];s=A.e}G(A.b);
+if(16==s)h&=32767,a[c+t++]=e[h++]=A.n;else{if(15==s)break;z(s);d=A.n+N(s);G(s);z(r);A=q.list[N(r)];for(s=A.e;16<s;){if(99==s)return-1;G(A.b);s-=16;z(s);A=A.t[N(s)];s=A.e}G(A.b);z(s);k=h-A.n-N(s);for(G(s);0<d&&t<f;)d--,k&=32767,h&=32767,a[c+t++]=e[h++]=e[k++]}if(t==f)return f}b=-1;return t},Z,ka=function(a,d,b){var c,k,f,e,h,A,t,m=Array(316);for(c=0;c<m.length;c++)m[c]=0;z(5);A=257+N(5);G(5);z(5);t=1+N(5);G(5);z(4);c=4+N(4);G(4);if(286<A||30<t)return-1;for(k=0;k<c;k++)z(3),m[C[k]]=N(3),G(3);for(;19>
+k;k++)m[C[k]]=0;l=7;k=new I(m,19,19,null,null,l);if(0!=k.status)return-1;g=k.root;l=k.m;e=A+t;for(c=f=0;c<e;)if(z(l),h=g.list[N(l)],k=h.b,G(k),k=h.n,16>k)m[c++]=f=k;else if(16==k){z(2);k=3+N(2);G(2);if(c+k>e)return-1;for(;0<k--;)m[c++]=f}else{17==k?(z(3),k=3+N(3),G(3)):(z(7),k=11+N(7),G(7));if(c+k>e)return-1;for(;0<k--;)m[c++]=0;f=0}l=9;k=new I(m,A,257,y,x,l);0==l&&(k.status=1);if(0!=k.status)return-1;g=k.root;l=k.m;for(c=0;c<t;c++)m[c]=m[c+A];r=6;k=new I(m,t,0,u,s,r);q=k.root;r=k.m;return 0==r&&
+257<A||0!=k.status?-1:R(a,d,b)};this.inflate=function(A,v){null==e&&(e=Array(65536));c=p=h=0;b=-1;a=!1;d=k=0;g=null;t=A;w=0;var B=new runtime.ByteArray(v);a:{var C,U;for(C=0;C<v&&(!a||-1!=b);){if(0<d){if(0!=b)for(;0<d&&C<v;)d--,k&=32767,h&=32767,B[0+C++]=e[h++]=e[k++];else{for(;0<d&&C<v;)d--,h&=32767,z(8),B[0+C++]=e[h++]=N(8),G(8);0==d&&(b=-1)}if(C==v)break}if(-1==b){if(a)break;z(1);0!=N(1)&&(a=!0);G(1);z(2);b=N(2);G(2);g=null;d=0}switch(b){case 0:U=B;var O=0+C,W=v-C,E=void 0,E=c&7;G(E);z(16);E=N(16);
+G(16);z(16);if(E!=(~p&65535))U=-1;else{G(16);d=E;for(E=0;0<d&&E<W;)d--,h&=32767,z(8),U[O+E++]=e[h++]=N(8),G(8);0==d&&(b=-1);U=E}break;case 1:if(null!=g)U=R(B,0+C,v-C);else b:{U=B;O=0+C;W=v-C;if(null==f){for(var H=void 0,E=Array(288),H=void 0,H=0;144>H;H++)E[H]=8;for(;256>H;H++)E[H]=9;for(;280>H;H++)E[H]=7;for(;288>H;H++)E[H]=8;m=7;H=new I(E,288,257,y,x,m);if(0!=H.status){alert("HufBuild error: "+H.status);U=-1;break b}f=H.root;m=H.m;for(H=0;30>H;H++)E[H]=5;Z=5;H=new I(E,30,0,u,s,Z);if(1<H.status){f=
+null;alert("HufBuild error: "+H.status);U=-1;break b}n=H.root;Z=H.m}g=f;q=n;l=m;r=Z;U=R(U,O,W)}break;case 2:U=null!=g?R(B,0+C,v-C):ka(B,0+C,v-C);break;default:U=-1}if(-1==U)break a;C+=U}}t=null;return B}};
 // Input 7
 /*
 
@@ -122,6 +125,9 @@ null;alert("HufBuild error: "+D.status);O=-1;break b}a=D.root;fa=D.m}n=f;g=a;l=c
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -142,11 +148,11 @@ null;alert("HufBuild error: "+D.status);O=-1;break b}a=D.root;fa=D.m}n=f;g=a;l=c
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-core.LoopWatchDog=function(h,m){var f=Date.now(),a=0;this.check=function(){var c;if(h&&(c=Date.now(),c-f>h))throw runtime.log("alert","watchdog timeout"),"timeout!";if(0<m&&(a+=1,a>m))throw runtime.log("alert","watchdog loop overflow"),"loop overflow";}};
+core.LoopWatchDog=function(e,h){var f=Date.now(),n=0;this.check=function(){var m;if(e&&(m=Date.now(),m-f>e))throw runtime.log("alert","watchdog timeout"),"timeout!";if(0<h&&(n+=1,n>h))throw runtime.log("alert","watchdog loop overflow"),"loop overflow";}};
 // Input 8
-core.Utils=function(){function h(m,f){f&&Array.isArray(f)?m=(m||[]).concat(f.map(function(a){return h({},a)})):f&&"object"===typeof f?(m=m||{},Object.keys(f).forEach(function(a){m[a]=h(m[a],f[a])})):m=f;return m}this.hashString=function(h){var f=0,a,c;a=0;for(c=h.length;a<c;a+=1)f=(f<<5)-f+h.charCodeAt(a),f|=0;return f};this.mergeObjects=h};
+core.Utils=function(){function e(h,f){f&&Array.isArray(f)?h=(h||[]).concat(f.map(function(f){return e({},f)})):f&&"object"===typeof f?(h=h||{},Object.keys(f).forEach(function(n){h[n]=e(h[n],f[n])})):h=f;return h}this.hashString=function(e){var f=0,n,m;n=0;for(m=e.length;n<m;n+=1)f=(f<<5)-f+e.charCodeAt(n),f|=0;return f};this.mergeObjects=e};
 // Input 9
 /*
 
@@ -160,6 +166,9 @@ core.Utils=function(){function h(m,f){f&&Array.isArray(f)?m=(m||[]).concat(f.map
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -180,21 +189,22 @@ core.Utils=function(){function h(m,f){f&&Array.isArray(f)?m=(m||[]).concat(f.map
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-core.DomUtils=function(){function h(a,c){var d=null;a.nodeType===Node.TEXT_NODE&&(0===a.length?(a.parentNode.removeChild(a),c.nodeType===Node.TEXT_NODE&&(d=c)):(c.nodeType===Node.TEXT_NODE&&(a.appendData(c.data),c.parentNode.removeChild(c)),d=a));return d}function m(a,c){for(var d=0,b;a.parentNode!==c;)runtime.assert(null!==a.parentNode,"parent is null"),a=a.parentNode;for(b=c.firstChild;b!==a;)d+=1,b=b.nextSibling;return d}function f(a,c){return a===c||Boolean(a.compareDocumentPosition(c)&Node.DOCUMENT_POSITION_CONTAINED_BY)}
-this.splitBoundaries=function(a){var c=[],d;if(a.startContainer.nodeType===Node.TEXT_NODE||a.endContainer.nodeType===Node.TEXT_NODE){d=a.endContainer;var b=a.endOffset;if(b<d.childNodes.length)for(d=d.childNodes[b],b=0;d.firstChild;)d=d.firstChild;else for(;d.lastChild;)d=d.lastChild,b=d.nodeType===Node.TEXT_NODE?d.textContent.length:d.childNodes.length;a.setEnd(d,b);0!==a.endOffset&&(a.endContainer.nodeType===Node.TEXT_NODE&&a.endOffset!==a.endContainer.length)&&(c.push(a.endContainer.splitText(a.endOffset)),
-c.push(a.endContainer));0!==a.startOffset&&(a.startContainer.nodeType===Node.TEXT_NODE&&a.startOffset!==a.startContainer.length)&&(d=a.startContainer.splitText(a.startOffset),c.push(a.startContainer),c.push(d),a.setStart(d,0))}return c};this.containsRange=function(a,c){return 0>=a.compareBoundaryPoints(a.START_TO_START,c)&&0<=a.compareBoundaryPoints(a.END_TO_END,c)};this.rangesIntersect=function(a,c){return 0>=a.compareBoundaryPoints(a.END_TO_START,c)&&0<=a.compareBoundaryPoints(a.START_TO_END,c)};
-this.getNodesInRange=function(a,c){var d=[],b,k=a.startContainer.ownerDocument.createTreeWalker(a.commonAncestorContainer,NodeFilter.SHOW_ALL,c,!1);for(b=k.currentNode=a.startContainer;b;){if(c(b)===NodeFilter.FILTER_ACCEPT)d.push(b);else if(c(b)===NodeFilter.FILTER_REJECT)break;b=b.parentNode}d.reverse();for(b=k.nextNode();b;)d.push(b),b=k.nextNode();return d};this.normalizeTextNodes=function(a){a&&a.nextSibling&&(a=h(a,a.nextSibling));a&&a.previousSibling&&h(a.previousSibling,a)};this.rangeContainsNode=
-function(a,c){var d=c.ownerDocument.createRange(),b=c.nodeType===Node.TEXT_NODE?c.length:c.childNodes.length;d.setStart(a.startContainer,a.startOffset);d.setEnd(a.endContainer,a.endOffset);b=0===d.comparePoint(c,0)&&0===d.comparePoint(c,b);d.detach();return b};this.mergeIntoParent=function(a){for(var c=a.parentNode;a.firstChild;)c.insertBefore(a.firstChild,a);c.removeChild(a);return c};this.getElementsByTagNameNS=function(a,c,d){return Array.prototype.slice.call(a.getElementsByTagNameNS(c,d))};this.rangeIntersectsNode=
-function(a,c){var d=c.nodeType===Node.TEXT_NODE?c.length:c.childNodes.length;return 0>=a.comparePoint(c,0)&&0<=a.comparePoint(c,d)};this.containsNode=function(a,c){return a===c||a.contains(c)};this.comparePoints=function(a,c,d,b){if(a===d)return b-c;var k=a.compareDocumentPosition(d);2===k?k=-1:4===k?k=1:10===k?(c=m(a,d),k=c<b?1:-1):(b=m(d,a),k=b<c?-1:1);return k};(function(a){var c=runtime.getWindow();null!==c&&(c=c.navigator.appVersion.toLowerCase(),c=-1===c.indexOf("chrome")&&(-1!==c.indexOf("applewebkit")||
--1!==c.indexOf("safari")))&&(a.containsNode=f)})(this)};
+(function(){function e(f){var e,m,p,c;void 0===h&&(c=f.createElement("div"),c.style.position="absolute",c.style.left="-99999px",c.style.transform="scale(2)",c.style["-webkit-transform"]="scale(2)",p=f.createElement("div"),p.style.width="10px",p.style.height="10px",c.appendChild(p),f.body.appendChild(c),e=p.ownerDocument.createRange(),m=p.getBoundingClientRect(),e.selectNode(p),p=e.getBoundingClientRect(),h=m.height!==p.height,e.detach(),f.body.removeChild(c));return h}var h;core.DomUtils=function(){function f(b,
+a){var d=null;b.nodeType===Node.TEXT_NODE&&(0===b.length?(b.parentNode.removeChild(b),a.nodeType===Node.TEXT_NODE&&(d=a)):(a.nodeType===Node.TEXT_NODE&&(b.appendData(a.data),a.parentNode.removeChild(a)),d=b));return d}function h(b){for(var a=b.parentNode;b.firstChild;)a.insertBefore(b.firstChild,b);a.removeChild(b);return a}function m(b,a){for(var d=b.parentNode,c=b.firstChild,g;c;)g=c.nextSibling,m(c,a),c=g;a(b)&&(d=h(b));return d}function p(b,a){for(var d=0,c;b.parentNode!==a;)runtime.assert(null!==
+b.parentNode,"parent is null"),b=b.parentNode;for(c=a.firstChild;c!==b;)d+=1,c=c.nextSibling;return d}function c(b,a){return b===a||Boolean(b.compareDocumentPosition(a)&Node.DOCUMENT_POSITION_CONTAINED_BY)}this.splitBoundaries=function(b){var a=[],d;if(b.startContainer.nodeType===Node.TEXT_NODE||b.endContainer.nodeType===Node.TEXT_NODE){d=b.endContainer;var c=b.endOffset;if(c<d.childNodes.length)for(d=d.childNodes[c],c=0;d.firstChild;)d=d.firstChild;else for(;d.lastChild;)d=d.lastChild,c=d.nodeType===
+Node.TEXT_NODE?d.textContent.length:d.childNodes.length;b.setEnd(d,c);0!==b.endOffset&&b.endContainer.nodeType===Node.TEXT_NODE&&b.endOffset!==b.endContainer.length&&(a.push(b.endContainer.splitText(b.endOffset)),a.push(b.endContainer));0!==b.startOffset&&b.startContainer.nodeType===Node.TEXT_NODE&&b.startOffset!==b.startContainer.length&&(d=b.startContainer.splitText(b.startOffset),a.push(b.startContainer),a.push(d),b.setStart(d,0))}return a};this.containsRange=function(b,a){return 0>=b.compareBoundaryPoints(b.START_TO_START,
+a)&&0<=b.compareBoundaryPoints(b.END_TO_END,a)};this.rangesIntersect=function(b,a){return 0>=b.compareBoundaryPoints(b.END_TO_START,a)&&0<=b.compareBoundaryPoints(b.START_TO_END,a)};this.getNodesInRange=function(b,a){var d=[],c,g,q=b.startContainer.ownerDocument.createTreeWalker(b.commonAncestorContainer,NodeFilter.SHOW_ALL,a,!1);for(c=q.currentNode=b.startContainer;c;){g=a(c);if(g===NodeFilter.FILTER_ACCEPT)d.push(c);else if(g===NodeFilter.FILTER_REJECT)break;c=c.parentNode}d.reverse();for(c=q.nextNode();c;)d.push(c),
+c=q.nextNode();return d};this.normalizeTextNodes=function(b){b&&b.nextSibling&&(b=f(b,b.nextSibling));b&&b.previousSibling&&f(b.previousSibling,b)};this.rangeContainsNode=function(b,a){var d=a.ownerDocument.createRange(),c=a.nodeType===Node.TEXT_NODE?a.length:a.childNodes.length;d.setStart(b.startContainer,b.startOffset);d.setEnd(b.endContainer,b.endOffset);c=0===d.comparePoint(a,0)&&0===d.comparePoint(a,c);d.detach();return c};this.mergeIntoParent=h;this.removeUnwantedNodes=m;this.getElementsByTagNameNS=
+function(b,a,d){return Array.prototype.slice.call(b.getElementsByTagNameNS(a,d))};this.rangeIntersectsNode=function(b,a){var d=a.nodeType===Node.TEXT_NODE?a.length:a.childNodes.length;return 0>=b.comparePoint(a,0)&&0<=b.comparePoint(a,d)};this.containsNode=function(b,a){return b===a||b.contains(a)};this.comparePoints=function(b,a,d,c){if(b===d)return c-a;var g=b.compareDocumentPosition(d);2===g?g=-1:4===g?g=1:10===g?(a=p(b,d),g=a<c?1:-1):(c=p(d,b),g=c<a?-1:1);return g};this.areRangeRectanglesTransformed=
+function(b){return!e(b)};this.adaptRangeDifferenceToZoomLevel=function(b,a){var d=runtime.getWindow();return(d=d&&d.document)&&e(d)?b:b/a};(function(b){var a=runtime.getWindow(),d;null!==a&&(d=a.navigator.appVersion.toLowerCase(),a=-1===d.indexOf("chrome")&&(-1!==d.indexOf("applewebkit")||-1!==d.indexOf("safari")),d=d.indexOf("msie"),a||d)&&(b.containsNode=c)})(this)};return core.DomUtils})();
 // Input 10
 runtime.loadClass("core.DomUtils");
-core.Cursor=function(h,m){function f(a){a.parentNode&&(k.push(a.previousSibling),k.push(a.nextSibling),a.parentNode.removeChild(a))}function a(a,b,e){if(b.nodeType===Node.TEXT_NODE){runtime.assert(Boolean(b),"putCursorIntoTextNode: invalid container");var c=b.parentNode;runtime.assert(Boolean(c),"putCursorIntoTextNode: container without parent");runtime.assert(0<=e&&e<=b.length,"putCursorIntoTextNode: offset is out of bounds");0===e?c.insertBefore(a,b):(e!==b.length&&b.splitText(e),c.insertBefore(a,
-b.nextSibling))}else if(b.nodeType===Node.ELEMENT_NODE){runtime.assert(Boolean(b),"putCursorIntoContainer: invalid container");for(c=b.firstChild;null!==c&&0<e;)c=c.nextSibling,e-=1;b.insertBefore(a,c)}k.push(a.previousSibling);k.push(a.nextSibling)}var c=h.createElementNS("urn:webodf:names:cursor","cursor"),d=h.createElementNS("urn:webodf:names:cursor","anchor"),b,k=[],p,e,s=new core.DomUtils;this.getNode=function(){return c};this.getAnchorNode=function(){return d.parentNode?d:c};this.getSelectedRange=
-function(){e?(p.setStartBefore(c),p.collapse(!0)):(p.setStartAfter(b?d:c),p.setEndBefore(b?c:d));return p};this.setSelectedRange=function(n,g){p&&p!==n&&p.detach();p=n;b=!1!==g;(e=n.collapsed)?(f(d),f(c),a(c,n.startContainer,n.startOffset)):(f(d),f(c),a(b?c:d,n.endContainer,n.endOffset),a(b?d:c,n.startContainer,n.startOffset));k.forEach(s.normalizeTextNodes);k.length=0};this.remove=function(){f(c);k.forEach(s.normalizeTextNodes);k.length=0};c.setAttributeNS("urn:webodf:names:cursor","memberId",m);
-d.setAttributeNS("urn:webodf:names:cursor","memberId",m)};
+core.Cursor=function(e,h){function f(a){a.parentNode&&(b.push(a.previousSibling),b.push(a.nextSibling),a.parentNode.removeChild(a))}function n(a,d,c){if(d.nodeType===Node.TEXT_NODE){runtime.assert(Boolean(d),"putCursorIntoTextNode: invalid container");var k=d.parentNode;runtime.assert(Boolean(k),"putCursorIntoTextNode: container without parent");runtime.assert(0<=c&&c<=d.length,"putCursorIntoTextNode: offset is out of bounds");0===c?k.insertBefore(a,d):(c!==d.length&&d.splitText(c),k.insertBefore(a,
+d.nextSibling))}else if(d.nodeType===Node.ELEMENT_NODE){runtime.assert(Boolean(d),"putCursorIntoContainer: invalid container");for(k=d.firstChild;null!==k&&0<c;)k=k.nextSibling,c-=1;d.insertBefore(a,k)}b.push(a.previousSibling);b.push(a.nextSibling)}var m=e.createElementNS("urn:webodf:names:cursor","cursor"),p=e.createElementNS("urn:webodf:names:cursor","anchor"),c,b=[],a,d,k=new core.DomUtils;this.getNode=function(){return m};this.getAnchorNode=function(){return p.parentNode?p:m};this.getSelectedRange=
+function(){d?(a.setStartBefore(m),a.collapse(!0)):(a.setStartAfter(c?p:m),a.setEndBefore(c?m:p));return a};this.setSelectedRange=function(g,q){a&&a!==g&&a.detach();a=g;c=!1!==q;(d=g.collapsed)?(f(p),f(m),n(m,g.startContainer,g.startOffset)):(f(p),f(m),n(c?m:p,g.endContainer,g.endOffset),n(c?p:m,g.startContainer,g.startOffset));b.forEach(k.normalizeTextNodes);b.length=0};this.hasForwardSelection=function(){return c};this.remove=function(){f(m);b.forEach(k.normalizeTextNodes);b.length=0};m.setAttributeNS("urn:webodf:names:cursor",
+"memberId",h);p.setAttributeNS("urn:webodf:names:cursor","memberId",h)};
 // Input 11
 /*
 
@@ -208,6 +218,9 @@ d.setAttributeNS("urn:webodf:names:cursor","memberId",m)};
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -228,37 +241,39 @@ d.setAttributeNS("urn:webodf:names:cursor","memberId",m)};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-core.EventNotifier=function(h){var m={};this.emit=function(f,a){var c,d;runtime.assert(m.hasOwnProperty(f),'unknown event fired "'+f+'"');d=m[f];for(c=0;c<d.length;c+=1)d[c](a)};this.subscribe=function(f,a){runtime.assert(m.hasOwnProperty(f),'tried to subscribe to unknown event "'+f+'"');m[f].push(a);runtime.log('event "'+f+'" subscribed.')};this.unsubscribe=function(f,a){var c;runtime.assert(m.hasOwnProperty(f),'tried to unsubscribe from unknown event "'+f+'"');c=m[f].indexOf(a);runtime.assert(-1!==
-c,'tried to unsubscribe unknown callback from event "'+f+'"');-1!==c&&m[f].splice(c,1);runtime.log('event "'+f+'" unsubscribed.')};(function(){var f;for(f=0;f<h.length;f+=1)m[h[f]]=[]})()};
+core.EventNotifier=function(e){var h={};this.emit=function(f,e){var m,p;runtime.assert(h.hasOwnProperty(f),'unknown event fired "'+f+'"');p=h[f];for(m=0;m<p.length;m+=1)p[m](e)};this.subscribe=function(f,e){runtime.assert(h.hasOwnProperty(f),'tried to subscribe to unknown event "'+f+'"');h[f].push(e);runtime.log('event "'+f+'" subscribed.')};this.unsubscribe=function(f,e){var m;runtime.assert(h.hasOwnProperty(f),'tried to unsubscribe from unknown event "'+f+'"');m=h[f].indexOf(e);runtime.assert(-1!==
+m,'tried to unsubscribe unknown callback from event "'+f+'"');-1!==m&&h[f].splice(m,1);runtime.log('event "'+f+'" unsubscribed.')};(function(){var f;for(f=0;f<e.length;f+=1)h[e[f]]=[]})()};
 // Input 12
 core.UnitTest=function(){};core.UnitTest.prototype.setUp=function(){};core.UnitTest.prototype.tearDown=function(){};core.UnitTest.prototype.description=function(){};core.UnitTest.prototype.tests=function(){};core.UnitTest.prototype.asyncTests=function(){};
-core.UnitTest.provideTestAreaDiv=function(){var h=runtime.getWindow().document,m=h.getElementById("testarea");runtime.assert(!m,'Unclean test environment, found a div with id "testarea".');m=h.createElement("div");m.setAttribute("id","testarea");h.body.appendChild(m);return m};
-core.UnitTest.cleanupTestAreaDiv=function(){var h=runtime.getWindow().document,m=h.getElementById("testarea");runtime.assert(!!m&&m.parentNode===h.body,'Test environment broken, found no div with id "testarea" below body.');h.body.removeChild(m)};core.UnitTest.createOdtDocument=function(h,m){var f="<?xml version='1.0' encoding='UTF-8'?>",f=f+"<office:document";Object.keys(m).forEach(function(a){f+=" xmlns:"+a+'="'+m[a]+'"'});f+=">";f+=h;f+="</office:document>";return runtime.parseXML(f)};
-core.UnitTestRunner=function(){function h(a){b+=1;runtime.log("fail",a)}function m(a,b){var c;try{if(a.length!==b.length)return h("array of length "+a.length+" should be "+b.length+" long"),!1;for(c=0;c<a.length;c+=1)if(a[c]!==b[c])return h(a[c]+" should be "+b[c]+" at array index "+c),!1}catch(d){return!1}return!0}function f(a,b,c){var d=a.attributes,g=d.length,l,k,q;for(l=0;l<g;l+=1)if(k=d.item(l),"xmlns"!==k.prefix){q=b.getAttributeNS(k.namespaceURI,k.localName);if(!b.hasAttributeNS(k.namespaceURI,
-k.localName))return h("Attribute "+k.localName+" with value "+k.value+" was not present"),!1;if(q!==k.value)return h("Attribute "+k.localName+" was "+q+" should be "+k.value),!1}return c?!0:f(b,a,!0)}function a(b,e){if(b.nodeType!==e.nodeType)return h(b.nodeType+" should be "+e.nodeType),!1;if(b.nodeType===Node.TEXT_NODE)return b.data===e.data;runtime.assert(b.nodeType===Node.ELEMENT_NODE,"Only textnodes and elements supported.");if(b.namespaceURI!==e.namespaceURI||b.localName!==e.localName)return h(b.namespaceURI+
-" should be "+e.namespaceURI),!1;if(!f(b,e,!1))return!1;for(var c=b.firstChild,d=e.firstChild;c;){if(!d||!a(c,d))return!1;c=c.nextSibling;d=d.nextSibling}return d?!1:!0}function c(b,e){return 0===e?b===e&&1/b===1/e:b===e?!0:"number"===typeof e&&isNaN(e)?"number"===typeof b&&isNaN(b):Object.prototype.toString.call(e)===Object.prototype.toString.call([])?m(b,e):"object"===typeof e&&"object"===typeof b?e.constructor===Element||e.constructor===Node?a(e,b):k(e,b):!1}function d(a,b,d){"string"===typeof b&&
-"string"===typeof d||runtime.log("WARN: shouldBe() expects string arguments");var n,g;try{g=eval(b)}catch(l){n=l}a=eval(d);n?h(b+" should be "+a+". Threw exception "+n):c(g,a)?runtime.log("pass",b+" is "+d):String(typeof g)===String(typeof a)?(d=0===g&&0>1/g?"-0":String(g),h(b+" should be "+a+". Was "+d+".")):h(b+" should be "+a+" (of type "+typeof a+"). Was "+g+" (of type "+typeof g+").")}var b=0,k;k=function(a,b){var d=Object.keys(a),n=Object.keys(b);d.sort();n.sort();return m(d,n)&&Object.keys(a).every(function(d){var n=
-a[d],k=b[d];return c(n,k)?!0:(h(n+" should be "+k+" for key "+d),!1)})};this.areNodesEqual=a;this.shouldBeNull=function(a,b){d(a,b,"null")};this.shouldBeNonNull=function(a,b){var c,d;try{d=eval(b)}catch(g){c=g}c?h(b+" should be non-null. Threw exception "+c):null!==d?runtime.log("pass",b+" is non-null."):h(b+" should be non-null. Was "+d)};this.shouldBe=d;this.countFailedTests=function(){return b}};
-core.UnitTester=function(){function h(a,c){return"<span style='color:blue;cursor:pointer' onclick='"+c+"'>"+a+"</span>"}var m=0,f={};this.runTests=function(a,c,d){function b(a){if(0===a.length)f[k]=s,m+=p.countFailedTests(),c();else{g=a[0];var d=Runtime.getFunctionName(g);runtime.log("Running "+d);u=p.countFailedTests();e.setUp();g(function(){e.tearDown();s[d]=u===p.countFailedTests();b(a.slice(1))})}}var k=Runtime.getFunctionName(a),p=new core.UnitTestRunner,e=new a(p),s={},n,g,l,u,q="BrowserRuntime"===
-runtime.type();if(f.hasOwnProperty(k))runtime.log("Test "+k+" has already run.");else{q?runtime.log("<span>Running "+h(k,'runSuite("'+k+'");')+": "+e.description()+"</span>"):runtime.log("Running "+k+": "+e.description);l=e.tests();for(n=0;n<l.length;n+=1)g=l[n],a=Runtime.getFunctionName(g)||g.testName,d.length&&-1===d.indexOf(a)||(q?runtime.log("<span>Running "+h(a,'runTest("'+k+'","'+a+'")')+"</span>"):runtime.log("Running "+a),u=p.countFailedTests(),e.setUp(),g(),e.tearDown(),s[a]=u===p.countFailedTests());
-b(e.asyncTests())}};this.countFailedTests=function(){return m};this.results=function(){return f}};
+core.UnitTest.provideTestAreaDiv=function(){var e=runtime.getWindow().document,h=e.getElementById("testarea");runtime.assert(!h,'Unclean test environment, found a div with id "testarea".');h=e.createElement("div");h.setAttribute("id","testarea");e.body.appendChild(h);return h};
+core.UnitTest.cleanupTestAreaDiv=function(){var e=runtime.getWindow().document,h=e.getElementById("testarea");runtime.assert(!!h&&h.parentNode===e.body,'Test environment broken, found no div with id "testarea" below body.');e.body.removeChild(h)};core.UnitTest.createOdtDocument=function(e,h){var f="<?xml version='1.0' encoding='UTF-8'?>",f=f+"<office:document";Object.keys(h).forEach(function(e){f+=" xmlns:"+e+'="'+h[e]+'"'});f+=">";f+=e;f+="</office:document>";return runtime.parseXML(f)};
+core.UnitTestRunner=function(){function e(a){c+=1;runtime.log("fail",a)}function h(a,d){var b;try{if(a.length!==d.length)return e("array of length "+a.length+" should be "+d.length+" long"),!1;for(b=0;b<a.length;b+=1)if(a[b]!==d[b])return e(a[b]+" should be "+d[b]+" at array index "+b),!1}catch(c){return!1}return!0}function f(a,d,b){var c=a.attributes,q=c.length,l,r,h;for(l=0;l<q;l+=1)if(r=c.item(l),"xmlns"!==r.prefix){h=d.getAttributeNS(r.namespaceURI,r.localName);if(!d.hasAttributeNS(r.namespaceURI,
+r.localName))return e("Attribute "+r.localName+" with value "+r.value+" was not present"),!1;if(h!==r.value)return e("Attribute "+r.localName+" was "+h+" should be "+r.value),!1}return b?!0:f(d,a,!0)}function n(a,d){if(a.nodeType!==d.nodeType)return e(a.nodeType+" should be "+d.nodeType),!1;if(a.nodeType===Node.TEXT_NODE)return a.data===d.data;runtime.assert(a.nodeType===Node.ELEMENT_NODE,"Only textnodes and elements supported.");if(a.namespaceURI!==d.namespaceURI||a.localName!==d.localName)return e(a.namespaceURI+
+" should be "+d.namespaceURI),!1;if(!f(a,d,!1))return!1;for(var b=a.firstChild,c=d.firstChild;b;){if(!c||!n(b,c))return!1;b=b.nextSibling;c=c.nextSibling}return c?!1:!0}function m(a,d){return 0===d?a===d&&1/a===1/d:a===d?!0:"number"===typeof d&&isNaN(d)?"number"===typeof a&&isNaN(a):Object.prototype.toString.call(d)===Object.prototype.toString.call([])?h(a,d):"object"===typeof d&&"object"===typeof a?d.constructor===Element||d.constructor===Node?n(d,a):b(d,a):!1}function p(a,d,b){"string"===typeof d&&
+"string"===typeof b||runtime.log("WARN: shouldBe() expects string arguments");var c,q;try{q=eval(d)}catch(l){c=l}a=eval(b);c?e(d+" should be "+a+". Threw exception "+c):m(q,a)?runtime.log("pass",d+" is "+b):String(typeof q)===String(typeof a)?(b=0===q&&0>1/q?"-0":String(q),e(d+" should be "+a+". Was "+b+".")):e(d+" should be "+a+" (of type "+typeof a+"). Was "+q+" (of type "+typeof q+").")}var c=0,b;b=function(a,d){var b=Object.keys(a),c=Object.keys(d);b.sort();c.sort();return h(b,c)&&Object.keys(a).every(function(b){var c=
+a[b],g=d[b];return m(c,g)?!0:(e(c+" should be "+g+" for key "+b),!1)})};this.areNodesEqual=n;this.shouldBeNull=function(a,d){p(a,d,"null")};this.shouldBeNonNull=function(a,d){var b,c;try{c=eval(d)}catch(q){b=q}b?e(d+" should be non-null. Threw exception "+b):null!==c?runtime.log("pass",d+" is non-null."):e(d+" should be non-null. Was "+c)};this.shouldBe=p;this.countFailedTests=function(){return c}};
+core.UnitTester=function(){function e(f,e){return"<span style='color:blue;cursor:pointer' onclick='"+e+"'>"+f+"</span>"}var h=0,f={};this.runTests=function(n,m,p){function c(g){if(0===g.length)f[b]=k,h+=a.countFailedTests(),m();else{q=g[0];var l=Runtime.getFunctionName(q);runtime.log("Running "+l);r=a.countFailedTests();d.setUp();q(function(){d.tearDown();k[l]=r===a.countFailedTests();c(g.slice(1))})}}var b=Runtime.getFunctionName(n),a=new core.UnitTestRunner,d=new n(a),k={},g,q,l,r,t="BrowserRuntime"===
+runtime.type();if(f.hasOwnProperty(b))runtime.log("Test "+b+" has already run.");else{t?runtime.log("<span>Running "+e(b,'runSuite("'+b+'");')+": "+d.description()+"</span>"):runtime.log("Running "+b+": "+d.description);l=d.tests();for(g=0;g<l.length;g+=1)q=l[g],n=Runtime.getFunctionName(q)||q.testName,p.length&&-1===p.indexOf(n)||(t?runtime.log("<span>Running "+e(n,'runTest("'+b+'","'+n+'")')+"</span>"):runtime.log("Running "+n),r=a.countFailedTests(),d.setUp(),q(),d.tearDown(),k[n]=r===a.countFailedTests());
+c(d.asyncTests())}};this.countFailedTests=function(){return h};this.results=function(){return f}};
 // Input 13
-core.PositionIterator=function(h,m,f,a){function c(){this.acceptNode=function(a){return a.nodeType===Node.TEXT_NODE&&0===a.length?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}}function d(a){this.acceptNode=function(b){return b.nodeType===Node.TEXT_NODE&&0===b.length?NodeFilter.FILTER_REJECT:a.acceptNode(b)}}function b(){var a=p.currentNode.nodeType;e=a===Node.TEXT_NODE?p.currentNode.length-1:a===Node.ELEMENT_NODE?1:0}var k=this,p,e,s;this.nextPosition=function(){if(p.currentNode===h)return!1;
-if(0===e&&p.currentNode.nodeType===Node.ELEMENT_NODE)null===p.firstChild()&&(e=1);else if(p.currentNode.nodeType===Node.TEXT_NODE&&e+1<p.currentNode.length)e+=1;else if(null!==p.nextSibling())e=0;else if(p.parentNode())e=1;else return!1;return!0};this.previousPosition=function(){var a=!0;if(0===e)if(null===p.previousSibling()){if(!p.parentNode()||p.currentNode===h)return p.firstChild(),!1;e=0}else b();else p.currentNode.nodeType===Node.TEXT_NODE?e-=1:null!==p.lastChild()?b():p.currentNode===h?a=!1:
-e=0;return a};this.container=function(){var a=p.currentNode,b=a.nodeType;return 0===e&&b!==Node.TEXT_NODE?a.parentNode:a};this.rightNode=function(){var a=p.currentNode,b=a.nodeType;if(b===Node.TEXT_NODE&&e===a.length)for(a=a.nextSibling;a&&1!==s(a);)a=a.nextSibling;else b===Node.ELEMENT_NODE&&1===e&&(a=null);return a};this.leftNode=function(){var a=p.currentNode;if(0===e)for(a=a.previousSibling;a&&1!==s(a);)a=a.previousSibling;else if(a.nodeType===Node.ELEMENT_NODE)for(a=a.lastChild;a&&1!==s(a);)a=
-a.previousSibling;return a};this.getCurrentNode=function(){return p.currentNode};this.unfilteredDomOffset=function(){if(p.currentNode.nodeType===Node.TEXT_NODE)return e;for(var a=0,b=p.currentNode,b=1===e?b.lastChild:b.previousSibling;b;)a+=1,b=b.previousSibling;return a};this.getPreviousSibling=function(){var a=p.currentNode,b=p.previousSibling();p.currentNode=a;return b};this.getNextSibling=function(){var a=p.currentNode,b=p.nextSibling();p.currentNode=a;return b};this.setUnfilteredPosition=function(a,
-b){var c,d;runtime.assert(null!==a&&void 0!==a,"PositionIterator.setUnfilteredPosition called without container");p.currentNode=a;if(a.nodeType===Node.TEXT_NODE)return e=b,runtime.assert(b<=a.length,"Error in setPosition: "+b+" > "+a.length),runtime.assert(0<=b,"Error in setPosition: "+b+" < 0"),b===a.length&&(e=void 0,p.nextSibling()?e=0:p.parentNode()&&(e=1),runtime.assert(void 0!==e,"Error in setPosition: position not valid.")),!0;c=s(a);for(d=a.parentNode;d&&d!==h&&c===NodeFilter.FILTER_ACCEPT;)c=
-s(d),c!==NodeFilter.FILTER_ACCEPT&&(p.currentNode=d),d=d.parentNode;b<a.childNodes.length&&c!==NodeFilter.FILTER_REJECT?(p.currentNode=a.childNodes[b],c=s(p.currentNode),e=0):e=0===b?0:1;c===NodeFilter.FILTER_REJECT&&(e=1);if(c!==NodeFilter.FILTER_ACCEPT)return k.nextPosition();runtime.assert(s(p.currentNode)===NodeFilter.FILTER_ACCEPT,"PositionIterater.setUnfilteredPosition call resulted in an non-visible node being set");return!0};this.moveToEnd=function(){p.currentNode=h;e=1};this.moveToEndOfNode=
-function(a){a.nodeType===Node.TEXT_NODE?k.setUnfilteredPosition(a,a.length):(p.currentNode=a,e=1)};this.getNodeFilter=function(){return s};s=(f?new d(f):new c).acceptNode;s.acceptNode=s;p=h.ownerDocument.createTreeWalker(h,m||4294967295,s,a);e=0;null===p.firstChild()&&(e=1)};
+core.PositionIterator=function(e,h,f,n){function m(){this.acceptNode=function(a){return a.nodeType===Node.TEXT_NODE&&0===a.length?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}}function p(a){this.acceptNode=function(d){return d.nodeType===Node.TEXT_NODE&&0===d.length?NodeFilter.FILTER_REJECT:a.acceptNode(d)}}function c(){var b=a.currentNode.nodeType;d=b===Node.TEXT_NODE?a.currentNode.length-1:b===Node.ELEMENT_NODE?1:0}var b=this,a,d,k;this.nextPosition=function(){if(a.currentNode===e)return!1;
+if(0===d&&a.currentNode.nodeType===Node.ELEMENT_NODE)null===a.firstChild()&&(d=1);else if(a.currentNode.nodeType===Node.TEXT_NODE&&d+1<a.currentNode.length)d+=1;else if(null!==a.nextSibling())d=0;else if(a.parentNode())d=1;else return!1;return!0};this.previousPosition=function(){var b=!0;if(0===d)if(null===a.previousSibling()){if(!a.parentNode()||a.currentNode===e)return a.firstChild(),!1;d=0}else c();else a.currentNode.nodeType===Node.TEXT_NODE?d-=1:null!==a.lastChild()?c():a.currentNode===e?b=!1:
+d=0;return b};this.container=function(){var b=a.currentNode,c=b.nodeType;return 0===d&&c!==Node.TEXT_NODE?b.parentNode:b};this.rightNode=function(){var b=a.currentNode,c=b.nodeType;if(c===Node.TEXT_NODE&&d===b.length)for(b=b.nextSibling;b&&1!==k(b);)b=b.nextSibling;else c===Node.ELEMENT_NODE&&1===d&&(b=null);return b};this.leftNode=function(){var b=a.currentNode;if(0===d)for(b=b.previousSibling;b&&1!==k(b);)b=b.previousSibling;else if(b.nodeType===Node.ELEMENT_NODE)for(b=b.lastChild;b&&1!==k(b);)b=
+b.previousSibling;return b};this.getCurrentNode=function(){return a.currentNode};this.unfilteredDomOffset=function(){if(a.currentNode.nodeType===Node.TEXT_NODE)return d;for(var b=0,c=a.currentNode,c=1===d?c.lastChild:c.previousSibling;c;)b+=1,c=c.previousSibling;return b};this.getPreviousSibling=function(){var d=a.currentNode,b=a.previousSibling();a.currentNode=d;return b};this.getNextSibling=function(){var d=a.currentNode,b=a.nextSibling();a.currentNode=d;return b};this.setUnfilteredPosition=function(c,
+f){var l,h;runtime.assert(null!==c&&void 0!==c,"PositionIterator.setUnfilteredPosition called without container");a.currentNode=c;if(c.nodeType===Node.TEXT_NODE)return d=f,runtime.assert(f<=c.length,"Error in setPosition: "+f+" > "+c.length),runtime.assert(0<=f,"Error in setPosition: "+f+" < 0"),f===c.length&&(d=void 0,a.nextSibling()?d=0:a.parentNode()&&(d=1),runtime.assert(void 0!==d,"Error in setPosition: position not valid.")),!0;l=k(c);for(h=c.parentNode;h&&h!==e&&l===NodeFilter.FILTER_ACCEPT;)l=
+k(h),l!==NodeFilter.FILTER_ACCEPT&&(a.currentNode=h),h=h.parentNode;f<c.childNodes.length&&l!==NodeFilter.FILTER_REJECT?(a.currentNode=c.childNodes[f],l=k(a.currentNode),d=0):d=1;l===NodeFilter.FILTER_REJECT&&(d=1);if(l!==NodeFilter.FILTER_ACCEPT)return b.nextPosition();runtime.assert(k(a.currentNode)===NodeFilter.FILTER_ACCEPT,"PositionIterater.setUnfilteredPosition call resulted in an non-visible node being set");return!0};this.moveToEnd=function(){a.currentNode=e;d=1};this.moveToEndOfNode=function(c){c.nodeType===
+Node.TEXT_NODE?b.setUnfilteredPosition(c,c.length):(a.currentNode=c,d=1)};this.getNodeFilter=function(){return k};k=(f?new p(f):new m).acceptNode;k.acceptNode=k;a=e.ownerDocument.createTreeWalker(e,h||4294967295,k,n);d=0;null===a.firstChild()&&(d=1)};
 // Input 14
-runtime.loadClass("core.PositionIterator");core.PositionFilter=function(){};core.PositionFilter.FilterResult={FILTER_ACCEPT:1,FILTER_REJECT:2,FILTER_SKIP:3};core.PositionFilter.prototype.acceptPosition=function(h){};(function(){return core.PositionFilter})();
+runtime.loadClass("core.PositionIterator");core.PositionFilter=function(){};core.PositionFilter.FilterResult={FILTER_ACCEPT:1,FILTER_REJECT:2,FILTER_SKIP:3};core.PositionFilter.prototype.acceptPosition=function(e){};(function(){return core.PositionFilter})();
 // Input 15
-runtime.loadClass("core.PositionFilter");core.PositionFilterChain=function(){var h={},m=core.PositionFilter.FilterResult.FILTER_ACCEPT,f=core.PositionFilter.FilterResult.FILTER_REJECT;this.acceptPosition=function(a){for(var c in h)if(h.hasOwnProperty(c)&&h[c].acceptPosition(a)===f)return f;return m};this.addFilter=function(a,c){h[a]=c};this.removeFilter=function(a){delete h[a]}};
+runtime.loadClass("core.PositionFilter");core.PositionFilterChain=function(){var e={},h=core.PositionFilter.FilterResult.FILTER_ACCEPT,f=core.PositionFilter.FilterResult.FILTER_REJECT;this.acceptPosition=function(n){for(var m in e)if(e.hasOwnProperty(m)&&e[m].acceptPosition(n)===f)return f;return h};this.addFilter=function(f,h){e[f]=h};this.removeFilter=function(f){delete e[f]}};
 // Input 16
-core.Async=function(){this.forEach=function(h,m,f){function a(a){b!==d&&(a?(b=d,f(a)):(b+=1,b===d&&f(null)))}var c,d=h.length,b=0;for(c=0;c<d;c+=1)m(h[c],a)}};
+core.ScheduledTask=function(e,h){function f(){e();p=!1}function n(){p&&(runtime.clearTimeout(m),p=!1)}var m,p=!1;this.trigger=function(){p||(m=runtime.setTimeout(f,h))};this.triggerImmediate=function(){n();f()};this.processRequests=function(){p&&(n(),f())};this.cancel=n;this.destroy=function(c){n();c()}};
 // Input 17
+core.Async=function(){this.forEach=function(e,h,f){function n(b){c!==p&&(b?(c=p,f(b)):(c+=1,c===p&&f(null)))}var m,p=e.length,c=0;for(m=0;m<p;m+=1)h(e[m],n)};this.destroyAll=function(e,h){function f(n,m){if(m)h(m);else if(n<e.length)e[n](function(e){f(n+1,e)});else h()}f(0,void 0)}};
+// Input 18
 /*
 
  WebODF
@@ -268,78 +283,78 @@ core.Async=function(){this.forEach=function(h,m,f){function a(a){b!==d&&(a?(b=d,
  Project home: http://www.webodf.org/
 */
 runtime.loadClass("core.RawInflate");runtime.loadClass("core.ByteArray");runtime.loadClass("core.ByteArrayWriter");runtime.loadClass("core.Base64");
-core.Zip=function(h,m){function f(a){var b=[0,1996959894,3993919788,2567524794,124634137,1886057615,3915621685,2657392035,249268274,2044508324,3772115230,2547177864,162941995,2125561021,3887607047,2428444049,498536548,1789927666,4089016648,2227061214,450548861,1843258603,4107580753,2211677639,325883990,1684777152,4251122042,2321926636,335633487,1661365465,4195302755,2366115317,997073096,1281953886,3579855332,2724688242,1006888145,1258607687,3524101629,2768942443,901097722,1119000684,3686517206,2898065728,
+core.Zip=function(e,h){function f(a){var d=[0,1996959894,3993919788,2567524794,124634137,1886057615,3915621685,2657392035,249268274,2044508324,3772115230,2547177864,162941995,2125561021,3887607047,2428444049,498536548,1789927666,4089016648,2227061214,450548861,1843258603,4107580753,2211677639,325883990,1684777152,4251122042,2321926636,335633487,1661365465,4195302755,2366115317,997073096,1281953886,3579855332,2724688242,1006888145,1258607687,3524101629,2768942443,901097722,1119000684,3686517206,2898065728,
 853044451,1172266101,3705015759,2882616665,651767980,1373503546,3369554304,3218104598,565507253,1454621731,3485111705,3099436303,671266974,1594198024,3322730930,2970347812,795835527,1483230225,3244367275,3060149565,1994146192,31158534,2563907772,4023717930,1907459465,112637215,2680153253,3904427059,2013776290,251722036,2517215374,3775830040,2137656763,141376813,2439277719,3865271297,1802195444,476864866,2238001368,4066508878,1812370925,453092731,2181625025,4111451223,1706088902,314042704,2344532202,
 4240017532,1658658271,366619977,2362670323,4224994405,1303535960,984961486,2747007092,3569037538,1256170817,1037604311,2765210733,3554079995,1131014506,879679996,2909243462,3663771856,1141124467,855842277,2852801631,3708648649,1342533948,654459306,3188396048,3373015174,1466479909,544179635,3110523913,3462522015,1591671054,702138776,2966460450,3352799412,1504918807,783551873,3082640443,3233442989,3988292384,2596254646,62317068,1957810842,3939845945,2647816111,81470997,1943803523,3814918930,2489596804,
 225274430,2053790376,3826175755,2466906013,167816743,2097651377,4027552580,2265490386,503444072,1762050814,4150417245,2154129355,426522225,1852507879,4275313526,2312317920,282753626,1742555852,4189708143,2394877945,397917763,1622183637,3604390888,2714866558,953729732,1340076626,3518719985,2797360999,1068828381,1219638859,3624741850,2936675148,906185462,1090812512,3747672003,2825379669,829329135,1181335161,3412177804,3160834842,628085408,1382605366,3423369109,3138078467,570562233,1426400815,3317316542,
 2998733608,733239954,1555261956,3268935591,3050360625,752459403,1541320221,2607071920,3965973030,1969922972,40735498,2617837225,3943577151,1913087877,83908371,2512341634,3803740692,2075208622,213261112,2463272603,3855990285,2094854071,198958881,2262029012,4057260610,1759359992,534414190,2176718541,4139329115,1873836001,414664567,2282248934,4279200368,1711684554,285281116,2405801727,4167216745,1634467795,376229701,2685067896,3608007406,1308918612,956543938,2808555105,3495958263,1231636301,1047427035,
-2932959818,3654703836,1088359270,936918E3,2847714899,3736837829,1202900863,817233897,3183342108,3401237130,1404277552,615818150,3134207493,3453421203,1423857449,601450431,3009837614,3294710456,1567103746,711928724,3020668471,3272380065,1510334235,755167117],c,e,d=a.length,g=0,g=0;c=-1;for(e=0;e<d;e+=1)g=(c^a[e])&255,g=b[g],c=c>>>8^g;return c^-1}function a(a){return new Date((a>>25&127)+1980,(a>>21&15)-1,a>>16&31,a>>11&15,a>>5&63,(a&31)<<1)}function c(a){var b=a.getFullYear();return 1980>b?0:b-1980<<
-25|a.getMonth()+1<<21|a.getDate()<<16|a.getHours()<<11|a.getMinutes()<<5|a.getSeconds()>>1}function d(b,c){var e,d,g,l,k,n,f,h=this;this.load=function(a){if(void 0!==h.data)a(null,h.data);else{var c=k+34+d+g+256;c+f>u&&(c=u-f);runtime.read(b,f,c,function(c,e){if(c||null===e)a(c,e);else a:{var d=e,g=new core.ByteArray(d),v=g.readUInt32LE(),f;if(67324752!==v)a("File entry signature is wrong."+v.toString()+" "+d.length.toString(),null);else{g.pos+=22;v=g.readUInt16LE();f=g.readUInt16LE();g.pos+=v+f;
-if(l){d=d.slice(g.pos,g.pos+k);if(k!==d.length){a("The amount of compressed bytes read was "+d.length.toString()+" instead of "+k.toString()+" for "+h.filename+" in "+b+".",null);break a}d=x(d,n)}else d=d.slice(g.pos,g.pos+n);n!==d.length?a("The amount of bytes read was "+d.length.toString()+" instead of "+n.toString()+" for "+h.filename+" in "+b+".",null):(h.data=d,a(null,d))}}})}};this.set=function(a,b,c,e){h.filename=a;h.data=b;h.compressed=c;h.date=e};this.error=null;c&&(e=c.readUInt32LE(),33639248!==
-e?this.error="Central directory entry has wrong signature at position "+(c.pos-4).toString()+' for file "'+b+'": '+c.data.length.toString():(c.pos+=6,l=c.readUInt16LE(),this.date=a(c.readUInt32LE()),c.readUInt32LE(),k=c.readUInt32LE(),n=c.readUInt32LE(),d=c.readUInt16LE(),g=c.readUInt16LE(),e=c.readUInt16LE(),c.pos+=8,f=c.readUInt32LE(),this.filename=runtime.byteArrayToString(c.data.slice(c.pos,c.pos+d),"utf8"),c.pos+=d+g+e))}function b(a,b){if(22!==a.length)b("Central directory length should be 22.",
-r);else{var c=new core.ByteArray(a),e;e=c.readUInt32LE();101010256!==e?b("Central directory signature is wrong: "+e.toString(),r):(e=c.readUInt16LE(),0!==e?b("Zip files with non-zero disk numbers are not supported.",r):(e=c.readUInt16LE(),0!==e?b("Zip files with non-zero disk numbers are not supported.",r):(e=c.readUInt16LE(),q=c.readUInt16LE(),e!==q?b("Number of entries is inconsistent.",r):(e=c.readUInt32LE(),c=c.readUInt16LE(),c=u-22-e,runtime.read(h,c,u-c,function(a,c){if(a||null===c)b(a,r);else a:{var e=
-new core.ByteArray(c),g,k;l=[];for(g=0;g<q;g+=1){k=new d(h,e);if(k.error){b(k.error,r);break a}l[l.length]=k}b(null,r)}})))))}}function k(a,b){var c=null,e,d;for(d=0;d<l.length;d+=1)if(e=l[d],e.filename===a){c=e;break}c?c.data?b(null,c.data):c.load(b):b(a+" not found.",null)}function p(a){var b=new core.ByteArrayWriter("utf8"),e=0;b.appendArray([80,75,3,4,20,0,0,0,0,0]);a.data&&(e=a.data.length);b.appendUInt32LE(c(a.date));b.appendUInt32LE(f(a.data));b.appendUInt32LE(e);b.appendUInt32LE(e);b.appendUInt16LE(a.filename.length);
-b.appendUInt16LE(0);b.appendString(a.filename);a.data&&b.appendByteArray(a.data);return b}function e(a,b){var e=new core.ByteArrayWriter("utf8"),d=0;e.appendArray([80,75,1,2,20,0,20,0,0,0,0,0]);a.data&&(d=a.data.length);e.appendUInt32LE(c(a.date));e.appendUInt32LE(f(a.data));e.appendUInt32LE(d);e.appendUInt32LE(d);e.appendUInt16LE(a.filename.length);e.appendArray([0,0,0,0,0,0,0,0,0,0,0,0]);e.appendUInt32LE(b);e.appendString(a.filename);return e}function s(a,b){if(a===l.length)b(null);else{var c=l[a];
-void 0!==c.data?s(a+1,b):c.load(function(c){c?b(c):s(a+1,b)})}}function n(a,b){s(0,function(c){if(c)b(c);else{c=new core.ByteArrayWriter("utf8");var d,g,k,n=[0];for(d=0;d<l.length;d+=1)c.appendByteArrayWriter(p(l[d])),n.push(c.getLength());k=c.getLength();for(d=0;d<l.length;d+=1)g=l[d],c.appendByteArrayWriter(e(g,n[d]));d=c.getLength()-k;c.appendArray([80,75,5,6,0,0,0,0]);c.appendUInt16LE(l.length);c.appendUInt16LE(l.length);c.appendUInt32LE(d);c.appendUInt32LE(k);c.appendArray([0,0]);a(c.getByteArray())}})}
-function g(a,b){n(function(c){runtime.writeFile(a,c,b)},b)}var l,u,q,x=(new core.RawInflate).inflate,r=this,y=new core.Base64;this.load=k;this.save=function(a,b,c,e){var g,k;for(g=0;g<l.length;g+=1)if(k=l[g],k.filename===a){k.set(a,b,c,e);return}k=new d(h);k.set(a,b,c,e);l.push(k)};this.write=function(a){g(h,a)};this.writeAs=g;this.createByteArray=n;this.loadContentXmlAsFragments=function(a,b){r.loadAsString(a,function(a,c){if(a)return b.rootElementReady(a);b.rootElementReady(null,c,!0)})};this.loadAsString=
-function(a,b){k(a,function(a,c){if(a||null===c)return b(a,null);var e=runtime.byteArrayToString(c,"utf8");b(null,e)})};this.loadAsDOM=function(a,b){r.loadAsString(a,function(a,c){if(a||null===c)b(a,null);else{var e=(new DOMParser).parseFromString(c,"text/xml");b(null,e)}})};this.loadAsDataURL=function(a,b,c){k(a,function(a,e){if(a)return c(a,null);var d=0,g;b||(b=80===e[1]&&78===e[2]&&71===e[3]?"image/png":255===e[0]&&216===e[1]&&255===e[2]?"image/jpeg":71===e[0]&&73===e[1]&&70===e[2]?"image/gif":
-"");for(g="data:"+b+";base64,";d<e.length;)g+=y.convertUTF8ArrayToBase64(e.slice(d,Math.min(d+45E3,e.length))),d+=45E3;c(null,g)})};this.getEntries=function(){return l.slice()};u=-1;null===m?l=[]:runtime.getFileSize(h,function(a){u=a;0>u?m("File '"+h+"' cannot be read.",r):runtime.read(h,u-22,22,function(a,c){a||null===m||null===c?m(a,r):b(c,m)})})};
-// Input 18
-core.CSSUnits=function(){var h={"in":1,cm:2.54,mm:25.4,pt:72,pc:12};this.convert=function(m,f,a){return m*h[a]/h[f]};this.convertMeasure=function(h,f){var a,c;h&&f?(a=parseFloat(h),c=h.replace(a.toString(),""),a=this.convert(a,c,f)):a="";return a.toString()};this.getUnits=function(h){return h.substr(h.length-2,h.length)}};
+2932959818,3654703836,1088359270,936918E3,2847714899,3736837829,1202900863,817233897,3183342108,3401237130,1404277552,615818150,3134207493,3453421203,1423857449,601450431,3009837614,3294710456,1567103746,711928724,3020668471,3272380065,1510334235,755167117],b,c,g=a.length,l=0,l=0;b=-1;for(c=0;c<g;c+=1)l=(b^a[c])&255,l=d[l],b=b>>>8^l;return b^-1}function n(a){return new Date((a>>25&127)+1980,(a>>21&15)-1,a>>16&31,a>>11&15,a>>5&63,(a&31)<<1)}function m(a){var d=a.getFullYear();return 1980>d?0:d-1980<<
+25|a.getMonth()+1<<21|a.getDate()<<16|a.getHours()<<11|a.getMinutes()<<5|a.getSeconds()>>1}function p(a,d){var b,c,g,l,k,f,e,q=this;this.load=function(d){if(void 0!==q.data)d(null,q.data);else{var b=k+34+c+g+256;b+e>r&&(b=r-e);runtime.read(a,e,b,function(b,c){if(b||null===c)d(b,c);else a:{var g=c,e=new core.ByteArray(g),h=e.readUInt32LE(),r;if(67324752!==h)d("File entry signature is wrong."+h.toString()+" "+g.length.toString(),null);else{e.pos+=22;h=e.readUInt16LE();r=e.readUInt16LE();e.pos+=h+r;
+if(l){g=g.slice(e.pos,e.pos+k);if(k!==g.length){d("The amount of compressed bytes read was "+g.length.toString()+" instead of "+k.toString()+" for "+q.filename+" in "+a+".",null);break a}g=w(g,f)}else g=g.slice(e.pos,e.pos+f);f!==g.length?d("The amount of bytes read was "+g.length.toString()+" instead of "+f.toString()+" for "+q.filename+" in "+a+".",null):(q.data=g,d(null,g))}}})}};this.set=function(a,d,b,c){q.filename=a;q.data=d;q.compressed=b;q.date=c};this.error=null;d&&(b=d.readUInt32LE(),33639248!==
+b?this.error="Central directory entry has wrong signature at position "+(d.pos-4).toString()+' for file "'+a+'": '+d.data.length.toString():(d.pos+=6,l=d.readUInt16LE(),this.date=n(d.readUInt32LE()),d.readUInt32LE(),k=d.readUInt32LE(),f=d.readUInt32LE(),c=d.readUInt16LE(),g=d.readUInt16LE(),b=d.readUInt16LE(),d.pos+=8,e=d.readUInt32LE(),this.filename=runtime.byteArrayToString(d.data.slice(d.pos,d.pos+c),"utf8"),d.pos+=c+g+b))}function c(a,d){if(22!==a.length)d("Central directory length should be 22.",
+v);else{var b=new core.ByteArray(a),c;c=b.readUInt32LE();101010256!==c?d("Central directory signature is wrong: "+c.toString(),v):(c=b.readUInt16LE(),0!==c?d("Zip files with non-zero disk numbers are not supported.",v):(c=b.readUInt16LE(),0!==c?d("Zip files with non-zero disk numbers are not supported.",v):(c=b.readUInt16LE(),t=b.readUInt16LE(),c!==t?d("Number of entries is inconsistent.",v):(c=b.readUInt32LE(),b=b.readUInt16LE(),b=r-22-c,runtime.read(e,b,r-b,function(a,b){if(a||null===b)d(a,v);else a:{var c=
+new core.ByteArray(b),g,k;l=[];for(g=0;g<t;g+=1){k=new p(e,c);if(k.error){d(k.error,v);break a}l[l.length]=k}d(null,v)}})))))}}function b(a,d){var b=null,c,g;for(g=0;g<l.length;g+=1)if(c=l[g],c.filename===a){b=c;break}b?b.data?d(null,b.data):b.load(d):d(a+" not found.",null)}function a(a){var d=new core.ByteArrayWriter("utf8"),b=0;d.appendArray([80,75,3,4,20,0,0,0,0,0]);a.data&&(b=a.data.length);d.appendUInt32LE(m(a.date));d.appendUInt32LE(f(a.data));d.appendUInt32LE(b);d.appendUInt32LE(b);d.appendUInt16LE(a.filename.length);
+d.appendUInt16LE(0);d.appendString(a.filename);a.data&&d.appendByteArray(a.data);return d}function d(a,d){var b=new core.ByteArrayWriter("utf8"),c=0;b.appendArray([80,75,1,2,20,0,20,0,0,0,0,0]);a.data&&(c=a.data.length);b.appendUInt32LE(m(a.date));b.appendUInt32LE(f(a.data));b.appendUInt32LE(c);b.appendUInt32LE(c);b.appendUInt16LE(a.filename.length);b.appendArray([0,0,0,0,0,0,0,0,0,0,0,0]);b.appendUInt32LE(d);b.appendString(a.filename);return b}function k(a,d){if(a===l.length)d(null);else{var b=l[a];
+void 0!==b.data?k(a+1,d):b.load(function(b){b?d(b):k(a+1,d)})}}function g(b,c){k(0,function(g){if(g)c(g);else{g=new core.ByteArrayWriter("utf8");var k,f,e,q=[0];for(k=0;k<l.length;k+=1)g.appendByteArrayWriter(a(l[k])),q.push(g.getLength());e=g.getLength();for(k=0;k<l.length;k+=1)f=l[k],g.appendByteArrayWriter(d(f,q[k]));k=g.getLength()-e;g.appendArray([80,75,5,6,0,0,0,0]);g.appendUInt16LE(l.length);g.appendUInt16LE(l.length);g.appendUInt32LE(k);g.appendUInt32LE(e);g.appendArray([0,0]);b(g.getByteArray())}})}
+function q(a,d){g(function(b){runtime.writeFile(a,b,d)},d)}var l,r,t,w=(new core.RawInflate).inflate,v=this,y=new core.Base64;this.load=b;this.save=function(a,d,b,c){var g,k;for(g=0;g<l.length;g+=1)if(k=l[g],k.filename===a){k.set(a,d,b,c);return}k=new p(e);k.set(a,d,b,c);l.push(k)};this.remove=function(a){var d,b;for(d=0;d<l.length;d+=1)if(b=l[d],b.filename===a)return l.splice(d,1),!0;return!1};this.write=function(a){q(e,a)};this.writeAs=q;this.createByteArray=g;this.loadContentXmlAsFragments=function(a,
+d){v.loadAsString(a,function(a,b){if(a)return d.rootElementReady(a);d.rootElementReady(null,b,!0)})};this.loadAsString=function(a,d){b(a,function(a,b){if(a||null===b)return d(a,null);var c=runtime.byteArrayToString(b,"utf8");d(null,c)})};this.loadAsDOM=function(a,d){v.loadAsString(a,function(a,b){if(a||null===b)d(a,null);else{var c=(new DOMParser).parseFromString(b,"text/xml");d(null,c)}})};this.loadAsDataURL=function(a,d,c){b(a,function(a,b){if(a)return c(a,null);var g=0,k;d||(d=80===b[1]&&78===
+b[2]&&71===b[3]?"image/png":255===b[0]&&216===b[1]&&255===b[2]?"image/jpeg":71===b[0]&&73===b[1]&&70===b[2]?"image/gif":"");for(k="data:"+d+";base64,";g<b.length;)k+=y.convertUTF8ArrayToBase64(b.slice(g,Math.min(g+45E3,b.length))),g+=45E3;c(null,k)})};this.getEntries=function(){return l.slice()};r=-1;null===h?l=[]:runtime.getFileSize(e,function(a){r=a;0>r?h("File '"+e+"' cannot be read.",v):runtime.read(e,r-22,22,function(a,d){a||null===h||null===d?h(a,v):c(d,h)})})};
 // Input 19
-xmldom.LSSerializerFilter=function(){};
+core.CSSUnits=function(){var e={"in":1,cm:2.54,mm:25.4,pt:72,pc:12};this.convert=function(h,f,n){return h*e[n]/e[f]};this.convertMeasure=function(e,f){var n,m;e&&f?(n=parseFloat(e),m=e.replace(n.toString(),""),n=this.convert(n,m,f)):n="";return n.toString()};this.getUnits=function(e){return e.substr(e.length-2,e.length)}};
 // Input 20
-"function"!==typeof Object.create&&(Object.create=function(h){var m=function(){};m.prototype=h;return new m});
-xmldom.LSSerializer=function(){function h(a){var d=a||{},b=function(a){var b={},c;for(c in a)a.hasOwnProperty(c)&&(b[a[c]]=c);return b}(a),k=[d],f=[b],e=0;this.push=function(){e+=1;d=k[e]=Object.create(d);b=f[e]=Object.create(b)};this.pop=function(){k[e]=void 0;f[e]=void 0;e-=1;d=k[e];b=f[e]};this.getLocalNamespaceDefinitions=function(){return b};this.getQName=function(a){var c=a.namespaceURI,e=0,l;if(!c)return a.localName;if(l=b[c])return l+":"+a.localName;do{l||!a.prefix?(l="ns"+e,e+=1):l=a.prefix;
-if(d[l]===c)break;if(!d[l]){d[l]=c;b[c]=l;break}l=null}while(null===l);return l+":"+a.localName}}function m(a){return a.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/'/g,"&apos;").replace(/"/g,"&quot;")}function f(c,d){var b="",k=a.filter?a.filter.acceptNode(d):NodeFilter.FILTER_ACCEPT,h;if(k===NodeFilter.FILTER_ACCEPT&&d.nodeType===Node.ELEMENT_NODE){c.push();h=c.getQName(d);var e,s=d.attributes,n,g,l,u="",q;e="<"+h;n=s.length;for(g=0;g<n;g+=1)l=s.item(g),"http://www.w3.org/2000/xmlns/"!==
-l.namespaceURI&&(q=a.filter?a.filter.acceptNode(l):NodeFilter.FILTER_ACCEPT,q===NodeFilter.FILTER_ACCEPT&&(q=c.getQName(l),l="string"===typeof l.value?m(l.value):l.value,u+=" "+(q+'="'+l+'"')));n=c.getLocalNamespaceDefinitions();for(g in n)n.hasOwnProperty(g)&&((s=n[g])?"xmlns"!==s&&(e+=" xmlns:"+n[g]+'="'+g+'"'):e+=' xmlns="'+g+'"');b+=e+(u+">")}if(k===NodeFilter.FILTER_ACCEPT||k===NodeFilter.FILTER_SKIP){for(k=d.firstChild;k;)b+=f(c,k),k=k.nextSibling;d.nodeValue&&(b+=m(d.nodeValue))}h&&(b+="</"+
-h+">",c.pop());return b}var a=this;this.filter=null;this.writeToString=function(a,d){if(!a)return"";var b=new h(d);return f(b,a)}};
+xmldom.LSSerializerFilter=function(){};
 // Input 21
-xmldom.RelaxNGParser=function(){function h(a,b){this.message=function(){b&&(a+=1===b.nodeType?" Element ":" Node ",a+=b.nodeName,b.nodeValue&&(a+=" with value '"+b.nodeValue+"'"),a+=".");return a}}function m(a){if(2>=a.e.length)return a;var b={name:a.name,e:a.e.slice(0,2)};return m({name:a.name,e:[b].concat(a.e.slice(2))})}function f(a){a=a.split(":",2);var b="",c;1===a.length?a=["",a[0]]:b=a[0];for(c in k)k[c]===b&&(a[0]=c);return a}function a(b,c){for(var d=0,g,l,k=b.name;b.e&&d<b.e.length;)if(g=
-b.e[d],"ref"===g.name){l=c[g.a.name];if(!l)throw g.a.name+" was not defined.";g=b.e.slice(d+1);b.e=b.e.slice(0,d);b.e=b.e.concat(l.e);b.e=b.e.concat(g)}else d+=1,a(g,c);g=b.e;"choice"!==k||g&&g[1]&&"empty"!==g[1].name||(g&&g[0]&&"empty"!==g[0].name?(g[1]=g[0],g[0]={name:"empty"}):(delete b.e,b.name="empty"));if("group"===k||"interleave"===k)"empty"===g[0].name?"empty"===g[1].name?(delete b.e,b.name="empty"):(k=b.name=g[1].name,b.names=g[1].names,g=b.e=g[1].e):"empty"===g[1].name&&(k=b.name=g[0].name,
-b.names=g[0].names,g=b.e=g[0].e);"oneOrMore"===k&&"empty"===g[0].name&&(delete b.e,b.name="empty");if("attribute"===k){l=b.names?b.names.length:0;for(var h,m=[],r=[],d=0;d<l;d+=1)h=f(b.names[d]),r[d]=h[0],m[d]=h[1];b.localnames=m;b.namespaces=r}"interleave"===k&&("interleave"===g[0].name?b.e="interleave"===g[1].name?g[0].e.concat(g[1].e):[g[1]].concat(g[0].e):"interleave"===g[1].name&&(b.e=[g[0]].concat(g[1].e)))}function c(a,b){for(var d=0,g;a.e&&d<a.e.length;)g=a.e[d],"elementref"===g.name?(g.id=
-g.id||0,a.e[d]=b[g.id]):"element"!==g.name&&c(g,b),d+=1}var d=this,b,k={"http://www.w3.org/XML/1998/namespace":"xml"},p;p=function(a,b,c){var d=[],l,h,q=a.localName,x=[];l=a.attributes;var r=q,y=x,t={},w,v;for(w=0;w<l.length;w+=1)if(v=l.item(w),v.namespaceURI)"http://www.w3.org/2000/xmlns/"===v.namespaceURI&&(k[v.value]=v.localName);else{"name"!==v.localName||"element"!==r&&"attribute"!==r||y.push(v.value);if("name"===v.localName||"combine"===v.localName||"type"===v.localName){var C=v,J;J=v.value;
-J=J.replace(/^\s\s*/,"");for(var E=/\s/,K=J.length-1;E.test(J.charAt(K));)K-=1;J=J.slice(0,K+1);C.value=J}t[v.localName]=v.value}l=t;l.combine=l.combine||void 0;a=a.firstChild;r=d;y=x;for(t="";a;){if(a.nodeType===Node.ELEMENT_NODE&&"http://relaxng.org/ns/structure/1.0"===a.namespaceURI){if(w=p(a,b,r))"name"===w.name?y.push(k[w.a.ns]+":"+w.text):"choice"===w.name&&(w.names&&w.names.length)&&(y=y.concat(w.names),delete w.names),r.push(w)}else a.nodeType===Node.TEXT_NODE&&(t+=a.nodeValue);a=a.nextSibling}a=
-t;"value"!==q&&"param"!==q&&(a=/^\s*([\s\S]*\S)?\s*$/.exec(a)[1]);"value"===q&&void 0===l.type&&(l.type="token",l.datatypeLibrary="");"attribute"!==q&&"element"!==q||void 0===l.name||(h=f(l.name),d=[{name:"name",text:h[1],a:{ns:h[0]}}].concat(d),delete l.name);"name"===q||"nsName"===q||"value"===q?void 0===l.ns&&(l.ns=""):delete l.ns;"name"===q&&(h=f(a),l.ns=h[0],a=h[1]);1<d.length&&("define"===q||"oneOrMore"===q||"zeroOrMore"===q||"optional"===q||"list"===q||"mixed"===q)&&(d=[{name:"group",e:m({name:"group",
-e:d}).e}]);2<d.length&&"element"===q&&(d=[d[0]].concat({name:"group",e:m({name:"group",e:d.slice(1)}).e}));1===d.length&&"attribute"===q&&d.push({name:"text",text:a});1!==d.length||"choice"!==q&&"group"!==q&&"interleave"!==q?2<d.length&&("choice"===q||"group"===q||"interleave"===q)&&(d=m({name:q,e:d}).e):(q=d[0].name,x=d[0].names,l=d[0].a,a=d[0].text,d=d[0].e);"mixed"===q&&(q="interleave",d=[d[0],{name:"text"}]);"optional"===q&&(q="choice",d=[d[0],{name:"empty"}]);"zeroOrMore"===q&&(q="choice",d=
-[{name:"oneOrMore",e:[d[0]]},{name:"empty"}]);if("define"===q&&l.combine){a:{r=l.combine;y=l.name;t=d;for(w=0;c&&w<c.length;w+=1)if(v=c[w],"define"===v.name&&v.a&&v.a.name===y){v.e=[{name:r,e:v.e.concat(t)}];c=v;break a}c=null}if(c)return}c={name:q};d&&0<d.length&&(c.e=d);for(h in l)if(l.hasOwnProperty(h)){c.a=l;break}void 0!==a&&(c.text=a);x&&0<x.length&&(c.names=x);"element"===q&&(c.id=b.length,b.push(c),c={name:"elementref",id:c.id});return c};this.parseRelaxNGDOM=function(e,f){var n=[],g=p(e&&
-e.documentElement,n,void 0),l,m,q={};for(l=0;l<g.e.length;l+=1)m=g.e[l],"define"===m.name?q[m.a.name]=m:"start"===m.name&&(b=m);if(!b)return[new h("No Relax NG start element was found.")];a(b,q);for(l in q)q.hasOwnProperty(l)&&a(q[l],q);for(l=0;l<n.length;l+=1)a(n[l],q);f&&(d.rootPattern=f(b.e[0],n));c(b,n);for(l=0;l<n.length;l+=1)c(n[l],n);d.start=b;d.elements=n;d.nsmap=k;return null}};
+"function"!==typeof Object.create&&(Object.create=function(e){var h=function(){};h.prototype=e;return new h});
+xmldom.LSSerializer=function(){function e(e){var f=e||{},c=function(a){var d={},b;for(b in a)a.hasOwnProperty(b)&&(d[a[b]]=b);return d}(e),b=[f],a=[c],d=0;this.push=function(){d+=1;f=b[d]=Object.create(f);c=a[d]=Object.create(c)};this.pop=function(){b[d]=void 0;a[d]=void 0;d-=1;f=b[d];c=a[d]};this.getLocalNamespaceDefinitions=function(){return c};this.getQName=function(a){var d=a.namespaceURI,b=0,l;if(!d)return a.localName;if(l=c[d])return l+":"+a.localName;do{l||!a.prefix?(l="ns"+b,b+=1):l=a.prefix;
+if(f[l]===d)break;if(!f[l]){f[l]=d;c[d]=l;break}l=null}while(null===l);return l+":"+a.localName}}function h(f){return f.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/'/g,"&apos;").replace(/"/g,"&quot;")}function f(e,p){var c="",b=n.filter?n.filter.acceptNode(p):NodeFilter.FILTER_ACCEPT,a;if(b===NodeFilter.FILTER_ACCEPT&&p.nodeType===Node.ELEMENT_NODE){e.push();a=e.getQName(p);var d,k=p.attributes,g,q,l,r="",t;d="<"+a;g=k.length;for(q=0;q<g;q+=1)l=k.item(q),"http://www.w3.org/2000/xmlns/"!==
+l.namespaceURI&&(t=n.filter?n.filter.acceptNode(l):NodeFilter.FILTER_ACCEPT,t===NodeFilter.FILTER_ACCEPT&&(t=e.getQName(l),l="string"===typeof l.value?h(l.value):l.value,r+=" "+(t+'="'+l+'"')));g=e.getLocalNamespaceDefinitions();for(q in g)g.hasOwnProperty(q)&&((k=g[q])?"xmlns"!==k&&(d+=" xmlns:"+g[q]+'="'+q+'"'):d+=' xmlns="'+q+'"');c+=d+(r+">")}if(b===NodeFilter.FILTER_ACCEPT||b===NodeFilter.FILTER_SKIP){for(b=p.firstChild;b;)c+=f(e,b),b=b.nextSibling;p.nodeValue&&(c+=h(p.nodeValue))}a&&(c+="</"+
+a+">",e.pop());return c}var n=this;this.filter=null;this.writeToString=function(h,p){if(!h)return"";var c=new e(p);return f(c,h)}};
 // Input 22
-runtime.loadClass("xmldom.RelaxNGParser");
-xmldom.RelaxNG=function(){function h(a){return function(){var b;return function(){void 0===b&&(b=a());return b}}()}function m(a,b){return function(){var c={},d=0;return function(e){var g=e.hash||e.toString(),l;l=c[g];if(void 0!==l)return l;c[g]=l=b(e);l.hash=a+d.toString();d+=1;return l}}()}function f(a){return function(){var b={};return function(c){var d,e;e=b[c.localName];if(void 0===e)b[c.localName]=e={};else if(d=e[c.namespaceURI],void 0!==d)return d;return e[c.namespaceURI]=d=a(c)}}()}function a(a,
-b,c){return function(){var d={},e=0;return function(g,l){var k=b&&b(g,l),n,f;if(void 0!==k)return k;k=g.hash||g.toString();n=l.hash||l.toString();f=d[k];if(void 0===f)d[k]=f={};else if(k=f[n],void 0!==k)return k;f[n]=k=c(g,l);k.hash=a+e.toString();e+=1;return k}}()}function c(a,b){"choice"===b.p1.type?c(a,b.p1):a[b.p1.hash]=b.p1;"choice"===b.p2.type?c(a,b.p2):a[b.p2.hash]=b.p2}function d(a,b){return{type:"element",nc:a,nullable:!1,textDeriv:function(){return w},startTagOpenDeriv:function(c){return a.contains(c)?
-l(b,v):w},attDeriv:function(){return w},startTagCloseDeriv:function(){return this}}}function b(){return{type:"list",nullable:!1,hash:"list",textDeriv:function(){return v}}}function k(a,b,c,d){if(b===w)return w;if(d>=c.length)return b;0===d&&(d=0);for(var g=c.item(d);g.namespaceURI===e;){d+=1;if(d>=c.length)return b;g=c.item(d)}return g=k(a,b.attDeriv(a,c.item(d)),c,d+1)}function p(a,b,c){c.e[0].a?(a.push(c.e[0].text),b.push(c.e[0].a.ns)):p(a,b,c.e[0]);c.e[1].a?(a.push(c.e[1].text),b.push(c.e[1].a.ns)):
-p(a,b,c.e[1])}var e="http://www.w3.org/2000/xmlns/",s,n,g,l,u,q,x,r,y,t,w={type:"notAllowed",nullable:!1,hash:"notAllowed",textDeriv:function(){return w},startTagOpenDeriv:function(){return w},attDeriv:function(){return w},startTagCloseDeriv:function(){return w},endTagDeriv:function(){return w}},v={type:"empty",nullable:!0,hash:"empty",textDeriv:function(){return w},startTagOpenDeriv:function(){return w},attDeriv:function(){return w},startTagCloseDeriv:function(){return v},endTagDeriv:function(){return w}},
-C={type:"text",nullable:!0,hash:"text",textDeriv:function(){return C},startTagOpenDeriv:function(){return w},attDeriv:function(){return w},startTagCloseDeriv:function(){return C},endTagDeriv:function(){return w}},J,E,K;s=a("choice",function(a,b){if(a===w)return b;if(b===w||a===b)return a},function(a,b){var d={},e;c(d,{p1:a,p2:b});b=a=void 0;for(e in d)d.hasOwnProperty(e)&&(void 0===a?a=d[e]:b=void 0===b?d[e]:s(b,d[e]));return function(a,b){return{type:"choice",p1:a,p2:b,nullable:a.nullable||b.nullable,
-textDeriv:function(c,d){return s(a.textDeriv(c,d),b.textDeriv(c,d))},startTagOpenDeriv:f(function(c){return s(a.startTagOpenDeriv(c),b.startTagOpenDeriv(c))}),attDeriv:function(c,d){return s(a.attDeriv(c,d),b.attDeriv(c,d))},startTagCloseDeriv:h(function(){return s(a.startTagCloseDeriv(),b.startTagCloseDeriv())}),endTagDeriv:h(function(){return s(a.endTagDeriv(),b.endTagDeriv())})}}(a,b)});n=function(a,b,c){return function(){var d={},e=0;return function(g,l){var k=b&&b(g,l),n,f;if(void 0!==k)return k;
-k=g.hash||g.toString();n=l.hash||l.toString();k<n&&(f=k,k=n,n=f,f=g,g=l,l=f);f=d[k];if(void 0===f)d[k]=f={};else if(k=f[n],void 0!==k)return k;f[n]=k=c(g,l);k.hash=a+e.toString();e+=1;return k}}()}("interleave",function(a,b){if(a===w||b===w)return w;if(a===v)return b;if(b===v)return a},function(a,b){return{type:"interleave",p1:a,p2:b,nullable:a.nullable&&b.nullable,textDeriv:function(c,d){return s(n(a.textDeriv(c,d),b),n(a,b.textDeriv(c,d)))},startTagOpenDeriv:f(function(c){return s(J(function(a){return n(a,
-b)},a.startTagOpenDeriv(c)),J(function(b){return n(a,b)},b.startTagOpenDeriv(c)))}),attDeriv:function(c,d){return s(n(a.attDeriv(c,d),b),n(a,b.attDeriv(c,d)))},startTagCloseDeriv:h(function(){return n(a.startTagCloseDeriv(),b.startTagCloseDeriv())})}});g=a("group",function(a,b){if(a===w||b===w)return w;if(a===v)return b;if(b===v)return a},function(a,b){return{type:"group",p1:a,p2:b,nullable:a.nullable&&b.nullable,textDeriv:function(c,d){var e=g(a.textDeriv(c,d),b);return a.nullable?s(e,b.textDeriv(c,
-d)):e},startTagOpenDeriv:function(c){var d=J(function(a){return g(a,b)},a.startTagOpenDeriv(c));return a.nullable?s(d,b.startTagOpenDeriv(c)):d},attDeriv:function(c,d){return s(g(a.attDeriv(c,d),b),g(a,b.attDeriv(c,d)))},startTagCloseDeriv:h(function(){return g(a.startTagCloseDeriv(),b.startTagCloseDeriv())})}});l=a("after",function(a,b){if(a===w||b===w)return w},function(a,b){return{type:"after",p1:a,p2:b,nullable:!1,textDeriv:function(c,d){return l(a.textDeriv(c,d),b)},startTagOpenDeriv:f(function(c){return J(function(a){return l(a,
-b)},a.startTagOpenDeriv(c))}),attDeriv:function(c,d){return l(a.attDeriv(c,d),b)},startTagCloseDeriv:h(function(){return l(a.startTagCloseDeriv(),b)}),endTagDeriv:h(function(){return a.nullable?b:w})}});u=m("oneormore",function(a){return a===w?w:{type:"oneOrMore",p:a,nullable:a.nullable,textDeriv:function(b,c){return g(a.textDeriv(b,c),s(this,v))},startTagOpenDeriv:function(b){var c=this;return J(function(a){return g(a,s(c,v))},a.startTagOpenDeriv(b))},attDeriv:function(b,c){return g(a.attDeriv(b,
-c),s(this,v))},startTagCloseDeriv:h(function(){return u(a.startTagCloseDeriv())})}});x=a("attribute",void 0,function(a,b){return{type:"attribute",nullable:!1,nc:a,p:b,attDeriv:function(c,d){return a.contains(d)&&(b.nullable&&/^\s+$/.test(d.nodeValue)||b.textDeriv(c,d.nodeValue).nullable)?v:w},startTagCloseDeriv:function(){return w}}});q=m("value",function(a){return{type:"value",nullable:!1,value:a,textDeriv:function(b,c){return c===a?v:w},attDeriv:function(){return w},startTagCloseDeriv:function(){return this}}});
-y=m("data",function(a){return{type:"data",nullable:!1,dataType:a,textDeriv:function(){return v},attDeriv:function(){return w},startTagCloseDeriv:function(){return this}}});J=function N(a,b){return"after"===b.type?l(b.p1,a(b.p2)):"choice"===b.type?s(N(a,b.p1),N(a,b.p2)):b};E=function(a,b,c){var d=c.currentNode;b=b.startTagOpenDeriv(d);b=k(a,b,d.attributes,0);var e=b=b.startTagCloseDeriv(),d=c.currentNode;b=c.firstChild();for(var g=[],l;b;)b.nodeType===Node.ELEMENT_NODE?g.push(b):b.nodeType!==Node.TEXT_NODE||
-/^\s*$/.test(b.nodeValue)||g.push(b.nodeValue),b=c.nextSibling();0===g.length&&(g=[""]);l=e;for(e=0;l!==w&&e<g.length;e+=1)b=g[e],"string"===typeof b?l=/^\s*$/.test(b)?s(l,l.textDeriv(a,b)):l.textDeriv(a,b):(c.currentNode=b,l=E(a,l,c));c.currentNode=d;return b=l.endTagDeriv()};r=function(a){var b,c,d;if("name"===a.name)b=a.text,c=a.a.ns,a={name:b,ns:c,hash:"{"+c+"}"+b,contains:function(a){return a.namespaceURI===c&&a.localName===b}};else if("choice"===a.name){b=[];c=[];p(b,c,a);a="";for(d=0;d<b.length;d+=
-1)a+="{"+c[d]+"}"+b[d]+",";a={hash:a,contains:function(a){var d;for(d=0;d<b.length;d+=1)if(b[d]===a.localName&&c[d]===a.namespaceURI)return!0;return!1}}}else a={hash:"anyName",contains:function(){return!0}};return a};t=function H(a,c){var e,l;if("elementref"===a.name){e=a.id||0;a=c[e];if(void 0!==a.name){var k=a;e=c[k.id]={hash:"element"+k.id.toString()};k=d(r(k.e[0]),t(k.e[1],c));for(l in k)k.hasOwnProperty(l)&&(e[l]=k[l]);return e}return a}switch(a.name){case "empty":return v;case "notAllowed":return w;
-case "text":return C;case "choice":return s(H(a.e[0],c),H(a.e[1],c));case "interleave":e=H(a.e[0],c);for(l=1;l<a.e.length;l+=1)e=n(e,H(a.e[l],c));return e;case "group":return g(H(a.e[0],c),H(a.e[1],c));case "oneOrMore":return u(H(a.e[0],c));case "attribute":return x(r(a.e[0]),H(a.e[1],c));case "value":return q(a.text);case "data":return e=a.a&&a.a.type,void 0===e&&(e=""),y(e);case "list":return b()}throw"No support for "+a.name;};this.makePattern=function(a,b){var c={},d;for(d in b)b.hasOwnProperty(d)&&
-(c[d]=b[d]);return d=t(a,c)};this.validate=function(a,b){var c;a.currentNode=a.root;c=E(null,K,a);c.nullable?b(null):(runtime.log("Error in Relax NG validation: "+c),b(["Error in Relax NG validation: "+c]))};this.init=function(a){K=a}};
+xmldom.RelaxNGParser=function(){function e(a,b){this.message=function(){b&&(a+=1===b.nodeType?" Element ":" Node ",a+=b.nodeName,b.nodeValue&&(a+=" with value '"+b.nodeValue+"'"),a+=".");return a}}function h(a){if(2>=a.e.length)return a;var b={name:a.name,e:a.e.slice(0,2)};return h({name:a.name,e:[b].concat(a.e.slice(2))})}function f(a){a=a.split(":",2);var c="",g;1===a.length?a=["",a[0]]:c=a[0];for(g in b)b[g]===c&&(a[0]=g);return a}function n(a,b){for(var c=0,e,l,h=a.name;a.e&&c<a.e.length;)if(e=
+a.e[c],"ref"===e.name){l=b[e.a.name];if(!l)throw e.a.name+" was not defined.";e=a.e.slice(c+1);a.e=a.e.slice(0,c);a.e=a.e.concat(l.e);a.e=a.e.concat(e)}else c+=1,n(e,b);e=a.e;"choice"!==h||e&&e[1]&&"empty"!==e[1].name||(e&&e[0]&&"empty"!==e[0].name?(e[1]=e[0],e[0]={name:"empty"}):(delete a.e,a.name="empty"));if("group"===h||"interleave"===h)"empty"===e[0].name?"empty"===e[1].name?(delete a.e,a.name="empty"):(h=a.name=e[1].name,a.names=e[1].names,e=a.e=e[1].e):"empty"===e[1].name&&(h=a.name=e[0].name,
+a.names=e[0].names,e=a.e=e[0].e);"oneOrMore"===h&&"empty"===e[0].name&&(delete a.e,a.name="empty");if("attribute"===h){l=a.names?a.names.length:0;for(var t,m=[],p=[],c=0;c<l;c+=1)t=f(a.names[c]),p[c]=t[0],m[c]=t[1];a.localnames=m;a.namespaces=p}"interleave"===h&&("interleave"===e[0].name?a.e="interleave"===e[1].name?e[0].e.concat(e[1].e):[e[1]].concat(e[0].e):"interleave"===e[1].name&&(a.e=[e[0]].concat(e[1].e)))}function m(a,b){for(var c=0,e;a.e&&c<a.e.length;)e=a.e[c],"elementref"===e.name?(e.id=
+e.id||0,a.e[c]=b[e.id]):"element"!==e.name&&m(e,b),c+=1}var p=this,c,b={"http://www.w3.org/XML/1998/namespace":"xml"},a;a=function(d,c,g){var e=[],l,r,t=d.localName,m=[];l=d.attributes;var p=t,n=m,x={},u,s;for(u=0;u<l.length;u+=1)if(s=l.item(u),s.namespaceURI)"http://www.w3.org/2000/xmlns/"===s.namespaceURI&&(b[s.value]=s.localName);else{"name"!==s.localName||"element"!==p&&"attribute"!==p||n.push(s.value);if("name"===s.localName||"combine"===s.localName||"type"===s.localName){var C=s,B;B=s.value;
+B=B.replace(/^\s\s*/,"");for(var A=/\s/,I=B.length-1;A.test(B.charAt(I));)I-=1;B=B.slice(0,I+1);C.value=B}x[s.localName]=s.value}l=x;l.combine=l.combine||void 0;d=d.firstChild;p=e;n=m;for(x="";d;){if(d.nodeType===Node.ELEMENT_NODE&&"http://relaxng.org/ns/structure/1.0"===d.namespaceURI){if(u=a(d,c,p))"name"===u.name?n.push(b[u.a.ns]+":"+u.text):"choice"===u.name&&u.names&&u.names.length&&(n=n.concat(u.names),delete u.names),p.push(u)}else d.nodeType===Node.TEXT_NODE&&(x+=d.nodeValue);d=d.nextSibling}d=
+x;"value"!==t&&"param"!==t&&(d=/^\s*([\s\S]*\S)?\s*$/.exec(d)[1]);"value"===t&&void 0===l.type&&(l.type="token",l.datatypeLibrary="");"attribute"!==t&&"element"!==t||void 0===l.name||(r=f(l.name),e=[{name:"name",text:r[1],a:{ns:r[0]}}].concat(e),delete l.name);"name"===t||"nsName"===t||"value"===t?void 0===l.ns&&(l.ns=""):delete l.ns;"name"===t&&(r=f(d),l.ns=r[0],d=r[1]);1<e.length&&("define"===t||"oneOrMore"===t||"zeroOrMore"===t||"optional"===t||"list"===t||"mixed"===t)&&(e=[{name:"group",e:h({name:"group",
+e:e}).e}]);2<e.length&&"element"===t&&(e=[e[0]].concat({name:"group",e:h({name:"group",e:e.slice(1)}).e}));1===e.length&&"attribute"===t&&e.push({name:"text",text:d});1!==e.length||"choice"!==t&&"group"!==t&&"interleave"!==t?2<e.length&&("choice"===t||"group"===t||"interleave"===t)&&(e=h({name:t,e:e}).e):(t=e[0].name,m=e[0].names,l=e[0].a,d=e[0].text,e=e[0].e);"mixed"===t&&(t="interleave",e=[e[0],{name:"text"}]);"optional"===t&&(t="choice",e=[e[0],{name:"empty"}]);"zeroOrMore"===t&&(t="choice",e=
+[{name:"oneOrMore",e:[e[0]]},{name:"empty"}]);if("define"===t&&l.combine){a:{p=l.combine;n=l.name;x=e;for(u=0;g&&u<g.length;u+=1)if(s=g[u],"define"===s.name&&s.a&&s.a.name===n){s.e=[{name:p,e:s.e.concat(x)}];g=s;break a}g=null}if(g)return}g={name:t};e&&0<e.length&&(g.e=e);for(r in l)if(l.hasOwnProperty(r)){g.a=l;break}void 0!==d&&(g.text=d);m&&0<m.length&&(g.names=m);"element"===t&&(g.id=c.length,c.push(g),g={name:"elementref",id:g.id});return g};this.parseRelaxNGDOM=function(d,f){var g=[],h=a(d&&
+d.documentElement,g,void 0),l,r,t={};for(l=0;l<h.e.length;l+=1)r=h.e[l],"define"===r.name?t[r.a.name]=r:"start"===r.name&&(c=r);if(!c)return[new e("No Relax NG start element was found.")];n(c,t);for(l in t)t.hasOwnProperty(l)&&n(t[l],t);for(l=0;l<g.length;l+=1)n(g[l],t);f&&(p.rootPattern=f(c.e[0],g));m(c,g);for(l=0;l<g.length;l+=1)m(g[l],g);p.start=c;p.elements=g;p.nsmap=b;return null}};
 // Input 23
 runtime.loadClass("xmldom.RelaxNGParser");
-xmldom.RelaxNG2=function(){function h(a,c){this.message=function(){c&&(a+=c.nodeType===Node.ELEMENT_NODE?" Element ":" Node ",a+=c.nodeName,c.nodeValue&&(a+=" with value '"+c.nodeValue+"'"),a+=".");return a}}function m(a,d,f,e){return"empty"===a.name?null:c(a,d,f,e)}function f(a,c){if(2!==a.e.length)throw"Element with wrong # of elements: "+a.e.length;for(var f=c.currentNode,e=f?f.nodeType:0,s=null;e>Node.ELEMENT_NODE;){if(e!==Node.COMMENT_NODE&&(e!==Node.TEXT_NODE||!/^\s+$/.test(c.currentNode.nodeValue)))return[new h("Not allowed node of type "+
-e+".")];e=(f=c.nextSibling())?f.nodeType:0}if(!f)return[new h("Missing element "+a.names)];if(a.names&&-1===a.names.indexOf(d[f.namespaceURI]+":"+f.localName))return[new h("Found "+f.nodeName+" instead of "+a.names+".",f)];if(c.firstChild()){for(s=m(a.e[1],c,f);c.nextSibling();)if(e=c.currentNode.nodeType,!(c.currentNode&&c.currentNode.nodeType===Node.TEXT_NODE&&/^\s+$/.test(c.currentNode.nodeValue)||e===Node.COMMENT_NODE))return[new h("Spurious content.",c.currentNode)];if(c.parentNode()!==f)return[new h("Implementation error.")]}else s=
-m(a.e[1],c,f);c.nextSibling();return s}var a,c,d;c=function(a,d,p,e){var s=a.name,n=null;if("text"===s)a:{for(var g=(a=d.currentNode)?a.nodeType:0;a!==p&&3!==g;){if(1===g){n=[new h("Element not allowed here.",a)];break a}g=(a=d.nextSibling())?a.nodeType:0}d.nextSibling();n=null}else if("data"===s)n=null;else if("value"===s)e!==a.text&&(n=[new h("Wrong value, should be '"+a.text+"', not '"+e+"'",p)]);else if("list"===s)n=null;else if("attribute"===s)a:{if(2!==a.e.length)throw"Attribute with wrong # of elements: "+
-a.e.length;s=a.localnames.length;for(n=0;n<s;n+=1){e=p.getAttributeNS(a.namespaces[n],a.localnames[n]);""!==e||p.hasAttributeNS(a.namespaces[n],a.localnames[n])||(e=void 0);if(void 0!==g&&void 0!==e){n=[new h("Attribute defined too often.",p)];break a}g=e}n=void 0===g?[new h("Attribute not found: "+a.names,p)]:m(a.e[1],d,p,g)}else if("element"===s)n=f(a,d);else if("oneOrMore"===s){e=0;do g=d.currentNode,s=c(a.e[0],d,p),e+=1;while(!s&&g!==d.currentNode);1<e?(d.currentNode=g,n=null):n=s}else if("choice"===
-s){if(2!==a.e.length)throw"Choice with wrong # of options: "+a.e.length;g=d.currentNode;if("empty"===a.e[0].name){if(s=c(a.e[1],d,p,e))d.currentNode=g;n=null}else{if(s=m(a.e[0],d,p,e))d.currentNode=g,s=c(a.e[1],d,p,e);n=s}}else if("group"===s){if(2!==a.e.length)throw"Group with wrong # of members: "+a.e.length;n=c(a.e[0],d,p)||c(a.e[1],d,p)}else if("interleave"===s)a:{g=a.e.length;e=[g];for(var l=g,u,q,x,r;0<l;){u=0;q=d.currentNode;for(n=0;n<g;n+=1)x=d.currentNode,!0!==e[n]&&e[n]!==x&&(r=a.e[n],(s=
-c(r,d,p))?(d.currentNode=x,void 0===e[n]&&(e[n]=!1)):x===d.currentNode||"oneOrMore"===r.name||"choice"===r.name&&("oneOrMore"===r.e[0].name||"oneOrMore"===r.e[1].name)?(u+=1,e[n]=x):(u+=1,e[n]=!0));if(q===d.currentNode&&u===l){n=null;break a}if(0===u){for(n=0;n<g;n+=1)if(!1===e[n]){n=[new h("Interleave does not match.",p)];break a}n=null;break a}for(n=l=0;n<g;n+=1)!0!==e[n]&&(l+=1)}n=null}else throw s+" not allowed in nonEmptyPattern.";return n};this.validate=function(b,c){b.currentNode=b.root;var d=
-m(a.e[0],b,b.root);c(d)};this.init=function(b,c){a=b;d=c}};
+xmldom.RelaxNG=function(){function e(a){return function(){var b;return function(){void 0===b&&(b=a());return b}}()}function h(a,b){return function(){var d={},c=0;return function(g){var e=g.hash||g.toString(),l;l=d[e];if(void 0!==l)return l;d[e]=l=b(g);l.hash=a+c.toString();c+=1;return l}}()}function f(a){return function(){var b={};return function(d){var c,g;g=b[d.localName];if(void 0===g)b[d.localName]=g={};else if(c=g[d.namespaceURI],void 0!==c)return c;return g[d.namespaceURI]=c=a(d)}}()}function n(a,
+b,d){return function(){var c={},g=0;return function(e,l){var f=b&&b(e,l),k,h;if(void 0!==f)return f;f=e.hash||e.toString();k=l.hash||l.toString();h=c[f];if(void 0===h)c[f]=h={};else if(f=h[k],void 0!==f)return f;h[k]=f=d(e,l);f.hash=a+g.toString();g+=1;return f}}()}function m(a,b){"choice"===b.p1.type?m(a,b.p1):a[b.p1.hash]=b.p1;"choice"===b.p2.type?m(a,b.p2):a[b.p2.hash]=b.p2}function p(a,b){return{type:"element",nc:a,nullable:!1,textDeriv:function(){return u},startTagOpenDeriv:function(d){return a.contains(d)?
+l(b,s):u},attDeriv:function(){return u},startTagCloseDeriv:function(){return this}}}function c(){return{type:"list",nullable:!1,hash:"list",textDeriv:function(){return s}}}function b(a,c,g,e){if(c===u)return u;if(e>=g.length)return c;0===e&&(e=0);for(var l=g.item(e);l.namespaceURI===d;){e+=1;if(e>=g.length)return c;l=g.item(e)}return l=b(a,c.attDeriv(a,g.item(e)),g,e+1)}function a(b,d,c){c.e[0].a?(b.push(c.e[0].text),d.push(c.e[0].a.ns)):a(b,d,c.e[0]);c.e[1].a?(b.push(c.e[1].text),d.push(c.e[1].a.ns)):
+a(b,d,c.e[1])}var d="http://www.w3.org/2000/xmlns/",k,g,q,l,r,t,w,v,y,x,u={type:"notAllowed",nullable:!1,hash:"notAllowed",textDeriv:function(){return u},startTagOpenDeriv:function(){return u},attDeriv:function(){return u},startTagCloseDeriv:function(){return u},endTagDeriv:function(){return u}},s={type:"empty",nullable:!0,hash:"empty",textDeriv:function(){return u},startTagOpenDeriv:function(){return u},attDeriv:function(){return u},startTagCloseDeriv:function(){return s},endTagDeriv:function(){return u}},
+C={type:"text",nullable:!0,hash:"text",textDeriv:function(){return C},startTagOpenDeriv:function(){return u},attDeriv:function(){return u},startTagCloseDeriv:function(){return C},endTagDeriv:function(){return u}},B,A,I;k=n("choice",function(a,b){if(a===u)return b;if(b===u||a===b)return a},function(a,b){var d={},c;m(d,{p1:a,p2:b});b=a=void 0;for(c in d)d.hasOwnProperty(c)&&(void 0===a?a=d[c]:b=void 0===b?d[c]:k(b,d[c]));return function(a,b){return{type:"choice",p1:a,p2:b,nullable:a.nullable||b.nullable,
+textDeriv:function(d,c){return k(a.textDeriv(d,c),b.textDeriv(d,c))},startTagOpenDeriv:f(function(d){return k(a.startTagOpenDeriv(d),b.startTagOpenDeriv(d))}),attDeriv:function(d,c){return k(a.attDeriv(d,c),b.attDeriv(d,c))},startTagCloseDeriv:e(function(){return k(a.startTagCloseDeriv(),b.startTagCloseDeriv())}),endTagDeriv:e(function(){return k(a.endTagDeriv(),b.endTagDeriv())})}}(a,b)});g=function(a,b,d){return function(){var c={},g=0;return function(e,l){var f=b&&b(e,l),k,h;if(void 0!==f)return f;
+f=e.hash||e.toString();k=l.hash||l.toString();f<k&&(h=f,f=k,k=h,h=e,e=l,l=h);h=c[f];if(void 0===h)c[f]=h={};else if(f=h[k],void 0!==f)return f;h[k]=f=d(e,l);f.hash=a+g.toString();g+=1;return f}}()}("interleave",function(a,b){if(a===u||b===u)return u;if(a===s)return b;if(b===s)return a},function(a,b){return{type:"interleave",p1:a,p2:b,nullable:a.nullable&&b.nullable,textDeriv:function(d,c){return k(g(a.textDeriv(d,c),b),g(a,b.textDeriv(d,c)))},startTagOpenDeriv:f(function(d){return k(B(function(a){return g(a,
+b)},a.startTagOpenDeriv(d)),B(function(b){return g(a,b)},b.startTagOpenDeriv(d)))}),attDeriv:function(d,c){return k(g(a.attDeriv(d,c),b),g(a,b.attDeriv(d,c)))},startTagCloseDeriv:e(function(){return g(a.startTagCloseDeriv(),b.startTagCloseDeriv())})}});q=n("group",function(a,b){if(a===u||b===u)return u;if(a===s)return b;if(b===s)return a},function(a,b){return{type:"group",p1:a,p2:b,nullable:a.nullable&&b.nullable,textDeriv:function(d,c){var g=q(a.textDeriv(d,c),b);return a.nullable?k(g,b.textDeriv(d,
+c)):g},startTagOpenDeriv:function(d){var c=B(function(a){return q(a,b)},a.startTagOpenDeriv(d));return a.nullable?k(c,b.startTagOpenDeriv(d)):c},attDeriv:function(d,c){return k(q(a.attDeriv(d,c),b),q(a,b.attDeriv(d,c)))},startTagCloseDeriv:e(function(){return q(a.startTagCloseDeriv(),b.startTagCloseDeriv())})}});l=n("after",function(a,b){if(a===u||b===u)return u},function(a,b){return{type:"after",p1:a,p2:b,nullable:!1,textDeriv:function(d,c){return l(a.textDeriv(d,c),b)},startTagOpenDeriv:f(function(d){return B(function(a){return l(a,
+b)},a.startTagOpenDeriv(d))}),attDeriv:function(d,c){return l(a.attDeriv(d,c),b)},startTagCloseDeriv:e(function(){return l(a.startTagCloseDeriv(),b)}),endTagDeriv:e(function(){return a.nullable?b:u})}});r=h("oneormore",function(a){return a===u?u:{type:"oneOrMore",p:a,nullable:a.nullable,textDeriv:function(b,d){return q(a.textDeriv(b,d),k(this,s))},startTagOpenDeriv:function(b){var d=this;return B(function(a){return q(a,k(d,s))},a.startTagOpenDeriv(b))},attDeriv:function(b,d){return q(a.attDeriv(b,
+d),k(this,s))},startTagCloseDeriv:e(function(){return r(a.startTagCloseDeriv())})}});w=n("attribute",void 0,function(a,b){return{type:"attribute",nullable:!1,nc:a,p:b,attDeriv:function(d,c){return a.contains(c)&&(b.nullable&&/^\s+$/.test(c.nodeValue)||b.textDeriv(d,c.nodeValue).nullable)?s:u},startTagCloseDeriv:function(){return u}}});t=h("value",function(a){return{type:"value",nullable:!1,value:a,textDeriv:function(b,d){return d===a?s:u},attDeriv:function(){return u},startTagCloseDeriv:function(){return this}}});
+y=h("data",function(a){return{type:"data",nullable:!1,dataType:a,textDeriv:function(){return s},attDeriv:function(){return u},startTagCloseDeriv:function(){return this}}});B=function N(a,b){return"after"===b.type?l(b.p1,a(b.p2)):"choice"===b.type?k(N(a,b.p1),N(a,b.p2)):b};A=function(a,d,c){var g=c.currentNode;d=d.startTagOpenDeriv(g);d=b(a,d,g.attributes,0);var e=d=d.startTagCloseDeriv(),g=c.currentNode;d=c.firstChild();for(var f=[],l;d;)d.nodeType===Node.ELEMENT_NODE?f.push(d):d.nodeType!==Node.TEXT_NODE||
+/^\s*$/.test(d.nodeValue)||f.push(d.nodeValue),d=c.nextSibling();0===f.length&&(f=[""]);l=e;for(e=0;l!==u&&e<f.length;e+=1)d=f[e],"string"===typeof d?l=/^\s*$/.test(d)?k(l,l.textDeriv(a,d)):l.textDeriv(a,d):(c.currentNode=d,l=A(a,l,c));c.currentNode=g;return d=l.endTagDeriv()};v=function(b){var d,c,g;if("name"===b.name)d=b.text,c=b.a.ns,b={name:d,ns:c,hash:"{"+c+"}"+d,contains:function(a){return a.namespaceURI===c&&a.localName===d}};else if("choice"===b.name){d=[];c=[];a(d,c,b);b="";for(g=0;g<d.length;g+=
+1)b+="{"+c[g]+"}"+d[g]+",";b={hash:b,contains:function(a){var b;for(b=0;b<d.length;b+=1)if(d[b]===a.localName&&c[b]===a.namespaceURI)return!0;return!1}}}else b={hash:"anyName",contains:function(){return!0}};return b};x=function G(a,b){var d,e;if("elementref"===a.name){d=a.id||0;a=b[d];if(void 0!==a.name){var f=a;d=b[f.id]={hash:"element"+f.id.toString()};f=p(v(f.e[0]),x(f.e[1],b));for(e in f)f.hasOwnProperty(e)&&(d[e]=f[e]);return d}return a}switch(a.name){case "empty":return s;case "notAllowed":return u;
+case "text":return C;case "choice":return k(G(a.e[0],b),G(a.e[1],b));case "interleave":d=G(a.e[0],b);for(e=1;e<a.e.length;e+=1)d=g(d,G(a.e[e],b));return d;case "group":return q(G(a.e[0],b),G(a.e[1],b));case "oneOrMore":return r(G(a.e[0],b));case "attribute":return w(v(a.e[0]),G(a.e[1],b));case "value":return t(a.text);case "data":return d=a.a&&a.a.type,void 0===d&&(d=""),y(d);case "list":return c()}throw"No support for "+a.name;};this.makePattern=function(a,b){var d={},c;for(c in b)b.hasOwnProperty(c)&&
+(d[c]=b[c]);return c=x(a,d)};this.validate=function(a,b){var d;a.currentNode=a.root;d=A(null,I,a);d.nullable?b(null):(runtime.log("Error in Relax NG validation: "+d),b(["Error in Relax NG validation: "+d]))};this.init=function(a){I=a}};
 // Input 24
-xmldom.XPathIterator=function(){};
-xmldom.XPath=function(){function h(a,b,c){return-1!==a&&(a<b||-1===b)&&(a<c||-1===c)}function m(a){for(var b=[],c=0,d=a.length,e;c<d;){var k=a,f=d,m=b,p="",w=[],v=k.indexOf("[",c),C=k.indexOf("/",c),J=k.indexOf("=",c);h(C,v,J)?(p=k.substring(c,C),c=C+1):h(v,C,J)?(p=k.substring(c,v),c=s(k,v,w)):h(J,C,v)?(p=k.substring(c,J),c=J):(p=k.substring(c,f),c=f);m.push({location:p,predicates:w});if(c<d&&"="===a[c]){e=a.substring(c+1,d);if(2<e.length&&("'"===e[0]||'"'===e[0]))e=e.slice(1,e.length-1);else try{e=
-parseInt(e,10)}catch(E){}c=d}}return{steps:b,value:e}}function f(){var a,b=!1;this.setNode=function(b){a=b};this.reset=function(){b=!1};this.next=function(){var c=b?null:a;b=!0;return c}}function a(a,b,c){this.reset=function(){a.reset()};this.next=function(){for(var d=a.next();d&&!(d=d.getAttributeNodeNS(b,c));)d=a.next();return d}}function c(a,b){var c=a.next(),d=null;this.reset=function(){a.reset();c=a.next();d=null};this.next=function(){for(;c;){if(d)if(b&&d.firstChild)d=d.firstChild;else{for(;!d.nextSibling&&
-d!==c;)d=d.parentNode;d===c?c=a.next():d=d.nextSibling}else{do(d=c.firstChild)||(c=a.next());while(c&&!d)}if(d&&d.nodeType===Node.ELEMENT_NODE)return d}return null}}function d(a,b){this.reset=function(){a.reset()};this.next=function(){for(var c=a.next();c&&!b(c);)c=a.next();return c}}function b(a,b,c){b=b.split(":",2);var e=c(b[0]),k=b[1];return new d(a,function(a){return a.localName===k&&a.namespaceURI===e})}function k(a,b,c){var k=new f,h=e(k,b,c),m=b.value;return void 0===m?new d(a,function(a){k.setNode(a);
-h.reset();return h.next()}):new d(a,function(a){k.setNode(a);h.reset();return(a=h.next())&&a.nodeValue===m})}function p(a,b,c){var d=a.ownerDocument,k=[],h=null;if(d&&d.evaluate)for(c=d.evaluate(b,a,c,XPathResult.UNORDERED_NODE_ITERATOR_TYPE,null),h=c.iterateNext();null!==h;)h.nodeType===Node.ELEMENT_NODE&&k.push(h),h=c.iterateNext();else{k=new f;k.setNode(a);a=m(b);k=e(k,a,c);a=[];for(c=k.next();c;)a.push(c),c=k.next();k=a}return k}var e,s;s=function(a,b,c){for(var d=b,e=a.length,k=0;d<e;)"]"===
-a[d]?(k-=1,0>=k&&c.push(m(a.substring(b,d)))):"["===a[d]&&(0>=k&&(b=d+1),k+=1),d+=1;return d};xmldom.XPathIterator.prototype.next=function(){};xmldom.XPathIterator.prototype.reset=function(){};e=function(d,e,l){var f,h,m,r;for(f=0;f<e.steps.length;f+=1)for(m=e.steps[f],h=m.location,""===h?d=new c(d,!1):"@"===h[0]?(r=h.slice(1).split(":",2),d=new a(d,l(r[0]),r[1])):"."!==h&&(d=new c(d,!1),-1!==h.indexOf(":")&&(d=b(d,h,l))),h=0;h<m.predicates.length;h+=1)r=m.predicates[h],d=k(d,r,l);return d};xmldom.XPath=
-function(){this.getODFElementsWithXPath=p};return xmldom.XPath}();
+runtime.loadClass("xmldom.RelaxNGParser");
+xmldom.RelaxNG2=function(){function e(c,b){this.message=function(){b&&(c+=b.nodeType===Node.ELEMENT_NODE?" Element ":" Node ",c+=b.nodeName,b.nodeValue&&(c+=" with value '"+b.nodeValue+"'"),c+=".");return c}}function h(c,b,a,d){return"empty"===c.name?null:m(c,b,a,d)}function f(c,b){if(2!==c.e.length)throw"Element with wrong # of elements: "+c.e.length;for(var a=b.currentNode,d=a?a.nodeType:0,f=null;d>Node.ELEMENT_NODE;){if(d!==Node.COMMENT_NODE&&(d!==Node.TEXT_NODE||!/^\s+$/.test(b.currentNode.nodeValue)))return[new e("Not allowed node of type "+
+d+".")];d=(a=b.nextSibling())?a.nodeType:0}if(!a)return[new e("Missing element "+c.names)];if(c.names&&-1===c.names.indexOf(p[a.namespaceURI]+":"+a.localName))return[new e("Found "+a.nodeName+" instead of "+c.names+".",a)];if(b.firstChild()){for(f=h(c.e[1],b,a);b.nextSibling();)if(d=b.currentNode.nodeType,!(b.currentNode&&b.currentNode.nodeType===Node.TEXT_NODE&&/^\s+$/.test(b.currentNode.nodeValue)||d===Node.COMMENT_NODE))return[new e("Spurious content.",b.currentNode)];if(b.parentNode()!==a)return[new e("Implementation error.")]}else f=
+h(c.e[1],b,a);b.nextSibling();return f}var n,m,p;m=function(c,b,a,d){var k=c.name,g=null;if("text"===k)a:{for(var q=(c=b.currentNode)?c.nodeType:0;c!==a&&3!==q;){if(1===q){g=[new e("Element not allowed here.",c)];break a}q=(c=b.nextSibling())?c.nodeType:0}b.nextSibling();g=null}else if("data"===k)g=null;else if("value"===k)d!==c.text&&(g=[new e("Wrong value, should be '"+c.text+"', not '"+d+"'",a)]);else if("list"===k)g=null;else if("attribute"===k)a:{if(2!==c.e.length)throw"Attribute with wrong # of elements: "+
+c.e.length;k=c.localnames.length;for(g=0;g<k;g+=1){d=a.getAttributeNS(c.namespaces[g],c.localnames[g]);""!==d||a.hasAttributeNS(c.namespaces[g],c.localnames[g])||(d=void 0);if(void 0!==q&&void 0!==d){g=[new e("Attribute defined too often.",a)];break a}q=d}g=void 0===q?[new e("Attribute not found: "+c.names,a)]:h(c.e[1],b,a,q)}else if("element"===k)g=f(c,b);else if("oneOrMore"===k){d=0;do q=b.currentNode,k=m(c.e[0],b,a),d+=1;while(!k&&q!==b.currentNode);1<d?(b.currentNode=q,g=null):g=k}else if("choice"===
+k){if(2!==c.e.length)throw"Choice with wrong # of options: "+c.e.length;q=b.currentNode;if("empty"===c.e[0].name){if(k=m(c.e[1],b,a,d))b.currentNode=q;g=null}else{if(k=h(c.e[0],b,a,d))b.currentNode=q,k=m(c.e[1],b,a,d);g=k}}else if("group"===k){if(2!==c.e.length)throw"Group with wrong # of members: "+c.e.length;g=m(c.e[0],b,a)||m(c.e[1],b,a)}else if("interleave"===k)a:{q=c.e.length;d=[q];for(var l=q,r,t,p,n;0<l;){r=0;t=b.currentNode;for(g=0;g<q;g+=1)p=b.currentNode,!0!==d[g]&&d[g]!==p&&(n=c.e[g],(k=
+m(n,b,a))?(b.currentNode=p,void 0===d[g]&&(d[g]=!1)):p===b.currentNode||"oneOrMore"===n.name||"choice"===n.name&&("oneOrMore"===n.e[0].name||"oneOrMore"===n.e[1].name)?(r+=1,d[g]=p):(r+=1,d[g]=!0));if(t===b.currentNode&&r===l){g=null;break a}if(0===r){for(g=0;g<q;g+=1)if(!1===d[g]){g=[new e("Interleave does not match.",a)];break a}g=null;break a}for(g=l=0;g<q;g+=1)!0!==d[g]&&(l+=1)}g=null}else throw k+" not allowed in nonEmptyPattern.";return g};this.validate=function(c,b){c.currentNode=c.root;var a=
+h(n.e[0],c,c.root);b(a)};this.init=function(c,b){n=c;p=b}};
 // Input 25
+xmldom.XPathIterator=function(){};
+xmldom.XPath=function(){function e(a,b,d){return-1!==a&&(a<b||-1===b)&&(a<d||-1===d)}function h(a){for(var b=[],d=0,c=a.length,f;d<c;){var h=a,m=c,p=b,n="",u=[],s=h.indexOf("[",d),C=h.indexOf("/",d),B=h.indexOf("=",d);e(C,s,B)?(n=h.substring(d,C),d=C+1):e(s,C,B)?(n=h.substring(d,s),d=k(h,s,u)):e(B,C,s)?(n=h.substring(d,B),d=B):(n=h.substring(d,m),d=m);p.push({location:n,predicates:u});if(d<c&&"="===a[d]){f=a.substring(d+1,c);if(2<f.length&&("'"===f[0]||'"'===f[0]))f=f.slice(1,f.length-1);else try{f=
+parseInt(f,10)}catch(A){}d=c}}return{steps:b,value:f}}function f(){var a,b=!1;this.setNode=function(b){a=b};this.reset=function(){b=!1};this.next=function(){var d=b?null:a;b=!0;return d}}function n(a,b,d){this.reset=function(){a.reset()};this.next=function(){for(var c=a.next();c&&!(c=c.getAttributeNodeNS(b,d));)c=a.next();return c}}function m(a,b){var d=a.next(),c=null;this.reset=function(){a.reset();d=a.next();c=null};this.next=function(){for(;d;){if(c)if(b&&c.firstChild)c=c.firstChild;else{for(;!c.nextSibling&&
+c!==d;)c=c.parentNode;c===d?d=a.next():c=c.nextSibling}else{do(c=d.firstChild)||(d=a.next());while(d&&!c)}if(c&&c.nodeType===Node.ELEMENT_NODE)return c}return null}}function p(a,b){this.reset=function(){a.reset()};this.next=function(){for(var d=a.next();d&&!b(d);)d=a.next();return d}}function c(a,b,d){b=b.split(":",2);var c=d(b[0]),e=b[1];return new p(a,function(a){return a.localName===e&&a.namespaceURI===c})}function b(a,b,c){var e=new f,k=d(e,b,c),h=b.value;return void 0===h?new p(a,function(a){e.setNode(a);
+k.reset();return k.next()}):new p(a,function(a){e.setNode(a);k.reset();return(a=k.next())&&a.nodeValue===h})}function a(a,b,c){var e=a.ownerDocument,k=[],m=null;if(e&&e.evaluate)for(c=e.evaluate(b,a,c,XPathResult.UNORDERED_NODE_ITERATOR_TYPE,null),m=c.iterateNext();null!==m;)m.nodeType===Node.ELEMENT_NODE&&k.push(m),m=c.iterateNext();else{k=new f;k.setNode(a);a=h(b);k=d(k,a,c);a=[];for(c=k.next();c;)a.push(c),c=k.next();k=a}return k}var d,k;k=function(a,b,d){for(var c=b,e=a.length,f=0;c<e;)"]"===
+a[c]?(f-=1,0>=f&&d.push(h(a.substring(b,c)))):"["===a[c]&&(0>=f&&(b=c+1),f+=1),c+=1;return c};xmldom.XPathIterator.prototype.next=function(){};xmldom.XPathIterator.prototype.reset=function(){};d=function(a,d,e){var f,k,h,p;for(f=0;f<d.steps.length;f+=1)for(h=d.steps[f],k=h.location,""===k?a=new m(a,!1):"@"===k[0]?(p=k.slice(1).split(":",2),a=new n(a,e(p[0]),p[1])):"."!==k&&(a=new m(a,!1),-1!==k.indexOf(":")&&(a=c(a,k,e))),k=0;k<h.predicates.length;k+=1)p=h.predicates[k],a=b(a,p,e);return a};xmldom.XPath=
+function(){this.getODFElementsWithXPath=a};return xmldom.XPath}();
+// Input 26
 /*
 
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
@@ -352,6 +367,9 @@ function(){this.getODFElementsWithXPath=p};return xmldom.XPath}();
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -372,16 +390,16 @@ function(){this.getODFElementsWithXPath=p};return xmldom.XPath}();
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-gui.AnnotationViewManager=function(h,m,f){function a(a){var b=a.node,c=a.end;a=p.createRange();c&&(a.setStart(b,b.childNodes.length),a.setEnd(c,0),c=e.getTextNodes(a,!1),c.forEach(function(a){var c=p.createElement("span");c.className="annotationHighlight";c.setAttribute("annotation",b.getAttributeNS(odf.Namespaces.officens,"name"));a.parentNode.insertBefore(c,a);c.appendChild(a)}));a.detach()}function c(a){var b=h.getSizer();a?(f.style.display="inline-block",b.style.paddingRight=s.getComputedStyle(f).width):
-(f.style.display="none",b.style.paddingRight=0);h.refreshSize()}function d(){k.sort(function(a,b){return a.node.compareDocumentPosition(b.node)===Node.DOCUMENT_POSITION_FOLLOWING?-1:1})}function b(){var a;for(a=0;a<k.length;a+=1){var b=k[a],c=b.node.parentNode,d=c.nextSibling,e=d.nextSibling,m=c.parentNode,r=0,y=k[k.indexOf(b)-1],t=void 0,b=b.node.getElementsByTagNameNS(odf.Namespaces.dcns,"creator")[0],r=void 0,r=h.getZoomLevel();c.style.left=(f.getBoundingClientRect().left-m.getBoundingClientRect().left)/
-r+"px";c.style.width=f.getBoundingClientRect().width/r+"px";d.style.width=parseFloat(c.style.left)-30+"px";y&&(t=y.node.parentNode.getBoundingClientRect(),20>=(m.getBoundingClientRect().top-t.bottom)/r?c.style.top=Math.abs(m.getBoundingClientRect().top-t.bottom)/r+20+"px":c.style.top="0px");e.style.left=d.getBoundingClientRect().width/r+"px";var d=e.style,m=e.getBoundingClientRect().left/r,y=e.getBoundingClientRect().top/r,t=c.getBoundingClientRect().left/r,w=c.getBoundingClientRect().top/r,v=0,C=
-0,v=t-m,v=v*v,C=w-y,C=C*C,m=Math.sqrt(v+C);d.width=m+"px";r=Math.asin((c.getBoundingClientRect().top-e.getBoundingClientRect().top)/(r*parseFloat(e.style.width)));e.style.transform="rotate("+r+"rad)";e.style.MozTransform="rotate("+r+"rad)";e.style.WebkitTransform="rotate("+r+"rad)";e.style.msTransform="rotate("+r+"rad)";b&&(r=s.getComputedStyle(b,":before").content)&&"none"!==r&&(r=r.substring(1,r.length-1),b.firstChild?b.firstChild.nodeValue=r:b.appendChild(p.createTextNode(r)))}}var k=[],p=m.ownerDocument,
-e=new odf.OdfUtils,s=runtime.getWindow();runtime.assert(Boolean(s),"Expected to be run in an environment which has a global window, like a browser.");this.rerenderAnnotations=b;this.addAnnotation=function(e){c(!0);k.push({node:e.node,end:e.end});d();var g=p.createElement("div"),l=p.createElement("div"),f=p.createElement("div"),h=p.createElement("div"),m=p.createElement("div"),r=e.node;g.className="annotationWrapper";r.parentNode.insertBefore(g,r);l.className="annotationNote";l.appendChild(r);m.className=
-"annotationRemoveButton";l.appendChild(m);f.className="annotationConnector horizontal";h.className="annotationConnector angular";g.appendChild(l);g.appendChild(f);g.appendChild(h);e.end&&a(e);b()};this.forgetAnnotations=function(){for(;k.length;){var a=k[0],b=k.indexOf(a),d=a.node,e=d.parentNode.parentNode;"div"===e.localName&&(e.parentNode.insertBefore(d,e),e.parentNode.removeChild(e));a=a.node.getAttributeNS(odf.Namespaces.officens,"name");a=p.querySelectorAll('span.annotationHighlight[annotation="'+
-a+'"]');e=d=void 0;for(d=0;d<a.length;d+=1){for(e=a[d];e.firstChild;)e.parentNode.insertBefore(e.firstChild,e);e.parentNode.removeChild(e)}-1!==b&&k.splice(b,1);0===k.length&&c(!1)}}};
-// Input 26
+gui.AnnotationViewManager=function(e,h,f){function n(b){var c=b.node,e=b.end;b=a.createRange();e&&(b.setStart(c,c.childNodes.length),b.setEnd(e,0),e=d.getTextNodes(b,!1),e.forEach(function(b){var d=a.createElement("span");d.className="annotationHighlight";d.setAttribute("annotation",c.getAttributeNS(odf.Namespaces.officens,"name"));b.parentNode.insertBefore(d,b);d.appendChild(b)}));b.detach()}function m(a){var b=e.getSizer();a?(f.style.display="inline-block",b.style.paddingRight=k.getComputedStyle(f).width):
+(f.style.display="none",b.style.paddingRight=0);e.refreshSize()}function p(){b.sort(function(a,b){return a.node.compareDocumentPosition(b.node)===Node.DOCUMENT_POSITION_FOLLOWING?-1:1})}function c(){var d;for(d=0;d<b.length;d+=1){var c=b[d],l=c.node.parentNode,h=l.nextSibling,m=h.nextSibling,p=l.parentNode,n=0,y=b[b.indexOf(c)-1],x=void 0,c=c.node.getElementsByTagNameNS(odf.Namespaces.dcns,"creator")[0],n=void 0,n=e.getZoomLevel();l.style.left=(f.getBoundingClientRect().left-p.getBoundingClientRect().left)/
+n+"px";l.style.width=f.getBoundingClientRect().width/n+"px";h.style.width=parseFloat(l.style.left)-30+"px";y&&(x=y.node.parentNode.getBoundingClientRect(),20>=(p.getBoundingClientRect().top-x.bottom)/n?l.style.top=Math.abs(p.getBoundingClientRect().top-x.bottom)/n+20+"px":l.style.top="0px");m.style.left=h.getBoundingClientRect().width/n+"px";var h=m.style,p=m.getBoundingClientRect().left/n,y=m.getBoundingClientRect().top/n,x=l.getBoundingClientRect().left/n,u=l.getBoundingClientRect().top/n,s=0,C=
+0,s=x-p,s=s*s,C=u-y,C=C*C,p=Math.sqrt(s+C);h.width=p+"px";n=Math.asin((l.getBoundingClientRect().top-m.getBoundingClientRect().top)/(n*parseFloat(m.style.width)));m.style.transform="rotate("+n+"rad)";m.style.MozTransform="rotate("+n+"rad)";m.style.WebkitTransform="rotate("+n+"rad)";m.style.msTransform="rotate("+n+"rad)";c&&(n=k.getComputedStyle(c,":before").content)&&"none"!==n&&(/^["'].*["']$/.test(n)&&(n=n.substring(1,n.length-1)),c.firstChild?c.firstChild.nodeValue=n:c.appendChild(a.createTextNode(n)))}}
+var b=[],a=h.ownerDocument,d=new odf.OdfUtils,k=runtime.getWindow();runtime.assert(Boolean(k),"Expected to be run in an environment which has a global window, like a browser.");this.rerenderAnnotations=c;this.addAnnotation=function(d){m(!0);b.push({node:d.node,end:d.end});p();var e=a.createElement("div"),f=a.createElement("div"),k=a.createElement("div"),h=a.createElement("div"),w=a.createElement("div"),v=d.node;e.className="annotationWrapper";v.parentNode.insertBefore(e,v);f.className="annotationNote";
+f.appendChild(v);w.className="annotationRemoveButton";f.appendChild(w);k.className="annotationConnector horizontal";h.className="annotationConnector angular";e.appendChild(f);e.appendChild(k);e.appendChild(h);d.end&&n(d);c()};this.forgetAnnotations=function(){for(;b.length;){var d=b[0],c=b.indexOf(d),e=d.node,f=e.parentNode.parentNode;"div"===f.localName&&(f.parentNode.insertBefore(e,f),f.parentNode.removeChild(f));d=d.node.getAttributeNS(odf.Namespaces.officens,"name");d=a.querySelectorAll('span.annotationHighlight[annotation="'+
+d+'"]');f=e=void 0;for(e=0;e<d.length;e+=1){for(f=d[e];f.firstChild;)f.parentNode.insertBefore(f.firstChild,f);f.parentNode.removeChild(f)}-1!==c&&b.splice(c,1);0===b.length&&m(!1)}}};
+// Input 27
 /*
 
  Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
@@ -394,41 +412,8 @@ a+'"]');e=d=void 0;for(d=0;d<a.length;d+=1){for(e=a[d];e.firstChild;)e.parentNod
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-odf.OdfNodeFilter=function(){this.acceptNode=function(h){return"http://www.w3.org/1999/xhtml"===h.namespaceURI?NodeFilter.FILTER_SKIP:h.namespaceURI&&h.namespaceURI.match(/^urn:webodf:/)?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}};
-// Input 27
-/*
-
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -450,13 +435,9 @@ odf.OdfNodeFilter=function(){this.acceptNode=function(h){return"http://www.w3.or
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-odf.Namespaces=function(){function h(a){return m[a]||null}var m={db:"urn:oasis:names:tc:opendocument:xmlns:database:1.0",dc:"http://purl.org/dc/elements/1.1/",dr3d:"urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0",draw:"urn:oasis:names:tc:opendocument:xmlns:drawing:1.0",chart:"urn:oasis:names:tc:opendocument:xmlns:chart:1.0",fo:"urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",form:"urn:oasis:names:tc:opendocument:xmlns:form:1.0",numberns:"urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0",
-office:"urn:oasis:names:tc:opendocument:xmlns:office:1.0",presentation:"urn:oasis:names:tc:opendocument:xmlns:presentation:1.0",style:"urn:oasis:names:tc:opendocument:xmlns:style:1.0",svg:"urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0",table:"urn:oasis:names:tc:opendocument:xmlns:table:1.0",text:"urn:oasis:names:tc:opendocument:xmlns:text:1.0",xlink:"http://www.w3.org/1999/xlink",xml:"http://www.w3.org/XML/1998/namespace",webodf:"urn:webodf"},f;h.lookupNamespaceURI=h;f=function(){};f.forEachPrefix=
-function(a){for(var c in m)m.hasOwnProperty(c)&&a(c,m[c])};f.resolvePrefix=h;f.namespaceMap=m;f.dbns="urn:oasis:names:tc:opendocument:xmlns:database:1.0";f.dcns="http://purl.org/dc/elements/1.1/";f.dr3dns="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0";f.drawns="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0";f.chartns="urn:oasis:names:tc:opendocument:xmlns:chart:1.0";f.fons="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0";f.formns="urn:oasis:names:tc:opendocument:xmlns:form:1.0";
-f.numberns="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0";f.officens="urn:oasis:names:tc:opendocument:xmlns:office:1.0";f.presentationns="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0";f.stylens="urn:oasis:names:tc:opendocument:xmlns:style:1.0";f.svgns="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0";f.tablens="urn:oasis:names:tc:opendocument:xmlns:table:1.0";f.textns="urn:oasis:names:tc:opendocument:xmlns:text:1.0";f.xlinkns="http://www.w3.org/1999/xlink";f.xmlns="http://www.w3.org/XML/1998/namespace";
-f.webodfns="urn:webodf";return f}();
+odf.OdfNodeFilter=function(){this.acceptNode=function(e){return"http://www.w3.org/1999/xhtml"===e.namespaceURI?NodeFilter.FILTER_SKIP:e.namespaceURI&&e.namespaceURI.match(/^urn:webodf:/)?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}};
 // Input 28
 /*
 
@@ -470,6 +451,9 @@ f.webodfns="urn:webodf";return f}();
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -490,36 +474,12 @@ f.webodfns="urn:webodf";return f}();
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.Namespaces");
-odf.StyleInfo=function(){function h(a,b){for(var c=v[a.localName],d=c&&c[a.namespaceURI],e=d?d.length:0,g,c=0;c<e;c+=1)(g=a.getAttributeNS(d[c].ns,d[c].localname))&&a.setAttributeNS(d[c].ns,w[d[c].ns]+d[c].localname,b+g);for(c=a.firstChild;c;)c.nodeType===Node.ELEMENT_NODE&&(d=c,h(d,b)),c=c.nextSibling}function m(a,b){for(var c=v[a.localName],d=c&&c[a.namespaceURI],e=d?d.length:0,g,c=0;c<e;c+=1)if(g=a.getAttributeNS(d[c].ns,d[c].localname))g=g.replace(b,""),a.setAttributeNS(d[c].ns,w[d[c].ns]+d[c].localname,
-g);for(c=a.firstChild;c;)c.nodeType===Node.ELEMENT_NODE&&(d=c,m(d,b)),c=c.nextSibling}function f(a,c){var b=v[a.localName],d=(b=b&&b[a.namespaceURI])?b.length:0,e,g,k;for(k=0;k<d;k+=1)if(e=a.getAttributeNS(b[k].ns,b[k].localname))c=c||{},g=b[k].keyname,g=c[g]=c[g]||{},g[e]=1;return c}function a(b,c){var d,e;f(b,c);for(d=b.firstChild;d;)d.nodeType===Node.ELEMENT_NODE&&(e=d,a(e,c)),d=d.nextSibling}function c(a,b,c){this.key=a;this.name=b;this.family=c;this.requires={}}function d(a,b,d){var e=a+'"'+
-b,g=d[e];g||(g=d[e]=new c(e,a,b));return g}function b(a,c,e){var g=v[a.localName],k=(g=g&&g[a.namespaceURI])?g.length:0,l=a.getAttributeNS(r,"name"),f=a.getAttributeNS(r,"family"),h;l&&f&&(c=d(l,f,e));if(c)for(l=0;l<k;l+=1)if(f=a.getAttributeNS(g[l].ns,g[l].localname))h=g[l].keyname,f=d(f,h,e),c.requires[f.key]=f;for(l=a.firstChild;l;)l.nodeType===Node.ELEMENT_NODE&&(a=l,b(a,c,e)),l=l.nextSibling;return e}function k(a,c){var b=c[a.family];b||(b=c[a.family]={});b[a.name]=1;Object.keys(a.requires).forEach(function(b){k(a.requires[b],
-c)})}function p(a,c){var d=b(a,null,{});Object.keys(d).forEach(function(a){a=d[a];var b=c[a.family];b&&b.hasOwnProperty(a.name)&&k(a,c)})}var e=odf.Namespaces.chartns,s=odf.Namespaces.dbns,n=odf.Namespaces.dr3dns,g=odf.Namespaces.drawns,l=odf.Namespaces.formns,u=odf.Namespaces.numberns,q=odf.Namespaces.officens,x=odf.Namespaces.presentationns,r=odf.Namespaces.stylens,y=odf.Namespaces.tablens,t=odf.Namespaces.textns,w={"urn:oasis:names:tc:opendocument:xmlns:chart:1.0":"chart:","urn:oasis:names:tc:opendocument:xmlns:database:1.0":"db:",
-"urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0":"dr3d:","urn:oasis:names:tc:opendocument:xmlns:drawing:1.0":"draw:","urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0":"fo:","urn:oasis:names:tc:opendocument:xmlns:form:1.0":"form:","urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0":"number:","urn:oasis:names:tc:opendocument:xmlns:office:1.0":"office:","urn:oasis:names:tc:opendocument:xmlns:presentation:1.0":"presentation:","urn:oasis:names:tc:opendocument:xmlns:style:1.0":"style:","urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0":"svg:",
-"urn:oasis:names:tc:opendocument:xmlns:table:1.0":"table:","urn:oasis:names:tc:opendocument:xmlns:text:1.0":"chart:","http://www.w3.org/XML/1998/namespace":"xml:"},e={text:[{ens:r,en:"tab-stop",ans:r,a:"leader-text-style"},{ens:r,en:"drop-cap",ans:r,a:"style-name"},{ens:t,en:"notes-configuration",ans:t,a:"citation-body-style-name"},{ens:t,en:"notes-configuration",ans:t,a:"citation-style-name"},{ens:t,en:"a",ans:t,a:"style-name"},{ens:t,en:"alphabetical-index",ans:t,a:"style-name"},{ens:t,en:"linenumbering-configuration",
-ans:t,a:"style-name"},{ens:t,en:"list-level-style-number",ans:t,a:"style-name"},{ens:t,en:"ruby-text",ans:t,a:"style-name"},{ens:t,en:"span",ans:t,a:"style-name"},{ens:t,en:"a",ans:t,a:"visited-style-name"},{ens:r,en:"text-properties",ans:r,a:"text-line-through-text-style"},{ens:t,en:"alphabetical-index-source",ans:t,a:"main-entry-style-name"},{ens:t,en:"index-entry-bibliography",ans:t,a:"style-name"},{ens:t,en:"index-entry-chapter",ans:t,a:"style-name"},{ens:t,en:"index-entry-link-end",ans:t,a:"style-name"},
-{ens:t,en:"index-entry-link-start",ans:t,a:"style-name"},{ens:t,en:"index-entry-page-number",ans:t,a:"style-name"},{ens:t,en:"index-entry-span",ans:t,a:"style-name"},{ens:t,en:"index-entry-tab-stop",ans:t,a:"style-name"},{ens:t,en:"index-entry-text",ans:t,a:"style-name"},{ens:t,en:"index-title-template",ans:t,a:"style-name"},{ens:t,en:"list-level-style-bullet",ans:t,a:"style-name"},{ens:t,en:"outline-level-style",ans:t,a:"style-name"}],paragraph:[{ens:g,en:"caption",ans:g,a:"text-style-name"},{ens:g,
-en:"circle",ans:g,a:"text-style-name"},{ens:g,en:"connector",ans:g,a:"text-style-name"},{ens:g,en:"control",ans:g,a:"text-style-name"},{ens:g,en:"custom-shape",ans:g,a:"text-style-name"},{ens:g,en:"ellipse",ans:g,a:"text-style-name"},{ens:g,en:"frame",ans:g,a:"text-style-name"},{ens:g,en:"line",ans:g,a:"text-style-name"},{ens:g,en:"measure",ans:g,a:"text-style-name"},{ens:g,en:"path",ans:g,a:"text-style-name"},{ens:g,en:"polygon",ans:g,a:"text-style-name"},{ens:g,en:"polyline",ans:g,a:"text-style-name"},
-{ens:g,en:"rect",ans:g,a:"text-style-name"},{ens:g,en:"regular-polygon",ans:g,a:"text-style-name"},{ens:q,en:"annotation",ans:g,a:"text-style-name"},{ens:l,en:"column",ans:l,a:"text-style-name"},{ens:r,en:"style",ans:r,a:"next-style-name"},{ens:y,en:"body",ans:y,a:"paragraph-style-name"},{ens:y,en:"even-columns",ans:y,a:"paragraph-style-name"},{ens:y,en:"even-rows",ans:y,a:"paragraph-style-name"},{ens:y,en:"first-column",ans:y,a:"paragraph-style-name"},{ens:y,en:"first-row",ans:y,a:"paragraph-style-name"},
-{ens:y,en:"last-column",ans:y,a:"paragraph-style-name"},{ens:y,en:"last-row",ans:y,a:"paragraph-style-name"},{ens:y,en:"odd-columns",ans:y,a:"paragraph-style-name"},{ens:y,en:"odd-rows",ans:y,a:"paragraph-style-name"},{ens:t,en:"notes-configuration",ans:t,a:"default-style-name"},{ens:t,en:"alphabetical-index-entry-template",ans:t,a:"style-name"},{ens:t,en:"bibliography-entry-template",ans:t,a:"style-name"},{ens:t,en:"h",ans:t,a:"style-name"},{ens:t,en:"illustration-index-entry-template",ans:t,a:"style-name"},
-{ens:t,en:"index-source-style",ans:t,a:"style-name"},{ens:t,en:"object-index-entry-template",ans:t,a:"style-name"},{ens:t,en:"p",ans:t,a:"style-name"},{ens:t,en:"table-index-entry-template",ans:t,a:"style-name"},{ens:t,en:"table-of-content-entry-template",ans:t,a:"style-name"},{ens:t,en:"table-index-entry-template",ans:t,a:"style-name"},{ens:t,en:"user-index-entry-template",ans:t,a:"style-name"},{ens:r,en:"page-layout-properties",ans:r,a:"register-truth-ref-style-name"}],chart:[{ens:e,en:"axis",ans:e,
-a:"style-name"},{ens:e,en:"chart",ans:e,a:"style-name"},{ens:e,en:"data-label",ans:e,a:"style-name"},{ens:e,en:"data-point",ans:e,a:"style-name"},{ens:e,en:"equation",ans:e,a:"style-name"},{ens:e,en:"error-indicator",ans:e,a:"style-name"},{ens:e,en:"floor",ans:e,a:"style-name"},{ens:e,en:"footer",ans:e,a:"style-name"},{ens:e,en:"grid",ans:e,a:"style-name"},{ens:e,en:"legend",ans:e,a:"style-name"},{ens:e,en:"mean-value",ans:e,a:"style-name"},{ens:e,en:"plot-area",ans:e,a:"style-name"},{ens:e,en:"regression-curve",
-ans:e,a:"style-name"},{ens:e,en:"series",ans:e,a:"style-name"},{ens:e,en:"stock-gain-marker",ans:e,a:"style-name"},{ens:e,en:"stock-loss-marker",ans:e,a:"style-name"},{ens:e,en:"stock-range-line",ans:e,a:"style-name"},{ens:e,en:"subtitle",ans:e,a:"style-name"},{ens:e,en:"title",ans:e,a:"style-name"},{ens:e,en:"wall",ans:e,a:"style-name"}],section:[{ens:t,en:"alphabetical-index",ans:t,a:"style-name"},{ens:t,en:"bibliography",ans:t,a:"style-name"},{ens:t,en:"illustration-index",ans:t,a:"style-name"},
-{ens:t,en:"index-title",ans:t,a:"style-name"},{ens:t,en:"object-index",ans:t,a:"style-name"},{ens:t,en:"section",ans:t,a:"style-name"},{ens:t,en:"table-of-content",ans:t,a:"style-name"},{ens:t,en:"table-index",ans:t,a:"style-name"},{ens:t,en:"user-index",ans:t,a:"style-name"}],ruby:[{ens:t,en:"ruby",ans:t,a:"style-name"}],table:[{ens:s,en:"query",ans:s,a:"style-name"},{ens:s,en:"table-representation",ans:s,a:"style-name"},{ens:y,en:"background",ans:y,a:"style-name"},{ens:y,en:"table",ans:y,a:"style-name"}],
-"table-column":[{ens:s,en:"column",ans:s,a:"style-name"},{ens:y,en:"table-column",ans:y,a:"style-name"}],"table-row":[{ens:s,en:"query",ans:s,a:"default-row-style-name"},{ens:s,en:"table-representation",ans:s,a:"default-row-style-name"},{ens:y,en:"table-row",ans:y,a:"style-name"}],"table-cell":[{ens:s,en:"column",ans:s,a:"default-cell-style-name"},{ens:y,en:"table-column",ans:y,a:"default-cell-style-name"},{ens:y,en:"table-row",ans:y,a:"default-cell-style-name"},{ens:y,en:"body",ans:y,a:"style-name"},
-{ens:y,en:"covered-table-cell",ans:y,a:"style-name"},{ens:y,en:"even-columns",ans:y,a:"style-name"},{ens:y,en:"covered-table-cell",ans:y,a:"style-name"},{ens:y,en:"even-columns",ans:y,a:"style-name"},{ens:y,en:"even-rows",ans:y,a:"style-name"},{ens:y,en:"first-column",ans:y,a:"style-name"},{ens:y,en:"first-row",ans:y,a:"style-name"},{ens:y,en:"last-column",ans:y,a:"style-name"},{ens:y,en:"last-row",ans:y,a:"style-name"},{ens:y,en:"odd-columns",ans:y,a:"style-name"},{ens:y,en:"odd-rows",ans:y,a:"style-name"},
-{ens:y,en:"table-cell",ans:y,a:"style-name"}],graphic:[{ens:n,en:"cube",ans:g,a:"style-name"},{ens:n,en:"extrude",ans:g,a:"style-name"},{ens:n,en:"rotate",ans:g,a:"style-name"},{ens:n,en:"scene",ans:g,a:"style-name"},{ens:n,en:"sphere",ans:g,a:"style-name"},{ens:g,en:"caption",ans:g,a:"style-name"},{ens:g,en:"circle",ans:g,a:"style-name"},{ens:g,en:"connector",ans:g,a:"style-name"},{ens:g,en:"control",ans:g,a:"style-name"},{ens:g,en:"custom-shape",ans:g,a:"style-name"},{ens:g,en:"ellipse",ans:g,a:"style-name"},
-{ens:g,en:"frame",ans:g,a:"style-name"},{ens:g,en:"g",ans:g,a:"style-name"},{ens:g,en:"line",ans:g,a:"style-name"},{ens:g,en:"measure",ans:g,a:"style-name"},{ens:g,en:"page-thumbnail",ans:g,a:"style-name"},{ens:g,en:"path",ans:g,a:"style-name"},{ens:g,en:"polygon",ans:g,a:"style-name"},{ens:g,en:"polyline",ans:g,a:"style-name"},{ens:g,en:"rect",ans:g,a:"style-name"},{ens:g,en:"regular-polygon",ans:g,a:"style-name"},{ens:q,en:"annotation",ans:g,a:"style-name"}],presentation:[{ens:n,en:"cube",ans:x,
-a:"style-name"},{ens:n,en:"extrude",ans:x,a:"style-name"},{ens:n,en:"rotate",ans:x,a:"style-name"},{ens:n,en:"scene",ans:x,a:"style-name"},{ens:n,en:"sphere",ans:x,a:"style-name"},{ens:g,en:"caption",ans:x,a:"style-name"},{ens:g,en:"circle",ans:x,a:"style-name"},{ens:g,en:"connector",ans:x,a:"style-name"},{ens:g,en:"control",ans:x,a:"style-name"},{ens:g,en:"custom-shape",ans:x,a:"style-name"},{ens:g,en:"ellipse",ans:x,a:"style-name"},{ens:g,en:"frame",ans:x,a:"style-name"},{ens:g,en:"g",ans:x,a:"style-name"},
-{ens:g,en:"line",ans:x,a:"style-name"},{ens:g,en:"measure",ans:x,a:"style-name"},{ens:g,en:"page-thumbnail",ans:x,a:"style-name"},{ens:g,en:"path",ans:x,a:"style-name"},{ens:g,en:"polygon",ans:x,a:"style-name"},{ens:g,en:"polyline",ans:x,a:"style-name"},{ens:g,en:"rect",ans:x,a:"style-name"},{ens:g,en:"regular-polygon",ans:x,a:"style-name"},{ens:q,en:"annotation",ans:x,a:"style-name"}],"drawing-page":[{ens:g,en:"page",ans:g,a:"style-name"},{ens:x,en:"notes",ans:g,a:"style-name"},{ens:r,en:"handout-master",
-ans:g,a:"style-name"},{ens:r,en:"master-page",ans:g,a:"style-name"}],"list-style":[{ens:t,en:"list",ans:t,a:"style-name"},{ens:t,en:"numbered-paragraph",ans:t,a:"style-name"},{ens:t,en:"list-item",ans:t,a:"style-override"},{ens:r,en:"style",ans:r,a:"list-style-name"}],data:[{ens:r,en:"style",ans:r,a:"data-style-name"},{ens:r,en:"style",ans:r,a:"percentage-data-style-name"},{ens:x,en:"date-time-decl",ans:r,a:"data-style-name"},{ens:t,en:"creation-date",ans:r,a:"data-style-name"},{ens:t,en:"creation-time",
-ans:r,a:"data-style-name"},{ens:t,en:"database-display",ans:r,a:"data-style-name"},{ens:t,en:"date",ans:r,a:"data-style-name"},{ens:t,en:"editing-duration",ans:r,a:"data-style-name"},{ens:t,en:"expression",ans:r,a:"data-style-name"},{ens:t,en:"meta-field",ans:r,a:"data-style-name"},{ens:t,en:"modification-date",ans:r,a:"data-style-name"},{ens:t,en:"modification-time",ans:r,a:"data-style-name"},{ens:t,en:"print-date",ans:r,a:"data-style-name"},{ens:t,en:"print-time",ans:r,a:"data-style-name"},{ens:t,
-en:"table-formula",ans:r,a:"data-style-name"},{ens:t,en:"time",ans:r,a:"data-style-name"},{ens:t,en:"user-defined",ans:r,a:"data-style-name"},{ens:t,en:"user-field-get",ans:r,a:"data-style-name"},{ens:t,en:"user-field-input",ans:r,a:"data-style-name"},{ens:t,en:"variable-get",ans:r,a:"data-style-name"},{ens:t,en:"variable-input",ans:r,a:"data-style-name"},{ens:t,en:"variable-set",ans:r,a:"data-style-name"}],"page-layout":[{ens:x,en:"notes",ans:r,a:"page-layout-name"},{ens:r,en:"handout-master",ans:r,
-a:"page-layout-name"},{ens:r,en:"master-page",ans:r,a:"page-layout-name"}]},v,C=new xmldom.XPath;this.UsedStyleList=function(b,c){var d={};this.uses=function(a){var b=a.localName,c=a.getAttributeNS(g,"name")||a.getAttributeNS(r,"name");a="style"===b?a.getAttributeNS(r,"family"):a.namespaceURI===u?"data":b;return(a=d[a])?0<a[c]:!1};a(b,d);c&&p(c,d)};this.hasDerivedStyles=function(a,b,c){var d=b("style"),e=c.getAttributeNS(d,"name");c=c.getAttributeNS(d,"family");return C.getODFElementsWithXPath(a,
-"//style:*[@style:parent-style-name='"+e+"'][@style:family='"+c+"']",b).length?!0:!1};this.prefixStyleNames=function(a,c,b){var d;if(a){for(d=a.firstChild;d;){if(d.nodeType===Node.ELEMENT_NODE){var e=d,k=c,l=e.getAttributeNS(g,"name"),f=void 0;l?f=g:(l=e.getAttributeNS(r,"name"))&&(f=r);f&&e.setAttributeNS(f,w[f]+"name",k+l)}d=d.nextSibling}h(a,c);b&&h(b,c)}};this.removePrefixFromStyleNames=function(a,c,b){var d=RegExp("^"+c);if(a){for(c=a.firstChild;c;){if(c.nodeType===Node.ELEMENT_NODE){var e=c,
-k=d,l=e.getAttributeNS(g,"name"),f=void 0;l?f=g:(l=e.getAttributeNS(r,"name"))&&(f=r);f&&(l=l.replace(k,""),e.setAttributeNS(f,w[f]+"name",l))}c=c.nextSibling}m(a,d);b&&m(b,d)}};this.determineStylesForNode=f;v=function(a){var c,b,d,e,g,k={},l;for(c in a)if(a.hasOwnProperty(c))for(e=a[c],d=e.length,b=0;b<d;b+=1)g=e[b],l=k[g.en]=k[g.en]||{},l=l[g.ens]=l[g.ens]||[],l.push({ns:g.ans,localname:g.a,keyname:c});return k}(e)};
+odf.Namespaces=function(){function e(e){return h[e]||null}var h={db:"urn:oasis:names:tc:opendocument:xmlns:database:1.0",dc:"http://purl.org/dc/elements/1.1/",dr3d:"urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0",draw:"urn:oasis:names:tc:opendocument:xmlns:drawing:1.0",chart:"urn:oasis:names:tc:opendocument:xmlns:chart:1.0",fo:"urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0",form:"urn:oasis:names:tc:opendocument:xmlns:form:1.0",numberns:"urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0",
+office:"urn:oasis:names:tc:opendocument:xmlns:office:1.0",presentation:"urn:oasis:names:tc:opendocument:xmlns:presentation:1.0",style:"urn:oasis:names:tc:opendocument:xmlns:style:1.0",svg:"urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0",table:"urn:oasis:names:tc:opendocument:xmlns:table:1.0",text:"urn:oasis:names:tc:opendocument:xmlns:text:1.0",xlink:"http://www.w3.org/1999/xlink",xml:"http://www.w3.org/XML/1998/namespace"},f;e.lookupNamespaceURI=e;f=function(){};f.forEachPrefix=function(e){for(var f in h)h.hasOwnProperty(f)&&
+e(f,h[f])};f.resolvePrefix=e;f.namespaceMap=h;f.dbns="urn:oasis:names:tc:opendocument:xmlns:database:1.0";f.dcns="http://purl.org/dc/elements/1.1/";f.dr3dns="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0";f.drawns="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0";f.chartns="urn:oasis:names:tc:opendocument:xmlns:chart:1.0";f.fons="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0";f.formns="urn:oasis:names:tc:opendocument:xmlns:form:1.0";f.numberns="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0";
+f.officens="urn:oasis:names:tc:opendocument:xmlns:office:1.0";f.presentationns="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0";f.stylens="urn:oasis:names:tc:opendocument:xmlns:style:1.0";f.svgns="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0";f.tablens="urn:oasis:names:tc:opendocument:xmlns:table:1.0";f.textns="urn:oasis:names:tc:opendocument:xmlns:text:1.0";f.xlinkns="http://www.w3.org/1999/xlink";f.xmlns="http://www.w3.org/XML/1998/namespace";return f}();
 // Input 29
 /*
 
@@ -533,6 +493,9 @@ k=d,l=e.getAttributeNS(g,"name"),f=void 0;l?f=g:(l=e.getAttributeNS(r,"name"))&&
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -553,58 +516,38 @@ k=d,l=e.getAttributeNS(g,"name"),f=void 0;l?f=g:(l=e.getAttributeNS(r,"name"))&&
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.DomUtils");runtime.loadClass("odf.Namespaces");
-odf.OdfUtils=function(){function h(a){var c=a&&a.localName;return("p"===c||"h"===c)&&a.namespaceURI===r}function m(a){for(;a&&!h(a);)a=a.parentNode;return a}function f(a){return/^[ \t\r\n]+$/.test(a)}function a(a){var c=a&&a.localName;return/^(span|p|h|a|meta)$/.test(c)&&a.namespaceURI===r||"span"===c&&"annotationHighlight"===a.className?!0:!1}function c(a){var c=a&&a.localName,b,d=!1;c&&(b=a.namespaceURI,b===r?d="s"===c||"tab"===c||"line-break"===c:b===y&&(d="frame"===c&&"as-char"===a.getAttributeNS(r,
-"anchor-type")));return d}function d(c){for(;null!==c.firstChild&&a(c);)c=c.firstChild;return c}function b(c){for(;null!==c.lastChild&&a(c);)c=c.lastChild;return c}function k(a){for(;!h(a)&&null===a.previousSibling;)a=a.parentNode;return h(a)?null:b(a.previousSibling)}function p(a){for(;!h(a)&&null===a.nextSibling;)a=a.parentNode;return h(a)?null:d(a.nextSibling)}function e(a){for(var b=!1;a;)if(a.nodeType===Node.TEXT_NODE)if(0===a.length)a=k(a);else return!f(a.data.substr(a.length-1,1));else c(a)?
-(b=!0,a=null):a=k(a);return b}function s(a){var b=!1;for(a=a&&d(a);a;){if(a.nodeType===Node.TEXT_NODE&&0<a.length&&!f(a.data)){b=!0;break}if(c(a)){b=!0;break}a=p(a)}return b}function n(a,c){return f(a.data.substr(c))?!s(p(a)):!1}function g(a,b){var d=a.data,g;if(!f(d[b])||c(a.parentNode))return!1;0<b?f(d[b-1])||(g=!0):e(k(a))&&(g=!0);return!0===g?n(a,b)?!1:!0:!1}function l(a){return(a=/(-?[0-9]*[0-9][0-9]*(\.[0-9]*)?|0+\.[0-9]*[1-9][0-9]*|\.[0-9]*[1-9][0-9]*)((cm)|(mm)|(in)|(pt)|(pc)|(px)|(%))/.exec(a))?
-{value:parseFloat(a[1]),unit:a[3]}:null}function u(a){return(a=l(a))&&(0>a.value||"%"===a.unit)?null:a}function q(a){return(a=l(a))&&"%"!==a.unit?null:a}function x(a){switch(a.namespaceURI){case odf.Namespaces.drawns:case odf.Namespaces.svgns:case odf.Namespaces.dr3dns:return!1;case odf.Namespaces.textns:switch(a.localName){case "note-body":case "ruby-text":return!1}break;case odf.Namespaces.officens:switch(a.localName){case "annotation":case "binary-data":case "event-listeners":return!1}break;default:switch(a.localName){case "editinfo":return!1}}return!0}
-var r=odf.Namespaces.textns,y=odf.Namespaces.drawns,t=/^\s*$/,w=new core.DomUtils;this.isParagraph=h;this.getParagraphElement=m;this.isWithinTrackedChanges=function(a,c){for(;a&&a!==c;){if(a.namespaceURI===r&&"tracked-changes"===a.localName)return!0;a=a.parentNode}return!1};this.isListItem=function(a){return"list-item"===(a&&a.localName)&&a.namespaceURI===r};this.isODFWhitespace=f;this.isGroupingElement=a;this.isCharacterElement=c;this.firstChild=d;this.lastChild=b;this.previousNode=k;this.nextNode=
-p;this.scanLeftForNonWhitespace=e;this.lookLeftForCharacter=function(a){var b;b=0;a.nodeType===Node.TEXT_NODE&&0<a.length?(b=a.data,b=f(b.substr(b.length-1,1))?1===b.length?e(k(a))?2:0:f(b.substr(b.length-2,1))?0:2:1):c(a)&&(b=1);return b};this.lookRightForCharacter=function(a){var b=!1;a&&a.nodeType===Node.TEXT_NODE&&0<a.length?b=!f(a.data.substr(0,1)):c(a)&&(b=!0);return b};this.scanLeftForAnyCharacter=function(a){var d=!1;for(a=a&&b(a);a;){if(a.nodeType===Node.TEXT_NODE&&0<a.length&&!f(a.data)){d=
-!0;break}if(c(a)){d=!0;break}a=k(a)}return d};this.scanRightForAnyCharacter=s;this.isTrailingWhitespace=n;this.isSignificantWhitespace=g;this.isDowngradableSpaceElement=function(a){return a.namespaceURI===r&&"s"===a.localName?e(k(a))&&s(p(a)):!1};this.getFirstNonWhitespaceChild=function(a){for(a=a&&a.firstChild;a&&a.nodeType===Node.TEXT_NODE&&t.test(a.nodeValue);)a=a.nextSibling;return a};this.parseLength=l;this.parseNonNegativeLength=u;this.parseFoFontSize=function(a){var c;c=(c=l(a))&&(0>=c.value||
-"%"===c.unit)?null:c;return c||q(a)};this.parseFoLineHeight=function(a){return u(a)||q(a)};this.getImpactedParagraphs=function(a){var c=a.commonAncestorContainer,b=[];for(c.nodeType===Node.ELEMENT_NODE&&(b=w.getElementsByTagNameNS(c,r,"p").concat(w.getElementsByTagNameNS(c,r,"h")));c&&!h(c);)c=c.parentNode;c&&b.push(c);return b.filter(function(c){return w.rangeIntersectsNode(a,c)})};this.getTextNodes=function(a,c){var b=a.startContainer.ownerDocument.createRange(),d;d=w.getNodesInRange(a,function(d){b.selectNodeContents(d);
-if(d.nodeType===Node.TEXT_NODE){if(c&&w.rangesIntersect(a,b)||w.containsRange(a,b))return Boolean(m(d)&&(!f(d.textContent)||g(d,0)))?NodeFilter.FILTER_ACCEPT:NodeFilter.FILTER_REJECT}else if(w.rangesIntersect(a,b)&&x(d))return NodeFilter.FILTER_SKIP;return NodeFilter.FILTER_REJECT});b.detach();return d};this.getTextElements=function(b,d){var e=b.startContainer.ownerDocument.createRange(),k;k=w.getNodesInRange(b,function(k){var l=k.nodeType;e.selectNodeContents(k);if(l===Node.TEXT_NODE){if(w.containsRange(b,
-e)&&(d||Boolean(m(k)&&(!f(k.textContent)||g(k,0)))))return NodeFilter.FILTER_ACCEPT}else if(c(k)){if(w.containsRange(b,e))return NodeFilter.FILTER_ACCEPT}else if(x(k)||a(k))return NodeFilter.FILTER_SKIP;return NodeFilter.FILTER_REJECT});e.detach();return k};this.getParagraphElements=function(c){var b=c.startContainer.ownerDocument.createRange(),d;d=w.getNodesInRange(c,function(d){b.selectNodeContents(d);if(h(d)){if(w.rangesIntersect(c,b))return NodeFilter.FILTER_ACCEPT}else if(x(d)||a(d))return NodeFilter.FILTER_SKIP;
-return NodeFilter.FILTER_REJECT});b.detach();return d}};
+runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.Namespaces");
+odf.StyleInfo=function(){function e(a,b){for(var d=B[a.localName],c=d&&d[a.namespaceURI],f=c?c.length:0,g,d=0;d<f;d+=1)(g=a.getAttributeNS(c[d].ns,c[d].localname))&&a.setAttributeNS(c[d].ns,C[c[d].ns]+c[d].localname,b+g);for(d=a.firstChild;d;)d.nodeType===Node.ELEMENT_NODE&&(c=d,e(c,b)),d=d.nextSibling}function h(a,b){for(var d=B[a.localName],c=d&&d[a.namespaceURI],e=c?c.length:0,f,d=0;d<e;d+=1)if(f=a.getAttributeNS(c[d].ns,c[d].localname))f=f.replace(b,""),a.setAttributeNS(c[d].ns,C[c[d].ns]+c[d].localname,
+f);for(d=a.firstChild;d;)d.nodeType===Node.ELEMENT_NODE&&(c=d,h(c,b)),d=d.nextSibling}function f(a,b){var d=B[a.localName],c=(d=d&&d[a.namespaceURI])?d.length:0,e,f,g;for(g=0;g<c;g+=1)if(e=a.getAttributeNS(d[g].ns,d[g].localname))b=b||{},f=d[g].keyname,f=b[f]=b[f]||{},f[e]=1;return b}function n(a,b){var d,c;f(a,b);for(d=a.firstChild;d;)d.nodeType===Node.ELEMENT_NODE&&(c=d,n(c,b)),d=d.nextSibling}function m(a,b,d){this.key=a;this.name=b;this.family=d;this.requires={}}function p(a,b,d){var c=a+'"'+
+b,e=d[c];e||(e=d[c]=new m(c,a,b));return e}function c(a,b,d){var e=B[a.localName],f=(e=e&&e[a.namespaceURI])?e.length:0,g=a.getAttributeNS(x,"name"),k=a.getAttributeNS(x,"family"),l;g&&k&&(b=p(g,k,d));if(b)for(g=0;g<f;g+=1)if(k=a.getAttributeNS(e[g].ns,e[g].localname))l=e[g].keyname,k=p(k,l,d),b.requires[k.key]=k;for(g=a.firstChild;g;)g.nodeType===Node.ELEMENT_NODE&&(a=g,c(a,b,d)),g=g.nextSibling;return d}function b(a,d){var c=d[a.family];c||(c=d[a.family]={});c[a.name]=1;Object.keys(a.requires).forEach(function(c){b(a.requires[c],
+d)})}function a(a,d){var e=c(a,null,{});Object.keys(e).forEach(function(a){a=e[a];var c=d[a.family];c&&c.hasOwnProperty(a.name)&&b(a,d)})}function d(a,b){function c(b){(b=f.getAttributeNS(x,b))&&(a[b]=!0)}var e=["font-name","font-name-asian","font-name-complex"],f;if(b)for(f=b.firstChild;f;)f.nodeType===Node.ELEMENT_NODE&&(e.forEach(c),d(a,f)),f=f.nextSibling}function k(a,b){function d(a){var c=e.getAttributeNS(x,a);c&&b.hasOwnProperty(c)&&e.setAttributeNS(x,"style:"+a,b[c])}var c=["font-name","font-name-asian",
+"font-name-complex"],e;if(a)for(e=a.firstChild;e;)e.nodeType===Node.ELEMENT_NODE&&(c.forEach(d),k(e,b)),e=e.nextSibling}var g=odf.Namespaces.chartns,q=odf.Namespaces.dbns,l=odf.Namespaces.dr3dns,r=odf.Namespaces.drawns,t=odf.Namespaces.formns,w=odf.Namespaces.numberns,v=odf.Namespaces.officens,y=odf.Namespaces.presentationns,x=odf.Namespaces.stylens,u=odf.Namespaces.tablens,s=odf.Namespaces.textns,C={"urn:oasis:names:tc:opendocument:xmlns:chart:1.0":"chart:","urn:oasis:names:tc:opendocument:xmlns:database:1.0":"db:",
+"urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0":"dr3d:","urn:oasis:names:tc:opendocument:xmlns:drawing:1.0":"draw:","urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0":"fo:","urn:oasis:names:tc:opendocument:xmlns:form:1.0":"form:","urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0":"number:","urn:oasis:names:tc:opendocument:xmlns:office:1.0":"office:","urn:oasis:names:tc:opendocument:xmlns:presentation:1.0":"presentation:","urn:oasis:names:tc:opendocument:xmlns:style:1.0":"style:","urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0":"svg:",
+"urn:oasis:names:tc:opendocument:xmlns:table:1.0":"table:","urn:oasis:names:tc:opendocument:xmlns:text:1.0":"chart:","http://www.w3.org/XML/1998/namespace":"xml:"},g={text:[{ens:x,en:"tab-stop",ans:x,a:"leader-text-style"},{ens:x,en:"drop-cap",ans:x,a:"style-name"},{ens:s,en:"notes-configuration",ans:s,a:"citation-body-style-name"},{ens:s,en:"notes-configuration",ans:s,a:"citation-style-name"},{ens:s,en:"a",ans:s,a:"style-name"},{ens:s,en:"alphabetical-index",ans:s,a:"style-name"},{ens:s,en:"linenumbering-configuration",
+ans:s,a:"style-name"},{ens:s,en:"list-level-style-number",ans:s,a:"style-name"},{ens:s,en:"ruby-text",ans:s,a:"style-name"},{ens:s,en:"span",ans:s,a:"style-name"},{ens:s,en:"a",ans:s,a:"visited-style-name"},{ens:x,en:"text-properties",ans:x,a:"text-line-through-text-style"},{ens:s,en:"alphabetical-index-source",ans:s,a:"main-entry-style-name"},{ens:s,en:"index-entry-bibliography",ans:s,a:"style-name"},{ens:s,en:"index-entry-chapter",ans:s,a:"style-name"},{ens:s,en:"index-entry-link-end",ans:s,a:"style-name"},
+{ens:s,en:"index-entry-link-start",ans:s,a:"style-name"},{ens:s,en:"index-entry-page-number",ans:s,a:"style-name"},{ens:s,en:"index-entry-span",ans:s,a:"style-name"},{ens:s,en:"index-entry-tab-stop",ans:s,a:"style-name"},{ens:s,en:"index-entry-text",ans:s,a:"style-name"},{ens:s,en:"index-title-template",ans:s,a:"style-name"},{ens:s,en:"list-level-style-bullet",ans:s,a:"style-name"},{ens:s,en:"outline-level-style",ans:s,a:"style-name"}],paragraph:[{ens:r,en:"caption",ans:r,a:"text-style-name"},{ens:r,
+en:"circle",ans:r,a:"text-style-name"},{ens:r,en:"connector",ans:r,a:"text-style-name"},{ens:r,en:"control",ans:r,a:"text-style-name"},{ens:r,en:"custom-shape",ans:r,a:"text-style-name"},{ens:r,en:"ellipse",ans:r,a:"text-style-name"},{ens:r,en:"frame",ans:r,a:"text-style-name"},{ens:r,en:"line",ans:r,a:"text-style-name"},{ens:r,en:"measure",ans:r,a:"text-style-name"},{ens:r,en:"path",ans:r,a:"text-style-name"},{ens:r,en:"polygon",ans:r,a:"text-style-name"},{ens:r,en:"polyline",ans:r,a:"text-style-name"},
+{ens:r,en:"rect",ans:r,a:"text-style-name"},{ens:r,en:"regular-polygon",ans:r,a:"text-style-name"},{ens:v,en:"annotation",ans:r,a:"text-style-name"},{ens:t,en:"column",ans:t,a:"text-style-name"},{ens:x,en:"style",ans:x,a:"next-style-name"},{ens:u,en:"body",ans:u,a:"paragraph-style-name"},{ens:u,en:"even-columns",ans:u,a:"paragraph-style-name"},{ens:u,en:"even-rows",ans:u,a:"paragraph-style-name"},{ens:u,en:"first-column",ans:u,a:"paragraph-style-name"},{ens:u,en:"first-row",ans:u,a:"paragraph-style-name"},
+{ens:u,en:"last-column",ans:u,a:"paragraph-style-name"},{ens:u,en:"last-row",ans:u,a:"paragraph-style-name"},{ens:u,en:"odd-columns",ans:u,a:"paragraph-style-name"},{ens:u,en:"odd-rows",ans:u,a:"paragraph-style-name"},{ens:s,en:"notes-configuration",ans:s,a:"default-style-name"},{ens:s,en:"alphabetical-index-entry-template",ans:s,a:"style-name"},{ens:s,en:"bibliography-entry-template",ans:s,a:"style-name"},{ens:s,en:"h",ans:s,a:"style-name"},{ens:s,en:"illustration-index-entry-template",ans:s,a:"style-name"},
+{ens:s,en:"index-source-style",ans:s,a:"style-name"},{ens:s,en:"object-index-entry-template",ans:s,a:"style-name"},{ens:s,en:"p",ans:s,a:"style-name"},{ens:s,en:"table-index-entry-template",ans:s,a:"style-name"},{ens:s,en:"table-of-content-entry-template",ans:s,a:"style-name"},{ens:s,en:"table-index-entry-template",ans:s,a:"style-name"},{ens:s,en:"user-index-entry-template",ans:s,a:"style-name"},{ens:x,en:"page-layout-properties",ans:x,a:"register-truth-ref-style-name"}],chart:[{ens:g,en:"axis",ans:g,
+a:"style-name"},{ens:g,en:"chart",ans:g,a:"style-name"},{ens:g,en:"data-label",ans:g,a:"style-name"},{ens:g,en:"data-point",ans:g,a:"style-name"},{ens:g,en:"equation",ans:g,a:"style-name"},{ens:g,en:"error-indicator",ans:g,a:"style-name"},{ens:g,en:"floor",ans:g,a:"style-name"},{ens:g,en:"footer",ans:g,a:"style-name"},{ens:g,en:"grid",ans:g,a:"style-name"},{ens:g,en:"legend",ans:g,a:"style-name"},{ens:g,en:"mean-value",ans:g,a:"style-name"},{ens:g,en:"plot-area",ans:g,a:"style-name"},{ens:g,en:"regression-curve",
+ans:g,a:"style-name"},{ens:g,en:"series",ans:g,a:"style-name"},{ens:g,en:"stock-gain-marker",ans:g,a:"style-name"},{ens:g,en:"stock-loss-marker",ans:g,a:"style-name"},{ens:g,en:"stock-range-line",ans:g,a:"style-name"},{ens:g,en:"subtitle",ans:g,a:"style-name"},{ens:g,en:"title",ans:g,a:"style-name"},{ens:g,en:"wall",ans:g,a:"style-name"}],section:[{ens:s,en:"alphabetical-index",ans:s,a:"style-name"},{ens:s,en:"bibliography",ans:s,a:"style-name"},{ens:s,en:"illustration-index",ans:s,a:"style-name"},
+{ens:s,en:"index-title",ans:s,a:"style-name"},{ens:s,en:"object-index",ans:s,a:"style-name"},{ens:s,en:"section",ans:s,a:"style-name"},{ens:s,en:"table-of-content",ans:s,a:"style-name"},{ens:s,en:"table-index",ans:s,a:"style-name"},{ens:s,en:"user-index",ans:s,a:"style-name"}],ruby:[{ens:s,en:"ruby",ans:s,a:"style-name"}],table:[{ens:q,en:"query",ans:q,a:"style-name"},{ens:q,en:"table-representation",ans:q,a:"style-name"},{ens:u,en:"background",ans:u,a:"style-name"},{ens:u,en:"table",ans:u,a:"style-name"}],
+"table-column":[{ens:q,en:"column",ans:q,a:"style-name"},{ens:u,en:"table-column",ans:u,a:"style-name"}],"table-row":[{ens:q,en:"query",ans:q,a:"default-row-style-name"},{ens:q,en:"table-representation",ans:q,a:"default-row-style-name"},{ens:u,en:"table-row",ans:u,a:"style-name"}],"table-cell":[{ens:q,en:"column",ans:q,a:"default-cell-style-name"},{ens:u,en:"table-column",ans:u,a:"default-cell-style-name"},{ens:u,en:"table-row",ans:u,a:"default-cell-style-name"},{ens:u,en:"body",ans:u,a:"style-name"},
+{ens:u,en:"covered-table-cell",ans:u,a:"style-name"},{ens:u,en:"even-columns",ans:u,a:"style-name"},{ens:u,en:"covered-table-cell",ans:u,a:"style-name"},{ens:u,en:"even-columns",ans:u,a:"style-name"},{ens:u,en:"even-rows",ans:u,a:"style-name"},{ens:u,en:"first-column",ans:u,a:"style-name"},{ens:u,en:"first-row",ans:u,a:"style-name"},{ens:u,en:"last-column",ans:u,a:"style-name"},{ens:u,en:"last-row",ans:u,a:"style-name"},{ens:u,en:"odd-columns",ans:u,a:"style-name"},{ens:u,en:"odd-rows",ans:u,a:"style-name"},
+{ens:u,en:"table-cell",ans:u,a:"style-name"}],graphic:[{ens:l,en:"cube",ans:r,a:"style-name"},{ens:l,en:"extrude",ans:r,a:"style-name"},{ens:l,en:"rotate",ans:r,a:"style-name"},{ens:l,en:"scene",ans:r,a:"style-name"},{ens:l,en:"sphere",ans:r,a:"style-name"},{ens:r,en:"caption",ans:r,a:"style-name"},{ens:r,en:"circle",ans:r,a:"style-name"},{ens:r,en:"connector",ans:r,a:"style-name"},{ens:r,en:"control",ans:r,a:"style-name"},{ens:r,en:"custom-shape",ans:r,a:"style-name"},{ens:r,en:"ellipse",ans:r,a:"style-name"},
+{ens:r,en:"frame",ans:r,a:"style-name"},{ens:r,en:"g",ans:r,a:"style-name"},{ens:r,en:"line",ans:r,a:"style-name"},{ens:r,en:"measure",ans:r,a:"style-name"},{ens:r,en:"page-thumbnail",ans:r,a:"style-name"},{ens:r,en:"path",ans:r,a:"style-name"},{ens:r,en:"polygon",ans:r,a:"style-name"},{ens:r,en:"polyline",ans:r,a:"style-name"},{ens:r,en:"rect",ans:r,a:"style-name"},{ens:r,en:"regular-polygon",ans:r,a:"style-name"},{ens:v,en:"annotation",ans:r,a:"style-name"}],presentation:[{ens:l,en:"cube",ans:y,
+a:"style-name"},{ens:l,en:"extrude",ans:y,a:"style-name"},{ens:l,en:"rotate",ans:y,a:"style-name"},{ens:l,en:"scene",ans:y,a:"style-name"},{ens:l,en:"sphere",ans:y,a:"style-name"},{ens:r,en:"caption",ans:y,a:"style-name"},{ens:r,en:"circle",ans:y,a:"style-name"},{ens:r,en:"connector",ans:y,a:"style-name"},{ens:r,en:"control",ans:y,a:"style-name"},{ens:r,en:"custom-shape",ans:y,a:"style-name"},{ens:r,en:"ellipse",ans:y,a:"style-name"},{ens:r,en:"frame",ans:y,a:"style-name"},{ens:r,en:"g",ans:y,a:"style-name"},
+{ens:r,en:"line",ans:y,a:"style-name"},{ens:r,en:"measure",ans:y,a:"style-name"},{ens:r,en:"page-thumbnail",ans:y,a:"style-name"},{ens:r,en:"path",ans:y,a:"style-name"},{ens:r,en:"polygon",ans:y,a:"style-name"},{ens:r,en:"polyline",ans:y,a:"style-name"},{ens:r,en:"rect",ans:y,a:"style-name"},{ens:r,en:"regular-polygon",ans:y,a:"style-name"},{ens:v,en:"annotation",ans:y,a:"style-name"}],"drawing-page":[{ens:r,en:"page",ans:r,a:"style-name"},{ens:y,en:"notes",ans:r,a:"style-name"},{ens:x,en:"handout-master",
+ans:r,a:"style-name"},{ens:x,en:"master-page",ans:r,a:"style-name"}],"list-style":[{ens:s,en:"list",ans:s,a:"style-name"},{ens:s,en:"numbered-paragraph",ans:s,a:"style-name"},{ens:s,en:"list-item",ans:s,a:"style-override"},{ens:x,en:"style",ans:x,a:"list-style-name"}],data:[{ens:x,en:"style",ans:x,a:"data-style-name"},{ens:x,en:"style",ans:x,a:"percentage-data-style-name"},{ens:y,en:"date-time-decl",ans:x,a:"data-style-name"},{ens:s,en:"creation-date",ans:x,a:"data-style-name"},{ens:s,en:"creation-time",
+ans:x,a:"data-style-name"},{ens:s,en:"database-display",ans:x,a:"data-style-name"},{ens:s,en:"date",ans:x,a:"data-style-name"},{ens:s,en:"editing-duration",ans:x,a:"data-style-name"},{ens:s,en:"expression",ans:x,a:"data-style-name"},{ens:s,en:"meta-field",ans:x,a:"data-style-name"},{ens:s,en:"modification-date",ans:x,a:"data-style-name"},{ens:s,en:"modification-time",ans:x,a:"data-style-name"},{ens:s,en:"print-date",ans:x,a:"data-style-name"},{ens:s,en:"print-time",ans:x,a:"data-style-name"},{ens:s,
+en:"table-formula",ans:x,a:"data-style-name"},{ens:s,en:"time",ans:x,a:"data-style-name"},{ens:s,en:"user-defined",ans:x,a:"data-style-name"},{ens:s,en:"user-field-get",ans:x,a:"data-style-name"},{ens:s,en:"user-field-input",ans:x,a:"data-style-name"},{ens:s,en:"variable-get",ans:x,a:"data-style-name"},{ens:s,en:"variable-input",ans:x,a:"data-style-name"},{ens:s,en:"variable-set",ans:x,a:"data-style-name"}],"page-layout":[{ens:y,en:"notes",ans:x,a:"page-layout-name"},{ens:x,en:"handout-master",ans:x,
+a:"page-layout-name"},{ens:x,en:"master-page",ans:x,a:"page-layout-name"}]},B,A=new xmldom.XPath;this.collectUsedFontFaces=d;this.changeFontFaceNames=k;this.UsedStyleList=function(b,d){var c={};this.uses=function(a){var b=a.localName,d=a.getAttributeNS(r,"name")||a.getAttributeNS(x,"name");a="style"===b?a.getAttributeNS(x,"family"):a.namespaceURI===w?"data":b;return(a=c[a])?0<a[d]:!1};n(b,c);d&&a(d,c)};this.hasDerivedStyles=function(a,b,d){var c=b("style"),e=d.getAttributeNS(c,"name");d=d.getAttributeNS(c,
+"family");return A.getODFElementsWithXPath(a,"//style:*[@style:parent-style-name='"+e+"'][@style:family='"+d+"']",b).length?!0:!1};this.prefixStyleNames=function(a,b,d){var c;if(a){for(c=a.firstChild;c;){if(c.nodeType===Node.ELEMENT_NODE){var f=c,g=b,k=f.getAttributeNS(r,"name"),l=void 0;k?l=r:(k=f.getAttributeNS(x,"name"))&&(l=x);l&&f.setAttributeNS(l,C[l]+"name",g+k)}c=c.nextSibling}e(a,b);d&&e(d,b)}};this.removePrefixFromStyleNames=function(a,b,d){var c=RegExp("^"+b);if(a){for(b=a.firstChild;b;){if(b.nodeType===
+Node.ELEMENT_NODE){var e=b,f=c,g=e.getAttributeNS(r,"name"),k=void 0;g?k=r:(g=e.getAttributeNS(x,"name"))&&(k=x);k&&(g=g.replace(f,""),e.setAttributeNS(k,C[k]+"name",g))}b=b.nextSibling}h(a,c);d&&h(d,c)}};this.determineStylesForNode=f;B=function(a){var b,d,c,e,f,g={},k;for(b in a)if(a.hasOwnProperty(b))for(e=a[b],c=e.length,d=0;d<c;d+=1)f=e[d],k=g[f.en]=g[f.en]||{},k=k[f.ens]=k[f.ens]||[],k.push({ns:f.ans,localname:f.a,keyname:b});return g}(g)};
 // Input 30
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-runtime.loadClass("odf.OdfUtils");
-odf.TextSerializer=function(){function h(a){var c="",d=m.filter?m.filter.acceptNode(a):NodeFilter.FILTER_ACCEPT,b=a.nodeType,k;if(d===NodeFilter.FILTER_ACCEPT||d===NodeFilter.FILTER_SKIP)for(k=a.firstChild;k;)c+=h(k),k=k.nextSibling;d===NodeFilter.FILTER_ACCEPT&&(b===Node.ELEMENT_NODE&&f.isParagraph(a)?c+="\n":b===Node.TEXT_NODE&&a.textContent&&(c+=a.textContent));return c}var m=this,f=new odf.OdfUtils;this.filter=null;this.writeToString=function(a){return a?h(a):""}};
-// Input 31
 /*
 
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
@@ -617,6 +560,9 @@ odf.TextSerializer=function(){function h(a){var c="",d=m.filter?m.filter.acceptN
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -637,13 +583,61 @@ odf.TextSerializer=function(){function h(a){var c="",d=m.filter?m.filter.acceptN
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.DomUtils");runtime.loadClass("core.LoopWatchDog");runtime.loadClass("odf.Namespaces");
-odf.TextStyleApplicator=function(h,m,f){function a(a){function c(a,b){return"object"===typeof a&&"object"===typeof b?Object.keys(a).every(function(d){return c(a[d],b[d])}):a===b}this.isStyleApplied=function(b){b=m.getAppliedStylesForElement(b);return c(a,b)}}function c(a){var c={};this.applyStyleToContainer=function(b){var d;d=b.getAttributeNS(k,"style-name");var l=b.ownerDocument;d=d||"";if(!c.hasOwnProperty(d)){var u=d,q;q=d?m.createDerivedStyleObject(d,"text",a):a;l=l.createElementNS(p,"style:style");
-m.updateStyle(l,q);l.setAttributeNS(p,"style:name",h.generateName());l.setAttributeNS(p,"style:family","text");l.setAttributeNS("urn:webodf:names:scope","scope","document-content");f.appendChild(l);c[u]=l}d=c[d].getAttributeNS(p,"name");b.setAttributeNS(k,"text:style-name",d)}}function d(a,c){var d=a.ownerDocument,g=a.parentNode,l,f,h=new core.LoopWatchDog(1E3);f=[];"span"!==g.localName||g.namespaceURI!==k?(l=d.createElementNS(k,"text:span"),g.insertBefore(l,a),g=!1):(a.previousSibling&&!b.rangeContainsNode(c,
-g.firstChild)?(l=g.cloneNode(!1),g.parentNode.insertBefore(l,g.nextSibling)):l=g,g=!0);f.push(a);for(d=a.nextSibling;d&&b.rangeContainsNode(c,d);)h.check(),f.push(d),d=d.nextSibling;f.forEach(function(a){a.parentNode!==l&&l.appendChild(a)});if(d&&g)for(f=l.cloneNode(!1),l.parentNode.insertBefore(f,l.nextSibling);d;)h.check(),g=d.nextSibling,f.appendChild(d),d=g;return l}var b=new core.DomUtils,k=odf.Namespaces.textns,p=odf.Namespaces.stylens;this.applyStyle=function(b,k,f){var g={},l,h,m,p;runtime.assert(f&&
-f["style:text-properties"],"applyStyle without any text properties");g["style:text-properties"]=f["style:text-properties"];m=new c(g);p=new a(g);b.forEach(function(a){l=p.isStyleApplied(a);!1===l&&(h=d(a,k),m.applyStyleToContainer(h))})}};
+runtime.loadClass("core.DomUtils");runtime.loadClass("odf.Namespaces");
+odf.OdfUtils=function(){function e(a){return"image"===(a&&a.localName)&&a.namespaceURI===s}function h(a){return"frame"===(a&&a.localName)&&a.namespaceURI===s&&"as-char"===a.getAttributeNS(u,"anchor-type")}function f(a){var b=a&&a.localName;return("p"===b||"h"===b)&&a.namespaceURI===u}function n(a){for(;a&&!f(a);)a=a.parentNode;return a}function m(a){return/^[ \t\r\n]+$/.test(a)}function p(a){var b=a&&a.localName;return/^(span|p|h|a|meta)$/.test(b)&&a.namespaceURI===u||"span"===b&&"annotationHighlight"===
+a.className?!0:!1}function c(a){var b=a&&a.localName,d;d=!1;b&&(d=a.namespaceURI,d=d===u?"s"===b||"tab"===b||"line-break"===b:h(a));return d}function b(a){var b=a&&a.localName,d=!1;b&&(a=a.namespaceURI,a===u&&(d="s"===b||"tab"===b));return d}function a(a){for(;null!==a.firstChild&&p(a);)a=a.firstChild;return a}function d(a){for(;null!==a.lastChild&&p(a);)a=a.lastChild;return a}function k(a){for(;!f(a)&&null===a.previousSibling;)a=a.parentNode;return f(a)?null:d(a.previousSibling)}function g(b){for(;!f(b)&&
+null===b.nextSibling;)b=b.parentNode;return f(b)?null:a(b.nextSibling)}function q(a){for(var d=!1;a;)if(a.nodeType===Node.TEXT_NODE)if(0===a.length)a=k(a);else return!m(a.data.substr(a.length-1,1));else c(a)?(d=!1===b(a),a=null):a=k(a);return d}function l(b){var d=!1;for(b=b&&a(b);b;){if(b.nodeType===Node.TEXT_NODE&&0<b.length&&!m(b.data)){d=!0;break}if(c(b)){d=!0;break}b=g(b)}return d}function r(a,b){return m(a.data.substr(b))?!l(g(a)):!1}function t(a,b){var d=a.data,e;if(!m(d[b])||c(a.parentNode))return!1;
+0<b?m(d[b-1])||(e=!0):q(k(a))&&(e=!0);return!0===e?r(a,b)?!1:!0:!1}function w(a){return(a=/(-?[0-9]*[0-9][0-9]*(\.[0-9]*)?|0+\.[0-9]*[1-9][0-9]*|\.[0-9]*[1-9][0-9]*)((cm)|(mm)|(in)|(pt)|(pc)|(px)|(%))/.exec(a))?{value:parseFloat(a[1]),unit:a[3]}:null}function v(a){return(a=w(a))&&(0>a.value||"%"===a.unit)?null:a}function y(a){return(a=w(a))&&"%"!==a.unit?null:a}function x(a){switch(a.namespaceURI){case odf.Namespaces.drawns:case odf.Namespaces.svgns:case odf.Namespaces.dr3dns:return!1;case odf.Namespaces.textns:switch(a.localName){case "note-body":case "ruby-text":return!1}break;
+case odf.Namespaces.officens:switch(a.localName){case "annotation":case "binary-data":case "event-listeners":return!1}break;default:switch(a.localName){case "editinfo":return!1}}return!0}var u=odf.Namespaces.textns,s=odf.Namespaces.drawns,C=/^\s*$/,B=new core.DomUtils;this.isImage=e;this.isCharacterFrame=h;this.isTextSpan=function(a){return"span"===(a&&a.localName)&&a.namespaceURI===u};this.isParagraph=f;this.getParagraphElement=n;this.isWithinTrackedChanges=function(a,b){for(;a&&a!==b;){if(a.namespaceURI===
+u&&"tracked-changes"===a.localName)return!0;a=a.parentNode}return!1};this.isListItem=function(a){return"list-item"===(a&&a.localName)&&a.namespaceURI===u};this.isLineBreak=function(a){return"line-break"===(a&&a.localName)&&a.namespaceURI===u};this.isODFWhitespace=m;this.isGroupingElement=p;this.isCharacterElement=c;this.isWhitespaceElement=b;this.firstChild=a;this.lastChild=d;this.previousNode=k;this.nextNode=g;this.scanLeftForNonWhitespace=q;this.lookLeftForCharacter=function(a){var b;b=0;a.nodeType===
+Node.TEXT_NODE&&0<a.length?(b=a.data,b=m(b.substr(b.length-1,1))?1===b.length?q(k(a))?2:0:m(b.substr(b.length-2,1))?0:2:1):c(a)&&(b=1);return b};this.lookRightForCharacter=function(a){var b=!1;a&&a.nodeType===Node.TEXT_NODE&&0<a.length?b=!m(a.data.substr(0,1)):c(a)&&(b=!0);return b};this.scanLeftForAnyCharacter=function(a){var b=!1;for(a=a&&d(a);a;){if(a.nodeType===Node.TEXT_NODE&&0<a.length&&!m(a.data)){b=!0;break}if(c(a)){b=!0;break}a=k(a)}return b};this.scanRightForAnyCharacter=l;this.isTrailingWhitespace=
+r;this.isSignificantWhitespace=t;this.isDowngradableSpaceElement=function(a){return a.namespaceURI===u&&"s"===a.localName?q(k(a))&&l(g(a)):!1};this.getFirstNonWhitespaceChild=function(a){for(a=a&&a.firstChild;a&&a.nodeType===Node.TEXT_NODE&&C.test(a.nodeValue);)a=a.nextSibling;return a};this.parseLength=w;this.parseNonNegativeLength=v;this.parseFoFontSize=function(a){var b;b=(b=w(a))&&(0>=b.value||"%"===b.unit)?null:b;return b||y(a)};this.parseFoLineHeight=function(a){return v(a)||y(a)};this.getImpactedParagraphs=
+function(a){var b=a.commonAncestorContainer,d=[];for(b.nodeType===Node.ELEMENT_NODE&&(d=B.getElementsByTagNameNS(b,u,"p").concat(B.getElementsByTagNameNS(b,u,"h")));b&&!f(b);)b=b.parentNode;b&&d.push(b);return d.filter(function(b){return B.rangeIntersectsNode(a,b)})};this.getTextNodes=function(a,b){var d=a.startContainer.ownerDocument.createRange(),c;c=B.getNodesInRange(a,function(c){d.selectNodeContents(c);if(c.nodeType===Node.TEXT_NODE){if(b&&B.rangesIntersect(a,d)||B.containsRange(a,d))return Boolean(n(c)&&
+(!m(c.textContent)||t(c,0)))?NodeFilter.FILTER_ACCEPT:NodeFilter.FILTER_REJECT}else if(B.rangesIntersect(a,d)&&x(c))return NodeFilter.FILTER_SKIP;return NodeFilter.FILTER_REJECT});d.detach();return c};this.getTextElements=function(a,b,d){var e=a.startContainer.ownerDocument.createRange(),f;f=B.getNodesInRange(a,function(f){e.selectNodeContents(f);if(c(f.parentNode))return NodeFilter.FILTER_REJECT;if(f.nodeType===Node.TEXT_NODE){if(b&&B.rangesIntersect(a,e)||B.containsRange(a,e))if(d||Boolean(n(f)&&
+(!m(f.textContent)||t(f,0))))return NodeFilter.FILTER_ACCEPT}else if(c(f)){if(b&&B.rangesIntersect(a,e)||B.containsRange(a,e))return NodeFilter.FILTER_ACCEPT}else if(x(f)||p(f))return NodeFilter.FILTER_SKIP;return NodeFilter.FILTER_REJECT});e.detach();return f};this.getParagraphElements=function(a){var b=a.startContainer.ownerDocument.createRange(),d;d=B.getNodesInRange(a,function(d){b.selectNodeContents(d);if(f(d)){if(B.rangesIntersect(a,b))return NodeFilter.FILTER_ACCEPT}else if(x(d)||p(d))return NodeFilter.FILTER_SKIP;
+return NodeFilter.FILTER_REJECT});b.detach();return d};this.getImageElements=function(a){var b=a.startContainer.ownerDocument.createRange(),d;d=B.getNodesInRange(a,function(d){b.selectNodeContents(d);return e(d)&&B.containsRange(a,b)?NodeFilter.FILTER_ACCEPT:NodeFilter.FILTER_SKIP});b.detach();return d}};
+// Input 31
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("odf.OdfUtils");
+odf.TextSerializer=function(){function e(n){var m="",p=h.filter?h.filter.acceptNode(n):NodeFilter.FILTER_ACCEPT,c=n.nodeType,b;if(p===NodeFilter.FILTER_ACCEPT||p===NodeFilter.FILTER_SKIP)for(b=n.firstChild;b;)m+=e(b),b=b.nextSibling;p===NodeFilter.FILTER_ACCEPT&&(c===Node.ELEMENT_NODE&&f.isParagraph(n)?m+="\n":c===Node.TEXT_NODE&&n.textContent&&(m+=n.textContent));return m}var h=this,f=new odf.OdfUtils;this.filter=null;this.writeToString=function(f){return f?e(f):""}};
 // Input 32
 /*
 
@@ -657,6 +651,9 @@ f["style:text-properties"],"applyStyle without any text properties");g["style:te
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -677,32 +674,13 @@ f["style:text-properties"],"applyStyle without any text properties");g["style:te
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");runtime.loadClass("xmldom.XPath");runtime.loadClass("core.CSSUnits");
-odf.Style2CSS=function(){function h(a){var c={},b,d;if(!a)return c;for(a=a.firstChild;a;){if(d=a.namespaceURI!==u||"style"!==a.localName&&"default-style"!==a.localName?a.namespaceURI===r&&"list-style"===a.localName?"list":a.namespaceURI!==u||"page-layout"!==a.localName&&"default-page-layout"!==a.localName?void 0:"page":a.getAttributeNS(u,"family"))(b=a.getAttributeNS&&a.getAttributeNS(u,"name"))||(b=""),d=c[d]=c[d]||{},d[b]=a;a=a.nextSibling}return c}function m(a,c){if(!c||!a)return null;if(a[c])return a[c];
-var b,d;for(b in a)if(a.hasOwnProperty(b)&&(d=m(a[b].derivedStyles,c)))return d;return null}function f(a,c,b){var d=c[a],e,g;d&&(e=d.getAttributeNS(u,"parent-style-name"),g=null,e&&(g=m(b,e),!g&&c[e]&&(f(e,c,b),g=c[e],c[e]=null)),g?(g.derivedStyles||(g.derivedStyles={}),g.derivedStyles[a]=d):b[a]=d)}function a(a,c){for(var b in a)a.hasOwnProperty(b)&&(f(b,a,c),a[b]=null)}function c(a,c){var b=w[a],d;if(null===b)return null;d=c?"["+b+'|style-name="'+c+'"]':"";"presentation"===b&&(b="draw",d=c?'[presentation|style-name="'+
-c+'"]':"");return b+"|"+v[a].join(d+","+b+"|")+d}function d(a,b,e){var g=[],k,l;g.push(c(a,b));for(k in e.derivedStyles)if(e.derivedStyles.hasOwnProperty(k))for(l in b=d(a,k,e.derivedStyles[k]),b)b.hasOwnProperty(l)&&g.push(b[l]);return g}function b(a,b,c){if(!a)return null;for(a=a.firstChild;a;){if(a.namespaceURI===b&&a.localName===c)return b=a;a=a.nextSibling}return null}function k(a,b){var c="",d,e;for(d in b)if(b.hasOwnProperty(d)&&(d=b[d],e=a.getAttributeNS(d[0],d[1]))){e=e.trim();if(M.hasOwnProperty(d[1])){var g=
-e.indexOf(" "),k=void 0,l=void 0;-1!==g?(k=e.substring(0,g),l=e.substring(g)):(k=e,l="");(k=W.parseLength(k))&&("pt"===k.unit&&0.75>k.value)&&(e="0.75pt"+l)}d[2]&&(c+=d[2]+":"+e+";")}return c}function p(a){return(a=b(a,u,"text-properties"))?W.parseFoFontSize(a.getAttributeNS(l,"font-size")):null}function e(a){a=a.replace(/^#?([a-f\d])([a-f\d])([a-f\d])$/i,function(a,b,c,d){return b+b+c+c+d+d});return(a=/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(a))?{r:parseInt(a[1],16),g:parseInt(a[2],16),b:parseInt(a[3],
-16)}:null}function s(a,b,c,d){b='text|list[text|style-name="'+b+'"]';var e=c.getAttributeNS(r,"level"),g;c=W.getFirstNonWhitespaceChild(c);c=W.getFirstNonWhitespaceChild(c);var k;c&&(g=c.attributes,k=g["fo:text-indent"]?g["fo:text-indent"].value:void 0,g=g["fo:margin-left"]?g["fo:margin-left"].value:void 0);k||(k="-0.6cm");c="-"===k.charAt(0)?k.substring(1):"-"+k;for(e=e&&parseInt(e,10);1<e;)b+=" > text|list-item > text|list",e-=1;e=b+" > text|list-item > *:not(text|list):first-child";void 0!==g&&
-(g=e+"{margin-left:"+g+";}",a.insertRule(g,a.cssRules.length));d=b+" > text|list-item > *:not(text|list):first-child:before{"+d+";";d+="counter-increment:list;";d+="margin-left:"+k+";";d+="width:"+c+";";d+="display:inline-block}";try{a.insertRule(d,a.cssRules.length)}catch(l){throw l;}}function n(a,c,f,h){if("list"===c)for(var m=h.firstChild,q,v;m;){if(m.namespaceURI===r)if(q=m,"list-level-style-number"===m.localName){var w=q;v=w.getAttributeNS(u,"num-format");var M=w.getAttributeNS(u,"num-suffix"),
-z={1:"decimal",a:"lower-latin",A:"upper-latin",i:"lower-roman",I:"upper-roman"},w=w.getAttributeNS(u,"num-prefix")||"",w=z.hasOwnProperty(v)?w+(" counter(list, "+z[v]+")"):v?w+("'"+v+"';"):w+" ''";M&&(w+=" '"+M+"'");v="content: "+w+";";s(a,f,q,v)}else"list-level-style-image"===m.localName?(v="content: none;",s(a,f,q,v)):"list-level-style-bullet"===m.localName&&(v="content: '"+q.getAttributeNS(r,"bullet-char")+"';",s(a,f,q,v));m=m.nextSibling}else if("page"===c)if(M=q=f="",m=h.getElementsByTagNameNS(u,
-"page-layout-properties")[0],q=m.parentNode.parentNode.parentNode.masterStyles,M="",f+=k(m,fa),v=m.getElementsByTagNameNS(u,"background-image"),0<v.length&&(M=v.item(0).getAttributeNS(y,"href"))&&(f+="background-image: url('odfkit:"+M+"');",v=v.item(0),f+=k(v,J)),"presentation"===aa){if(q)for(v=q.getElementsByTagNameNS(u,"master-page"),z=0;z<v.length;z+=1)if(v[z].getAttributeNS(u,"page-layout-name")===m.parentNode.getAttributeNS(u,"name")){M=v[z].getAttributeNS(u,"name");q="draw|page[draw|master-page-name="+
-M+"] {"+f+"}";M="office|body, draw|page[draw|master-page-name="+M+"] {"+k(m,ma)+" }";try{a.insertRule(q,a.cssRules.length),a.insertRule(M,a.cssRules.length)}catch(ga){throw ga;}}}else{if("text"===aa){q="office|text {"+f+"}";M="office|body {width: "+m.getAttributeNS(l,"page-width")+";}";try{a.insertRule(q,a.cssRules.length),a.insertRule(M,a.cssRules.length)}catch(da){throw da;}}}else{f=d(c,f,h).join(",");m="";if(q=b(h,u,"text-properties")){var z=q,I;v=I="";M=1;q=""+k(z,C);w=z.getAttributeNS(u,"text-underline-style");
-"solid"===w&&(I+=" underline");w=z.getAttributeNS(u,"text-line-through-style");"solid"===w&&(I+=" line-through");I.length&&(q+="text-decoration:"+I+";");if(I=z.getAttributeNS(u,"font-name")||z.getAttributeNS(l,"font-family"))w=pa[I],q+="font-family: "+(w||I)+";";w=z.parentNode;if(z=p(w)){for(;w;){if(z=p(w)){if("%"!==z.unit){v="font-size: "+z.value*M+z.unit+";";break}M*=z.value/100}z=w;I=w="";w=null;"default-style"===z.localName?w=null:(w=z.getAttributeNS(u,"parent-style-name"),I=z.getAttributeNS(u,
-"family"),w=F.getODFElementsWithXPath(O,w?"//style:*[@style:name='"+w+"'][@style:family='"+I+"']":"//style:default-style[@style:family='"+I+"']",odf.Namespaces.resolvePrefix)[0])}v||(v="font-size: "+parseFloat(R)*M+G.getUnits(R)+";");q+=v}m+=q}if(q=b(h,u,"paragraph-properties"))v=q,q=""+k(v,E),M=v.getElementsByTagNameNS(u,"background-image"),0<M.length&&(z=M.item(0).getAttributeNS(y,"href"))&&(q+="background-image: url('odfkit:"+z+"');",M=M.item(0),q+=k(M,J)),(v=v.getAttributeNS(l,"line-height"))&&
-"normal"!==v&&(v=W.parseFoLineHeight(v),q="%"!==v.unit?q+("line-height: "+v.value+v.unit+";"):q+("line-height: "+v.value/100+";")),m+=q;if(q=b(h,u,"graphic-properties"))z=q,q=""+k(z,K),v=z.getAttributeNS(g,"opacity"),M=z.getAttributeNS(g,"fill"),z=z.getAttributeNS(g,"fill-color"),"solid"===M||"hatch"===M?z&&"none"!==z?(v=isNaN(parseFloat(v))?1:parseFloat(v)/100,(z=e(z))&&(q+="background-color: rgba("+z.r+","+z.g+","+z.b+","+v+");")):q+="background: none;":"none"===M&&(q+="background: none;"),m+=q;
-if(q=b(h,u,"drawing-page-properties"))v=""+k(q,K),"true"===q.getAttributeNS(t,"background-visible")&&(v+="background: none;"),m+=v;if(q=b(h,u,"table-cell-properties"))q=""+k(q,B),m+=q;if(q=b(h,u,"table-row-properties"))q=""+k(q,H),m+=q;if(q=b(h,u,"table-column-properties"))q=""+k(q,N),m+=q;if(q=b(h,u,"table-properties"))v=q,q=""+k(v,L),v=v.getAttributeNS(x,"border-model"),"collapsing"===v?q+="border-collapse:collapse;":"separating"===v&&(q+="border-collapse:separate;"),m+=q;if(0!==m.length)try{a.insertRule(f+
-"{"+m+"}",a.cssRules.length)}catch(ia){throw ia;}}for(var A in h.derivedStyles)h.derivedStyles.hasOwnProperty(A)&&n(a,c,A,h.derivedStyles[A])}var g=odf.Namespaces.drawns,l=odf.Namespaces.fons,u=odf.Namespaces.stylens,q=odf.Namespaces.svgns,x=odf.Namespaces.tablens,r=odf.Namespaces.textns,y=odf.Namespaces.xlinkns,t=odf.Namespaces.presentationns,w={graphic:"draw","drawing-page":"draw",paragraph:"text",presentation:"presentation",ruby:"text",section:"text",table:"table","table-cell":"table","table-column":"table",
-"table-row":"table",text:"text",list:"text",page:"office"},v={graphic:"circle connected control custom-shape ellipse frame g line measure page page-thumbnail path polygon polyline rect regular-polygon".split(" "),paragraph:"alphabetical-index-entry-template h illustration-index-entry-template index-source-style object-index-entry-template p table-index-entry-template table-of-content-entry-template user-index-entry-template".split(" "),presentation:"caption circle connector control custom-shape ellipse frame g line measure page-thumbnail path polygon polyline rect regular-polygon".split(" "),
-"drawing-page":"caption circle connector control page custom-shape ellipse frame g line measure page-thumbnail path polygon polyline rect regular-polygon".split(" "),ruby:["ruby","ruby-text"],section:"alphabetical-index bibliography illustration-index index-title object-index section table-of-content table-index user-index".split(" "),table:["background","table"],"table-cell":"body covered-table-cell even-columns even-rows first-column first-row last-column last-row odd-columns odd-rows table-cell".split(" "),
-"table-column":["table-column"],"table-row":["table-row"],text:"a index-entry-chapter index-entry-link-end index-entry-link-start index-entry-page-number index-entry-span index-entry-tab-stop index-entry-text index-title-template linenumbering-configuration list-level-style-number list-level-style-bullet outline-level-style span".split(" "),list:["list-item"]},C=[[l,"color","color"],[l,"background-color","background-color"],[l,"font-weight","font-weight"],[l,"font-style","font-style"]],J=[[u,"repeat",
-"background-repeat"]],E=[[l,"background-color","background-color"],[l,"text-align","text-align"],[l,"text-indent","text-indent"],[l,"padding","padding"],[l,"padding-left","padding-left"],[l,"padding-right","padding-right"],[l,"padding-top","padding-top"],[l,"padding-bottom","padding-bottom"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"margin","margin"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],
-[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"],[l,"border","border"]],K=[[l,"background-color","background-color"],[l,"min-height","min-height"],[g,"stroke","border"],[q,"stroke-color","border-color"],[q,"stroke-width","border-width"],[l,"border","border"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"]],B=[[l,"background-color","background-color"],[l,"border-left","border-left"],[l,"border-right",
-"border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"border","border"]],N=[[u,"column-width","width"]],H=[[u,"row-height","height"],[l,"keep-together",null]],L=[[u,"width","width"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"]],fa=[[l,"background-color","background-color"],[l,"padding","padding"],[l,"padding-left","padding-left"],[l,"padding-right","padding-right"],[l,"padding-top",
-"padding-top"],[l,"padding-bottom","padding-bottom"],[l,"border","border"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"margin","margin"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"]],ma=[[l,"page-width","width"],[l,"page-height","height"]],M={border:!0,"border-left":!0,"border-right":!0,"border-top":!0,"border-bottom":!0,
-"stroke-width":!0},pa={},W=new odf.OdfUtils,aa,O,R,F=new xmldom.XPath,G=new core.CSSUnits;this.style2css=function(c,b,d,e,g){for(var k,l,f,q;b.cssRules.length;)b.deleteRule(b.cssRules.length-1);k=null;e&&(k=e.ownerDocument,O=e.parentNode);g&&(k=g.ownerDocument,O=g.parentNode);if(k)for(q in odf.Namespaces.forEachPrefix(function(a,c){f="@namespace "+a+" url("+c+");";try{b.insertRule(f,b.cssRules.length)}catch(d){}}),pa=d,aa=c,R=runtime.getWindow().getComputedStyle(document.body,null).getPropertyValue("font-size")||
-"12pt",c=h(e),e=h(g),g={},w)if(w.hasOwnProperty(q))for(l in d=g[q]={},a(c[q],d),a(e[q],d),d)d.hasOwnProperty(l)&&n(b,q,l,d[l])}};
+runtime.loadClass("core.DomUtils");runtime.loadClass("core.LoopWatchDog");runtime.loadClass("odf.Namespaces");
+odf.TextStyleApplicator=function(e,h,f){function n(a){function b(a,d){return"object"===typeof a&&"object"===typeof d?Object.keys(a).every(function(c){return b(a[c],d[c])}):a===d}this.isStyleApplied=function(c){c=h.getAppliedStylesForElement(c);return b(a,c)}}function m(d){var c={};this.applyStyleToContainer=function(g){var q;q=g.getAttributeNS(b,"style-name");var l=g.ownerDocument;q=q||"";if(!c.hasOwnProperty(q)){var m=q,p;p=q?h.createDerivedStyleObject(q,"text",d):d;l=l.createElementNS(a,"style:style");
+h.updateStyle(l,p);l.setAttributeNS(a,"style:name",e.generateStyleName());l.setAttributeNS(a,"style:family","text");l.setAttributeNS("urn:webodf:names:scope","scope","document-content");f.appendChild(l);c[m]=l}q=c[q].getAttributeNS(a,"name");g.setAttributeNS(b,"text:style-name",q)}}function p(a,e){var f=a.ownerDocument,h=a.parentNode,l,m,p=new core.LoopWatchDog(1E3);m=[];"span"!==h.localName||h.namespaceURI!==b?(l=f.createElementNS(b,"text:span"),h.insertBefore(l,a),h=!1):(a.previousSibling&&!c.rangeContainsNode(e,
+h.firstChild)?(l=h.cloneNode(!1),h.parentNode.insertBefore(l,h.nextSibling)):l=h,h=!0);m.push(a);for(f=a.nextSibling;f&&c.rangeContainsNode(e,f);)p.check(),m.push(f),f=f.nextSibling;m.forEach(function(a){a.parentNode!==l&&l.appendChild(a)});if(f&&h)for(m=l.cloneNode(!1),l.parentNode.insertBefore(m,l.nextSibling);f;)p.check(),h=f.nextSibling,m.appendChild(f),f=h;return l}var c=new core.DomUtils,b=odf.Namespaces.textns,a=odf.Namespaces.stylens;this.applyStyle=function(a,b,c){var e={},f,h,t,w;runtime.assert(c&&
+c["style:text-properties"],"applyStyle without any text properties");e["style:text-properties"]=c["style:text-properties"];t=new m(e);w=new n(e);a.forEach(function(a){f=w.isStyleApplied(a);!1===f&&(h=p(a,b),t.applyStyleToContainer(h))})}};
 // Input 33
 /*
 
@@ -716,6 +694,9 @@ if(q=b(h,u,"drawing-page-properties"))v=""+k(q,K),"true"===q.getAttributeNS(t,"b
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -736,30 +717,32 @@ if(q=b(h,u,"drawing-page-properties"))v=""+k(q,K),"true"===q.getAttributeNS(t,"b
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.Base64");runtime.loadClass("core.Zip");runtime.loadClass("xmldom.LSSerializer");runtime.loadClass("odf.StyleInfo");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfNodeFilter");
-odf.OdfContainer=function(){function h(a,c,b){for(a=a?a.firstChild:null;a;){if(a.localName===b&&a.namespaceURI===c)return a;a=a.nextSibling}return null}function m(a){var c,b=p.length;for(c=0;c<b;c+=1)if("urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI&&a.localName===p[c])return c;return-1}function f(a,c){var b=new k.UsedStyleList(a,c),d=new odf.OdfNodeFilter;this.acceptNode=function(a){var e=d.acceptNode(a);e===NodeFilter.FILTER_ACCEPT&&(a.parentNode===c&&a.nodeType===Node.ELEMENT_NODE)&&
-(e=b.uses(a)?NodeFilter.FILTER_ACCEPT:NodeFilter.FILTER_REJECT);return e}}function a(a,c){var b=new f(a,c);this.acceptNode=function(a){var c=b.acceptNode(a);c!==NodeFilter.FILTER_ACCEPT||(!a.parentNode||a.parentNode.namespaceURI!==odf.Namespaces.textns||"s"!==a.parentNode.localName&&"tab"!==a.parentNode.localName)||(c=NodeFilter.FILTER_REJECT);return c}}function c(a,c){if(c){var b=m(c),d,e=a.firstChild;if(-1!==b){for(;e;){d=m(e);if(-1!==d&&d>b)break;e=e.nextSibling}a.insertBefore(c,e)}}}function d(a){this.OdfContainer=
-a}function b(a,c,b,d){var e=this;this.size=0;this.type=null;this.name=a;this.container=b;this.onchange=this.onreadystatechange=this.document=this.mimetype=this.url=null;this.EMPTY=0;this.LOADING=1;this.DONE=2;this.state=this.EMPTY;this.load=function(){null!==d&&(this.mimetype=c,d.loadAsDataURL(a,c,function(a,c){a&&runtime.log(a);e.url=c;if(e.onchange)e.onchange(e);if(e.onstatereadychange)e.onstatereadychange(e)}))}}var k=new odf.StyleInfo,p="meta settings scripts font-face-decls styles automatic-styles master-styles body".split(" "),
-e=(new Date).getTime()+"_webodf_",s=new core.Base64;d.prototype=new function(){};d.prototype.constructor=d;d.namespaceURI="urn:oasis:names:tc:opendocument:xmlns:office:1.0";d.localName="document";b.prototype.load=function(){};b.prototype.getUrl=function(){return this.data?"data:;base64,"+s.toBase64(this.data):null};odf.OdfContainer=function g(l,m){function q(a){for(var c=a.firstChild,b;c;)b=c.nextSibling,c.nodeType===Node.ELEMENT_NODE?q(c):c.nodeType===Node.PROCESSING_INSTRUCTION_NODE&&a.removeChild(c),
-c=b}function p(a,c){for(var b=a&&a.firstChild;b;)b.nodeType===Node.ELEMENT_NODE&&b.setAttributeNS("urn:webodf:names:scope","scope",c),b=b.nextSibling}function r(a,c){var b=null,d,e,g;if(a)for(b=a.cloneNode(!0),d=b.firstChild;d;)e=d.nextSibling,d.nodeType===Node.ELEMENT_NODE&&(g=d.getAttributeNS("urn:webodf:names:scope","scope"))&&g!==c&&b.removeChild(d),d=e;return b}function y(a){var c=F.rootElement.ownerDocument,b;if(a){q(a.documentElement);try{b=c.importNode(a.documentElement,!0)}catch(d){}}return b}
-function t(a){F.state=a;if(F.onchange)F.onchange(F);if(F.onstatereadychange)F.onstatereadychange(F)}function s(a){T=null;F.rootElement=a;a.fontFaceDecls=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls");a.styles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","styles");a.automaticStyles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","automatic-styles");a.masterStyles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","master-styles");a.body=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-"body");a.meta=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","meta")}function v(a){a=y(a);var b=F.rootElement;a&&"document-styles"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI?(b.fontFaceDecls=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls"),c(b,b.fontFaceDecls),b.styles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","styles"),c(b,b.styles),b.automaticStyles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","automatic-styles"),
-p(b.automaticStyles,"document-styles"),c(b,b.automaticStyles),b.masterStyles=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","master-styles"),c(b,b.masterStyles),k.prefixStyleNames(b.automaticStyles,e,b.masterStyles)):t(g.INVALID)}function C(a){a=y(a);var b,d,e;if(a&&"document-content"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI){b=F.rootElement;d=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls");if(b.fontFaceDecls&&d)for(e=d.firstChild;e;)b.fontFaceDecls.appendChild(e),
-e=d.firstChild;else d&&(b.fontFaceDecls=d,c(b,d));d=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","automatic-styles");p(d,"document-content");if(b.automaticStyles&&d)for(e=d.firstChild;e;)b.automaticStyles.appendChild(e),e=d.firstChild;else d&&(b.automaticStyles=d,c(b,d));b.body=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","body");c(b,b.body)}else t(g.INVALID)}function J(a){a=y(a);var b;a&&("document-meta"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI)&&
-(b=F.rootElement,b.meta=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","meta"),c(b,b.meta))}function E(a){a=y(a);var b;a&&("document-settings"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI)&&(b=F.rootElement,b.settings=h(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","settings"),c(b,b.settings))}function K(a){a=y(a);var b;if(a&&"manifest"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"===a.namespaceURI)for(b=F.rootElement,b.manifest=
-a,a=b.manifest.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&("file-entry"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"===a.namespaceURI)&&(D[a.getAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","full-path")]=a.getAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","media-type")),a=a.nextSibling}function B(a){var b=a.shift(),c,d;b?(c=b[0],d=b[1],G.loadAsDOM(c,function(b,c){d(c);b||F.state===g.INVALID||B(a)})):t(g.DONE)}function N(a){var b="";odf.Namespaces.forEachPrefix(function(a,
-c){b+=" xmlns:"+a+'="'+c+'"'});return'<?xml version="1.0" encoding="UTF-8"?><office:'+a+" "+b+' office:version="1.2">'}function H(){var a=new xmldom.LSSerializer,b=N("document-meta");a.filter=new odf.OdfNodeFilter;b+=a.writeToString(F.rootElement.meta,odf.Namespaces.namespaceMap);return b+"</office:document-meta>"}function L(a,b){var c=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest:file-entry");c.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0",
-"manifest:full-path",a);c.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest:media-type",b);return c}function fa(){var a=runtime.parseXML('<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"></manifest:manifest>'),b=h(a,"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest"),c=new xmldom.LSSerializer,d;for(d in D)D.hasOwnProperty(d)&&b.appendChild(L(d,D[d]));c.filter=new odf.OdfNodeFilter;return'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'+
-c.writeToString(a,odf.Namespaces.namespaceMap)}function ma(){var a=new xmldom.LSSerializer,b=N("document-settings");a.filter=new odf.OdfNodeFilter;b+=a.writeToString(F.rootElement.settings,odf.Namespaces.namespaceMap);return b+"</office:document-settings>"}function M(){var a=odf.Namespaces.namespaceMap,b=new xmldom.LSSerializer,c=r(F.rootElement.automaticStyles,"document-styles"),d=F.rootElement.masterStyles&&F.rootElement.masterStyles.cloneNode(!0),g=N("document-styles");k.removePrefixFromStyleNames(c,
-e,d);b.filter=new f(d,c);g+=b.writeToString(F.rootElement.fontFaceDecls,a);g+=b.writeToString(F.rootElement.styles,a);g+=b.writeToString(c,a);g+=b.writeToString(d,a);return g+"</office:document-styles>"}function pa(){var b=odf.Namespaces.namespaceMap,c=new xmldom.LSSerializer,d=r(F.rootElement.automaticStyles,"document-content"),e=N("document-content");c.filter=new a(F.rootElement.body,d);e+=c.writeToString(d,b);e+=c.writeToString(F.rootElement.body,b);return e+"</office:document-content>"}function W(a,
-b){runtime.loadXML(a,function(a,c){if(a)b(a);else{var d=y(c);d&&"document"===d.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===d.namespaceURI?(s(d),t(g.DONE)):t(g.INVALID)}})}function aa(){function a(b,c){var e;c||(c=b);e=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0",c);d[b]=e;d.appendChild(e)}var b=new core.Zip("",null),c=runtime.byteArrayFromString("application/vnd.oasis.opendocument.text","utf8"),d=F.rootElement,e=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-"text");b.save("mimetype",c,!1,new Date);a("meta");a("settings");a("scripts");a("fontFaceDecls","font-face-decls");a("styles");a("automaticStyles","automatic-styles");a("masterStyles","master-styles");a("body");d.body.appendChild(e);t(g.DONE);return b}function O(){var a,b=new Date;a=runtime.byteArrayFromString(ma(),"utf8");G.save("settings.xml",a,!0,b);a=runtime.byteArrayFromString(H(),"utf8");G.save("meta.xml",a,!0,b);a=runtime.byteArrayFromString(M(),"utf8");G.save("styles.xml",a,!0,b);a=runtime.byteArrayFromString(pa(),
-"utf8");G.save("content.xml",a,!0,b);a=runtime.byteArrayFromString(fa(),"utf8");G.save("META-INF/manifest.xml",a,!0,b)}function R(a,b){O();G.writeAs(a,function(a){b(a)})}var F=this,G,D={},T;this.onstatereadychange=m;this.rootElement=this.state=this.onchange=null;this.setRootElement=s;this.getContentElement=function(){var a;T||(a=F.rootElement.body,T=a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0","text")[0]||a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0",
-"presentation")[0]||a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0","spreadsheet")[0]);return T};this.getDocumentType=function(){var a=F.getContentElement();return a&&a.localName};this.getPart=function(a){return new b(a,D[a],F,G)};this.getPartData=function(a,b){G.load(a,b)};this.createByteArray=function(a,b){O();G.createByteArray(a,b)};this.saveAs=R;this.save=function(a){R(l,a)};this.getUrl=function(){return l};this.state=g.LOADING;this.rootElement=function(a){var b=document.createElementNS(a.namespaceURI,
-a.localName),c;a=new a;for(c in a)a.hasOwnProperty(c)&&(b[c]=a[c]);return b}(d);G=l?new core.Zip(l,function(a,b){G=b;a?W(l,function(b){a&&(G.error=a+"\n"+b,t(g.INVALID))}):B([["styles.xml",v],["content.xml",C],["meta.xml",J],["settings.xml",E],["META-INF/manifest.xml",K]])}):aa()};odf.OdfContainer.EMPTY=0;odf.OdfContainer.LOADING=1;odf.OdfContainer.DONE=2;odf.OdfContainer.INVALID=3;odf.OdfContainer.SAVING=4;odf.OdfContainer.MODIFIED=5;odf.OdfContainer.getContainer=function(a){return new odf.OdfContainer(a,
-null)};return odf.OdfContainer}();
+runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");runtime.loadClass("xmldom.XPath");runtime.loadClass("core.CSSUnits");
+odf.Style2CSS=function(){function e(a){var b={},d,c;if(!a)return b;for(a=a.firstChild;a;){if(c=a.namespaceURI!==r||"style"!==a.localName&&"default-style"!==a.localName?a.namespaceURI===v&&"list-style"===a.localName?"list":a.namespaceURI!==r||"page-layout"!==a.localName&&"default-page-layout"!==a.localName?void 0:"page":a.getAttributeNS(r,"family"))(d=a.getAttributeNS&&a.getAttributeNS(r,"name"))||(d=""),c=b[c]=b[c]||{},c[d]=a;a=a.nextSibling}return b}function h(a,b){if(!b||!a)return null;if(a[b])return a[b];
+var d,c;for(d in a)if(a.hasOwnProperty(d)&&(c=h(a[d].derivedStyles,b)))return c;return null}function f(a,b,d){var c=b[a],e,g;c&&(e=c.getAttributeNS(r,"parent-style-name"),g=null,e&&(g=h(d,e),!g&&b[e]&&(f(e,b,d),g=b[e],b[e]=null)),g?(g.derivedStyles||(g.derivedStyles={}),g.derivedStyles[a]=c):d[a]=c)}function n(a,b){for(var d in a)a.hasOwnProperty(d)&&(f(d,a,b),a[d]=null)}function m(a,b){var d=u[a],c;if(null===d)return null;c=b?"["+d+'|style-name="'+b+'"]':"";"presentation"===d&&(d="draw",c=b?'[presentation|style-name="'+
+b+'"]':"");return d+"|"+s[a].join(c+","+d+"|")+c}function p(a,b,d){var c=[],e,f;c.push(m(a,b));for(e in d.derivedStyles)if(d.derivedStyles.hasOwnProperty(e))for(f in b=p(a,e,d.derivedStyles[e]),b)b.hasOwnProperty(f)&&c.push(b[f]);return c}function c(a,b,d){if(!a)return null;for(a=a.firstChild;a;){if(a.namespaceURI===b&&a.localName===d)return b=a;a=a.nextSibling}return null}function b(a,b){var d="",c,e;for(c in b)if(b.hasOwnProperty(c)&&(c=b[c],e=a.getAttributeNS(c[0],c[1]))){e=e.trim();if(T.hasOwnProperty(c[1])){var f=
+e.indexOf(" "),g=void 0,k=void 0;-1!==f?(g=e.substring(0,f),k=e.substring(f)):(g=e,k="");(g=$.parseLength(g))&&"pt"===g.unit&&0.75>g.value&&(e="0.75pt"+k)}c[2]&&(d+=c[2]+":"+e+";")}return d}function a(a){return(a=c(a,r,"text-properties"))?$.parseFoFontSize(a.getAttributeNS(l,"font-size")):null}function d(a){a=a.replace(/^#?([a-f\d])([a-f\d])([a-f\d])$/i,function(a,b,d,c){return b+b+d+d+c+c});return(a=/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(a))?{r:parseInt(a[1],16),g:parseInt(a[2],16),b:parseInt(a[3],
+16)}:null}function k(a,b,d,c){b='text|list[text|style-name="'+b+'"]';var e=d.getAttributeNS(v,"level"),f;d=$.getFirstNonWhitespaceChild(d);d=$.getFirstNonWhitespaceChild(d);var g;d&&(f=d.attributes,g=f["fo:text-indent"]?f["fo:text-indent"].value:void 0,f=f["fo:margin-left"]?f["fo:margin-left"].value:void 0);g||(g="-0.6cm");d="-"===g.charAt(0)?g.substring(1):"-"+g;for(e=e&&parseInt(e,10);1<e;)b+=" > text|list-item > text|list",e-=1;e=b+" > text|list-item > *:not(text|list):first-child";void 0!==f&&
+(f=e+"{margin-left:"+f+";}",a.insertRule(f,a.cssRules.length));c=b+" > text|list-item > *:not(text|list):first-child:before{"+c+";";c+="counter-increment:list;";c+="margin-left:"+g+";";c+="width:"+d+";";c+="display:inline-block}";try{a.insertRule(c,a.cssRules.length)}catch(k){throw k;}}function g(e,f,h,m){if("list"===f)for(var s=m.firstChild,n,t;s;){if(s.namespaceURI===v)if(n=s,"list-level-style-number"===s.localName){var u=n;t=u.getAttributeNS(r,"num-format");var Q=u.getAttributeNS(r,"num-suffix"),
+J={1:"decimal",a:"lower-latin",A:"upper-latin",i:"lower-roman",I:"upper-roman"},u=u.getAttributeNS(r,"num-prefix")||"",u=J.hasOwnProperty(t)?u+(" counter(list, "+J[t]+")"):t?u+("'"+t+"';"):u+" ''";Q&&(u+=" '"+Q+"'");t="content: "+u+";";k(e,h,n,t)}else"list-level-style-image"===s.localName?(t="content: none;",k(e,h,n,t)):"list-level-style-bullet"===s.localName&&(t="content: '"+n.getAttributeNS(v,"bullet-char")+"';",k(e,h,n,t));s=s.nextSibling}else if("page"===f)if(Q=n=h="",s=m.getElementsByTagNameNS(r,
+"page-layout-properties")[0],n=s.parentNode.parentNode.parentNode.masterStyles,Q="",h+=b(s,Z),t=s.getElementsByTagNameNS(r,"background-image"),0<t.length&&(Q=t.item(0).getAttributeNS(y,"href"))&&(h+="background-image: url('odfkit:"+Q+"');",t=t.item(0),h+=b(t,B)),"presentation"===ha){if(n)for(t=n.getElementsByTagNameNS(r,"master-page"),J=0;J<t.length;J+=1)if(t[J].getAttributeNS(r,"page-layout-name")===s.parentNode.getAttributeNS(r,"name")){Q=t[J].getAttributeNS(r,"name");n="draw|page[draw|master-page-name="+
+Q+"] {"+h+"}";Q="office|body, draw|page[draw|master-page-name="+Q+"] {"+b(s,ka)+" }";try{e.insertRule(n,e.cssRules.length),e.insertRule(Q,e.cssRules.length)}catch(T){throw T;}}}else{if("text"===ha){n="office|text {"+h+"}";Q="office|body {width: "+s.getAttributeNS(l,"page-width")+";}";try{e.insertRule(n,e.cssRules.length),e.insertRule(Q,e.cssRules.length)}catch(oa){throw oa;}}}else{h=p(f,h,m).join(",");s="";if(n=c(m,r,"text-properties")){var J=n,D;t=D="";Q=1;n=""+b(J,C);u=J.getAttributeNS(r,"text-underline-style");
+"solid"===u&&(D+=" underline");u=J.getAttributeNS(r,"text-line-through-style");"solid"===u&&(D+=" line-through");D.length&&(n+="text-decoration:"+D+";");if(D=J.getAttributeNS(r,"font-name")||J.getAttributeNS(l,"font-family"))u=ra[D],n+="font-family: "+(u||D)+";";u=J.parentNode;if(J=a(u)){for(;u;){if(J=a(u)){if("%"!==J.unit){t="font-size: "+J.value*Q+J.unit+";";break}Q*=J.value/100}J=u;D=u="";u=null;"default-style"===J.localName?u=null:(u=J.getAttributeNS(r,"parent-style-name"),D=J.getAttributeNS(r,
+"family"),u=W.getODFElementsWithXPath(U,u?"//style:*[@style:name='"+u+"'][@style:family='"+D+"']":"//style:default-style[@style:family='"+D+"']",odf.Namespaces.resolvePrefix)[0])}t||(t="font-size: "+parseFloat(O)*Q+E.getUnits(O)+";");n+=t}s+=n}if(n=c(m,r,"paragraph-properties"))t=n,n=""+b(t,A),Q=t.getElementsByTagNameNS(r,"background-image"),0<Q.length&&(J=Q.item(0).getAttributeNS(y,"href"))&&(n+="background-image: url('odfkit:"+J+"');",Q=Q.item(0),n+=b(Q,B)),(t=t.getAttributeNS(l,"line-height"))&&
+"normal"!==t&&(t=$.parseFoLineHeight(t),n="%"!==t.unit?n+("line-height: "+t.value+t.unit+";"):n+("line-height: "+t.value/100+";")),s+=n;if(n=c(m,r,"graphic-properties"))J=n,n=""+b(J,I),t=J.getAttributeNS(q,"opacity"),Q=J.getAttributeNS(q,"fill"),J=J.getAttributeNS(q,"fill-color"),"solid"===Q||"hatch"===Q?J&&"none"!==J?(t=isNaN(parseFloat(t))?1:parseFloat(t)/100,(J=d(J))&&(n+="background-color: rgba("+J.r+","+J.g+","+J.b+","+t+");")):n+="background: none;":"none"===Q&&(n+="background: none;"),s+=n;
+if(n=c(m,r,"drawing-page-properties"))t=""+b(n,I),"true"===n.getAttributeNS(x,"background-visible")&&(t+="background: none;"),s+=t;if(n=c(m,r,"table-cell-properties"))n=""+b(n,z),s+=n;if(n=c(m,r,"table-row-properties"))n=""+b(n,G),s+=n;if(n=c(m,r,"table-column-properties"))n=""+b(n,N),s+=n;if(n=c(m,r,"table-properties"))t=n,n=""+b(t,R),t=t.getAttributeNS(w,"border-model"),"collapsing"===t?n+="border-collapse:collapse;":"separating"===t&&(n+="border-collapse:separate;"),s+=n;if(0!==s.length)try{e.insertRule(h+
+"{"+s+"}",e.cssRules.length)}catch(fa){throw fa;}}for(var F in m.derivedStyles)m.derivedStyles.hasOwnProperty(F)&&g(e,f,F,m.derivedStyles[F])}var q=odf.Namespaces.drawns,l=odf.Namespaces.fons,r=odf.Namespaces.stylens,t=odf.Namespaces.svgns,w=odf.Namespaces.tablens,v=odf.Namespaces.textns,y=odf.Namespaces.xlinkns,x=odf.Namespaces.presentationns,u={graphic:"draw","drawing-page":"draw",paragraph:"text",presentation:"presentation",ruby:"text",section:"text",table:"table","table-cell":"table","table-column":"table",
+"table-row":"table",text:"text",list:"text",page:"office"},s={graphic:"circle connected control custom-shape ellipse frame g line measure page page-thumbnail path polygon polyline rect regular-polygon".split(" "),paragraph:"alphabetical-index-entry-template h illustration-index-entry-template index-source-style object-index-entry-template p table-index-entry-template table-of-content-entry-template user-index-entry-template".split(" "),presentation:"caption circle connector control custom-shape ellipse frame g line measure page-thumbnail path polygon polyline rect regular-polygon".split(" "),
+"drawing-page":"caption circle connector control page custom-shape ellipse frame g line measure page-thumbnail path polygon polyline rect regular-polygon".split(" "),ruby:["ruby","ruby-text"],section:"alphabetical-index bibliography illustration-index index-title object-index section table-of-content table-index user-index".split(" "),table:["background","table"],"table-cell":"body covered-table-cell even-columns even-rows first-column first-row last-column last-row odd-columns odd-rows table-cell".split(" "),
+"table-column":["table-column"],"table-row":["table-row"],text:"a index-entry-chapter index-entry-link-end index-entry-link-start index-entry-page-number index-entry-span index-entry-tab-stop index-entry-text index-title-template linenumbering-configuration list-level-style-number list-level-style-bullet outline-level-style span".split(" "),list:["list-item"]},C=[[l,"color","color"],[l,"background-color","background-color"],[l,"font-weight","font-weight"],[l,"font-style","font-style"]],B=[[r,"repeat",
+"background-repeat"]],A=[[l,"background-color","background-color"],[l,"text-align","text-align"],[l,"text-indent","text-indent"],[l,"padding","padding"],[l,"padding-left","padding-left"],[l,"padding-right","padding-right"],[l,"padding-top","padding-top"],[l,"padding-bottom","padding-bottom"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"margin","margin"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],
+[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"],[l,"border","border"]],I=[[l,"background-color","background-color"],[l,"min-height","min-height"],[q,"stroke","border"],[t,"stroke-color","border-color"],[t,"stroke-width","border-width"],[l,"border","border"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"]],z=[[l,"background-color","background-color"],[l,"border-left","border-left"],[l,"border-right",
+"border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"border","border"]],N=[[r,"column-width","width"]],G=[[r,"row-height","height"],[l,"keep-together",null]],R=[[r,"width","width"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"]],Z=[[l,"background-color","background-color"],[l,"padding","padding"],[l,"padding-left","padding-left"],[l,"padding-right","padding-right"],[l,"padding-top",
+"padding-top"],[l,"padding-bottom","padding-bottom"],[l,"border","border"],[l,"border-left","border-left"],[l,"border-right","border-right"],[l,"border-top","border-top"],[l,"border-bottom","border-bottom"],[l,"margin","margin"],[l,"margin-left","margin-left"],[l,"margin-right","margin-right"],[l,"margin-top","margin-top"],[l,"margin-bottom","margin-bottom"]],ka=[[l,"page-width","width"],[l,"page-height","height"]],T={border:!0,"border-left":!0,"border-right":!0,"border-top":!0,"border-bottom":!0,
+"stroke-width":!0},ra={},$=new odf.OdfUtils,ha,U,O,W=new xmldom.XPath,E=new core.CSSUnits;this.style2css=function(a,b,d,c,f){for(var k,h,l,m;b.cssRules.length;)b.deleteRule(b.cssRules.length-1);k=null;c&&(k=c.ownerDocument,U=c.parentNode);f&&(k=f.ownerDocument,U=f.parentNode);if(k)for(m in odf.Namespaces.forEachPrefix(function(a,d){l="@namespace "+a+" url("+d+");";try{b.insertRule(l,b.cssRules.length)}catch(c){}}),ra=d,ha=a,O=runtime.getWindow().getComputedStyle(document.body,null).getPropertyValue("font-size")||
+"12pt",a=e(c),c=e(f),f={},u)if(u.hasOwnProperty(m))for(h in d=f[m]={},n(a[m],d),n(c[m],d),d)d.hasOwnProperty(h)&&g(b,m,h,d[h])}};
 // Input 34
 /*
 
@@ -773,6 +756,9 @@ null)};return odf.OdfContainer}();
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -793,12 +779,32 @@ null)};return odf.OdfContainer}();
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.Base64");runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.OdfContainer");
-odf.FontLoader=function(){function h(a,c,d,b,k){var m,e=0,s;for(s in a)if(a.hasOwnProperty(s)){if(e===d){m=s;break}e+=1}m?c.getPartData(a[m].href,function(e,g){if(e)runtime.log(e);else{var l="@font-face { font-family: '"+(a[m].family||m)+"'; src: url(data:application/x-font-ttf;charset=binary;base64,"+f.convertUTF8ArrayToBase64(g)+') format("truetype"); }';try{b.insertRule(l,b.cssRules.length)}catch(s){runtime.log("Problem inserting rule in CSS: "+runtime.toJson(s)+"\nRule: "+l)}}h(a,c,d+1,b,k)}):
-k&&k()}var m=new xmldom.XPath,f=new core.Base64;odf.FontLoader=function(){this.loadFonts=function(a,c){for(var d=a.rootElement.fontFaceDecls;c.cssRules.length;)c.deleteRule(c.cssRules.length-1);if(d){var b={},k,f,e,s;if(d)for(d=m.getODFElementsWithXPath(d,"style:font-face[svg:font-face-src]",odf.Namespaces.resolvePrefix),k=0;k<d.length;k+=1)f=d[k],e=f.getAttributeNS(odf.Namespaces.stylens,"name"),s=f.getAttributeNS(odf.Namespaces.svgns,"font-family"),f=m.getODFElementsWithXPath(f,"svg:font-face-src/svg:font-face-uri",
-odf.Namespaces.resolvePrefix),0<f.length&&(f=f[0].getAttributeNS(odf.Namespaces.xlinkns,"href"),b[e]={href:f,family:s});h(b,a,0,c)}}};return odf.FontLoader}();
+runtime.loadClass("core.Base64");runtime.loadClass("core.Zip");runtime.loadClass("xmldom.LSSerializer");runtime.loadClass("odf.StyleInfo");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfNodeFilter");
+odf.OdfContainer=function(){function e(a,b,d){for(a=a?a.firstChild:null;a;){if(a.localName===d&&a.namespaceURI===b)return a;a=a.nextSibling}return null}function h(a){var b,c=d.length;for(b=0;b<c;b+=1)if("urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI&&a.localName===d[b])return b;return-1}function f(a,d){var c=new b.UsedStyleList(a,d),e=new odf.OdfNodeFilter;this.acceptNode=function(a){var b=e.acceptNode(a);b===NodeFilter.FILTER_ACCEPT&&a.parentNode===d&&a.nodeType===Node.ELEMENT_NODE&&
+(b=c.uses(a)?NodeFilter.FILTER_ACCEPT:NodeFilter.FILTER_REJECT);return b}}function n(a,b){var d=new f(a,b);this.acceptNode=function(a){var b=d.acceptNode(a);b!==NodeFilter.FILTER_ACCEPT||!a.parentNode||a.parentNode.namespaceURI!==odf.Namespaces.textns||"s"!==a.parentNode.localName&&"tab"!==a.parentNode.localName||(b=NodeFilter.FILTER_REJECT);return b}}function m(a,b){if(b){var d=h(b),c,e=a.firstChild;if(-1!==d){for(;e;){c=h(e);if(-1!==c&&c>d)break;e=e.nextSibling}a.insertBefore(b,e)}}}function p(a){this.OdfContainer=
+a}function c(a,b,d,c){var e=this;this.size=0;this.type=null;this.name=a;this.container=d;this.onchange=this.onreadystatechange=this.document=this.mimetype=this.url=null;this.EMPTY=0;this.LOADING=1;this.DONE=2;this.state=this.EMPTY;this.load=function(){null!==c&&(this.mimetype=b,c.loadAsDataURL(a,b,function(a,b){a&&runtime.log(a);e.url=b;if(e.onchange)e.onchange(e);if(e.onstatereadychange)e.onstatereadychange(e)}))}}var b=new odf.StyleInfo,a=odf.Namespaces.stylens,d="meta settings scripts font-face-decls styles automatic-styles master-styles body".split(" "),
+k=(new Date).getTime()+"_webodf_",g=new core.Base64;p.prototype=new function(){};p.prototype.constructor=p;p.namespaceURI="urn:oasis:names:tc:opendocument:xmlns:office:1.0";p.localName="document";c.prototype.load=function(){};c.prototype.getUrl=function(){return this.data?"data:;base64,"+g.toBase64(this.data):null};odf.OdfContainer=function l(d,h){function w(a){for(var b=a.firstChild,d;b;)d=b.nextSibling,b.nodeType===Node.ELEMENT_NODE?w(b):b.nodeType===Node.PROCESSING_INSTRUCTION_NODE&&a.removeChild(b),
+b=d}function v(a,b){for(var d=a&&a.firstChild;d;)d.nodeType===Node.ELEMENT_NODE&&d.setAttributeNS("urn:webodf:names:scope","scope",b),d=d.nextSibling}function y(b,d){function c(a,b,d){var e=0,f;for(f=a=a.replace(/\d+$/,"");b.hasOwnProperty(f)||d.hasOwnProperty(f);)e+=1,f=a+e;return f}function e(b){var d={};for(b=b.firstChild;b;)b.nodeType===Node.ELEMENT_NODE&&b.namespaceURI===a&&"font-face"===b.localName&&(k=b.getAttributeNS(a,"name"),d[k]=b),b=b.nextSibling;return d}var f,g,k,h,l,m,n={};l=e(b);m=
+e(d);for(f=d.firstChild;f;)g=f.nextSibling,f.nodeType===Node.ELEMENT_NODE&&f.namespaceURI===a&&"font-face"===f.localName&&(k=f.getAttributeNS(a,"name"),l.hasOwnProperty(k)?f.isEqualNode(l[k])||(h=c(k,l,m),f.setAttributeNS(a,"style:name",h),b.appendChild(f),l[h]=f,delete m[k],n[k]=h):(b.appendChild(f),l[k]=f,delete m[k])),f=g;return n}function x(a,b){var d=null,c,e,f;if(a)for(d=a.cloneNode(!0),c=d.firstChild;c;)e=c.nextSibling,c.nodeType===Node.ELEMENT_NODE&&(f=c.getAttributeNS("urn:webodf:names:scope",
+"scope"))&&f!==b&&d.removeChild(c),c=e;return d}function u(d,c){var e=null,f,g,k,h={};if(d)for(c.forEach(function(a){b.collectUsedFontFaces(h,a)}),e=d.cloneNode(!0),f=e.firstChild;f;)g=f.nextSibling,f.nodeType===Node.ELEMENT_NODE&&(k=f.getAttributeNS(a,"name"),h[k]||e.removeChild(f)),f=g;return e}function s(a){var b=M.rootElement.ownerDocument,d;if(a){w(a.documentElement);try{d=b.importNode(a.documentElement,!0)}catch(c){}}return d}function C(a){M.state=a;if(M.onchange)M.onchange(M);if(M.onstatereadychange)M.onstatereadychange(M)}
+function B(a){aa=null;M.rootElement=a;a.fontFaceDecls=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls");a.styles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","styles");a.automaticStyles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","automatic-styles");a.masterStyles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","master-styles");a.body=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","body");a.meta=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+"meta")}function A(a){a=s(a);var d=M.rootElement;a&&"document-styles"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI?(d.fontFaceDecls=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls"),m(d,d.fontFaceDecls),d.styles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","styles"),m(d,d.styles),d.automaticStyles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","automatic-styles"),v(d.automaticStyles,"document-styles"),m(d,d.automaticStyles),
+d.masterStyles=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","master-styles"),m(d,d.masterStyles),b.prefixStyleNames(d.automaticStyles,k,d.masterStyles)):C(l.INVALID)}function I(a){a=s(a);var d,c,f;if(a&&"document-content"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI){d=M.rootElement;c=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","font-face-decls");d.fontFaceDecls&&c?f=y(d.fontFaceDecls,c):c&&(d.fontFaceDecls=c,m(d,c));c=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+"automatic-styles");v(c,"document-content");f&&b.changeFontFaceNames(c,f);if(d.automaticStyles&&c)for(f=c.firstChild;f;)d.automaticStyles.appendChild(f),f=c.firstChild;else c&&(d.automaticStyles=c,m(d,c));d.body=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","body");m(d,d.body)}else C(l.INVALID)}function z(a){a=s(a);var b;a&&"document-meta"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI&&(b=M.rootElement,b.meta=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+"meta"),m(b,b.meta))}function N(a){a=s(a);var b;a&&"document-settings"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===a.namespaceURI&&(b=M.rootElement,b.settings=e(a,"urn:oasis:names:tc:opendocument:xmlns:office:1.0","settings"),m(b,b.settings))}function G(a){a=s(a);var b;if(a&&"manifest"===a.localName&&"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"===a.namespaceURI)for(b=M.rootElement,b.manifest=a,a=b.manifest.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&"file-entry"===
+a.localName&&"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"===a.namespaceURI&&(P[a.getAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","full-path")]=a.getAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","media-type")),a=a.nextSibling}function R(a){var b=a.shift(),d,c;b?(d=b[0],c=b[1],S.loadAsDOM(d,function(b,d){c(d);b||M.state===l.INVALID||R(a)})):C(l.DONE)}function Z(a){var b="";odf.Namespaces.forEachPrefix(function(a,d){b+=" xmlns:"+a+'="'+d+'"'});return'<?xml version="1.0" encoding="UTF-8"?><office:'+
+a+" "+b+' office:version="1.2">'}function ka(){var a=new xmldom.LSSerializer,b=Z("document-meta");a.filter=new odf.OdfNodeFilter;b+=a.writeToString(M.rootElement.meta,odf.Namespaces.namespaceMap);return b+"</office:document-meta>"}function T(a,b){var d=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest:file-entry");d.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest:full-path",a);d.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:manifest:1.0",
+"manifest:media-type",b);return d}function ra(){var a=runtime.parseXML('<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.2"></manifest:manifest>'),b=e(a,"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0","manifest"),d=new xmldom.LSSerializer,c;for(c in P)P.hasOwnProperty(c)&&b.appendChild(T(c,P[c]));d.filter=new odf.OdfNodeFilter;return'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'+d.writeToString(a,odf.Namespaces.namespaceMap)}
+function $(){var a=new xmldom.LSSerializer,b=Z("document-settings");a.filter=new odf.OdfNodeFilter;b+=a.writeToString(M.rootElement.settings,odf.Namespaces.namespaceMap);return b+"</office:document-settings>"}function ha(){var a=odf.Namespaces.namespaceMap,d=new xmldom.LSSerializer,c,e,g,h=Z("document-styles");e=x(M.rootElement.automaticStyles,"document-styles");g=M.rootElement.masterStyles&&M.rootElement.masterStyles.cloneNode(!0);c=u(M.rootElement.fontFaceDecls,[g,M.rootElement.styles,e]);b.removePrefixFromStyleNames(e,
+k,g);d.filter=new f(g,e);h+=d.writeToString(c,a);h+=d.writeToString(M.rootElement.styles,a);h+=d.writeToString(e,a);h+=d.writeToString(g,a);return h+"</office:document-styles>"}function U(){var a=odf.Namespaces.namespaceMap,b=new xmldom.LSSerializer,d,c,e=Z("document-content");c=x(M.rootElement.automaticStyles,"document-content");d=u(M.rootElement.fontFaceDecls,[c]);b.filter=new n(M.rootElement.body,c);e+=b.writeToString(d,a);e+=b.writeToString(c,a);e+=b.writeToString(M.rootElement.body,a);return e+
+"</office:document-content>"}function O(a,b){runtime.loadXML(a,function(a,d){if(a)b(a);else{var c=s(d);c&&"document"===c.localName&&"urn:oasis:names:tc:opendocument:xmlns:office:1.0"===c.namespaceURI?(B(c),C(l.DONE)):C(l.INVALID)}})}function W(){function a(b,d){var e;d||(d=b);e=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0",d);c[b]=e;c.appendChild(e)}var b=new core.Zip("",null),d=runtime.byteArrayFromString("application/vnd.oasis.opendocument.text","utf8"),c=M.rootElement,
+e=document.createElementNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0","text");b.save("mimetype",d,!1,new Date);a("meta");a("settings");a("scripts");a("fontFaceDecls","font-face-decls");a("styles");a("automaticStyles","automatic-styles");a("masterStyles","master-styles");a("body");c.body.appendChild(e);C(l.DONE);return b}function E(){var a,b=new Date;a=runtime.byteArrayFromString($(),"utf8");S.save("settings.xml",a,!0,b);a=runtime.byteArrayFromString(ka(),"utf8");S.save("meta.xml",a,!0,b);
+a=runtime.byteArrayFromString(ha(),"utf8");S.save("styles.xml",a,!0,b);a=runtime.byteArrayFromString(U(),"utf8");S.save("content.xml",a,!0,b);a=runtime.byteArrayFromString(ra(),"utf8");S.save("META-INF/manifest.xml",a,!0,b)}function H(a,b){E();S.writeAs(a,function(a){b(a)})}var M=this,S,P={},aa;this.onstatereadychange=h;this.rootElement=this.state=this.onchange=null;this.setRootElement=B;this.getContentElement=function(){var a;aa||(a=M.rootElement.body,aa=a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+"text")[0]||a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0","presentation")[0]||a.getElementsByTagNameNS("urn:oasis:names:tc:opendocument:xmlns:office:1.0","spreadsheet")[0]);return aa};this.getDocumentType=function(){var a=M.getContentElement();return a&&a.localName};this.getPart=function(a){return new c(a,P[a],M,S)};this.getPartData=function(a,b){S.load(a,b)};this.createByteArray=function(a,b){E();S.createByteArray(a,b)};this.saveAs=H;this.save=function(a){H(d,a)};this.getUrl=
+function(){return d};this.setBlob=function(a,b,d){d=g.convertBase64ToByteArray(d);S.save(a,d,!1,new Date);P.hasOwnProperty(a)&&runtime.log(a+" has been overwritten.");P[a]=b};this.removeBlob=function(a){var b=S.remove(a);runtime.assert(b,"file is not found: "+a);delete P[a]};this.state=l.LOADING;this.rootElement=function(a){var b=document.createElementNS(a.namespaceURI,a.localName),d;a=new a;for(d in a)a.hasOwnProperty(d)&&(b[d]=a[d]);return b}(p);S=d?new core.Zip(d,function(a,b){S=b;a?O(d,function(b){a&&
+(S.error=a+"\n"+b,C(l.INVALID))}):R([["styles.xml",A],["content.xml",I],["meta.xml",z],["settings.xml",N],["META-INF/manifest.xml",G]])}):W()};odf.OdfContainer.EMPTY=0;odf.OdfContainer.LOADING=1;odf.OdfContainer.DONE=2;odf.OdfContainer.INVALID=3;odf.OdfContainer.SAVING=4;odf.OdfContainer.MODIFIED=5;odf.OdfContainer.getContainer=function(a){return new odf.OdfContainer(a,null)};return odf.OdfContainer}();
 // Input 35
 /*
 
@@ -812,6 +818,9 @@ odf.Namespaces.resolvePrefix),0<f.length&&(f=f[0].getAttributeNS(odf.Namespaces.
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -832,9 +841,12 @@ odf.Namespaces.resolvePrefix),0<f.length&&(f=f[0].getAttributeNS(odf.Namespaces.
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-odf.StyleNameGenerator=function(h,m){var f={};this.generateName=function(){var a,c={},d=0;m.getAllStyleNames().forEach(function(a){c[a]=!0});do a=h+d,d+=1;while(f[a]||c[a]);f[a]=!0;return a}};
+runtime.loadClass("core.Base64");runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.OdfContainer");
+odf.FontLoader=function(){function e(h,m,p,c,b){var a,d=0,k;for(k in h)if(h.hasOwnProperty(k)){if(d===p){a=k;break}d+=1}a?m.getPartData(h[a].href,function(d,k){if(d)runtime.log(d);else{var l="@font-face { font-family: '"+(h[a].family||a)+"'; src: url(data:application/x-font-ttf;charset=binary;base64,"+f.convertUTF8ArrayToBase64(k)+') format("truetype"); }';try{c.insertRule(l,c.cssRules.length)}catch(r){runtime.log("Problem inserting rule in CSS: "+runtime.toJson(r)+"\nRule: "+l)}}e(h,m,p+1,c,b)}):
+b&&b()}var h=new xmldom.XPath,f=new core.Base64;odf.FontLoader=function(){this.loadFonts=function(f,m){for(var p=f.rootElement.fontFaceDecls;m.cssRules.length;)m.deleteRule(m.cssRules.length-1);if(p){var c={},b,a,d,k;if(p)for(p=h.getODFElementsWithXPath(p,"style:font-face[svg:font-face-src]",odf.Namespaces.resolvePrefix),b=0;b<p.length;b+=1)a=p[b],d=a.getAttributeNS(odf.Namespaces.stylens,"name"),k=a.getAttributeNS(odf.Namespaces.svgns,"font-family"),a=h.getODFElementsWithXPath(a,"svg:font-face-src/svg:font-face-uri",
+odf.Namespaces.resolvePrefix),0<a.length&&(a=a[0].getAttributeNS(odf.Namespaces.xlinkns,"href"),c[d]={href:a,family:k});e(c,f,0,m)}}};return odf.FontLoader}();
 // Input 36
 /*
 
@@ -848,6 +860,9 @@ odf.StyleNameGenerator=function(h,m){var f={};this.generateName=function(){var a
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -868,20 +883,12 @@ odf.StyleNameGenerator=function(h,m){var f={};this.generateName=function(){var a
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.Utils");runtime.loadClass("odf.StyleNameGenerator");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfContainer");runtime.loadClass("odf.StyleInfo");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.TextStyleApplicator");
-odf.Formatting=function(){function h(){for(var a=e.rootElement.fontFaceDecls,b={},c,d,a=a&&a.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&(c=a.getAttributeNS(g,"name"))&&((d=a.getAttributeNS(n,"font-family"))||a.getElementsByTagNameNS(n,"font-face-uri")[0])&&(b[c]=d),a=a.nextSibling;return b}function m(a){for(var b=e.rootElement.styles.firstChild;b;){if(b.nodeType===Node.ELEMENT_NODE&&b.namespaceURI===g&&"default-style"===b.localName&&b.getAttributeNS(g,"family")===a)return b;b=b.nextSibling}return null}
-function f(a,b,c){var d,k;c=c||[e.rootElement.automaticStyles,e.rootElement.styles];for(d=c.shift();d;){for(d=d.firstChild;d;){if(d.nodeType===Node.ELEMENT_NODE&&(k=d.getAttributeNS(g,"name"),d.namespaceURI===g&&"style"===d.localName&&d.getAttributeNS(g,"family")===b&&k===a||"list-style"===b&&d.namespaceURI===l&&"list-style"===d.localName&&k===a||"data"===b&&d.namespaceURI===u&&k===a))return d;d=d.nextSibling}d=c.shift()}return null}function a(a){for(var b,c={},d=a.firstChild;d;){if(d.nodeType===
-Node.ELEMENT_NODE&&d.namespaceURI===g)for(c[d.nodeName]={},b=0;b<d.attributes.length;b+=1)c[d.nodeName][d.attributes[b].name]=d.attributes[b].value;d=d.nextSibling}for(b=0;b<a.attributes.length;b+=1)c[a.attributes[b].name]=a.attributes[b].value;return c}function c(a,b){Object.keys(b).forEach(function(d){var e=d.split(":"),g=e[1],k=odf.Namespaces.resolvePrefix(e[0]),e=b[d];"object"===typeof e&&Object.keys(e).length?(d=a.getElementsByTagNameNS(k,g)[0]||a.ownerDocument.createElementNS(k,d),a.appendChild(d),
-c(d,e)):k&&a.setAttributeNS(k,d,e)})}function d(b,c){for(var d=e.rootElement.styles,k,l={},h=b.getAttributeNS(g,"family"),q=b;q;)k=a(q),l=x.mergeObjects(k,l),q=(k=q.getAttributeNS(g,"parent-style-name"))?f(k,h,[d]):null;if(q=m(h))k=a(q),l=x.mergeObjects(k,l);c&&(k=(d=r[h])?x.mergeObjects({},d):null)&&(l=x.mergeObjects(k,l));return l}function b(a,b){for(var c=a.nodeType===Node.TEXT_NODE?a.parentNode:a,d,e=[],k="",g=!1;c;)!g&&q.isGroupingElement(c)&&(g=!0),(d=s.determineStylesForNode(c))&&e.push(d),
-c=c.parentNode;g&&(e.forEach(function(a){Object.keys(a).forEach(function(b){Object.keys(a[b]).forEach(function(a){k+="|"+b+":"+a+"|"})})}),b&&(b[k]=e));return g?e:void 0}function k(a){var b={orderedStyles:[]};a.forEach(function(a){Object.keys(a).forEach(function(c){var e=Object.keys(a[c])[0],k,l;(k=f(e,c))?(l=d(k),b=x.mergeObjects(l,b),l=k.getAttributeNS(g,"display-name")):runtime.log("No style element found for '"+e+"' of family '"+c+"'");b.orderedStyles.push({name:e,family:c,displayName:l})})});
-return b}var p=this,e,s=new odf.StyleInfo,n=odf.Namespaces.svgns,g=odf.Namespaces.stylens,l=odf.Namespaces.textns,u=odf.Namespaces.numberns,q=new odf.OdfUtils,x=new core.Utils,r={paragraph:{"style:paragraph-properties":{"fo:text-align":"left"}}};this.setOdfContainer=function(a){e=a};this.getFontMap=h;this.getAvailableParagraphStyles=function(){for(var a=e.rootElement.styles&&e.rootElement.styles.firstChild,b,c,d=[];a;)a.nodeType===Node.ELEMENT_NODE&&("style"===a.localName&&a.namespaceURI===g)&&(c=
-a,b=c.getAttributeNS(g,"family"),"paragraph"===b&&(b=c.getAttributeNS(g,"name"),c=c.getAttributeNS(g,"display-name")||b,b&&c&&d.push({name:b,displayName:c}))),a=a.nextSibling;return d};this.isStyleUsed=function(a){var b;b=s.hasDerivedStyles(e.rootElement,odf.Namespaces.resolvePrefix,a);a=(new s.UsedStyleList(e.rootElement.styles)).uses(a)||(new s.UsedStyleList(e.rootElement.automaticStyles)).uses(a)||(new s.UsedStyleList(e.rootElement.body)).uses(a);return b||a};this.getDefaultStyleElement=m;this.getStyleElement=
-f;this.getStyleAttributes=a;this.getInheritedStyleAttributes=d;this.getFirstCommonParentStyleNameOrSelf=function(a){var b=e.rootElement.automaticStyles,c=e.rootElement.styles,d;for(d=f(a,"paragraph",[b]);d;)a=d.getAttributeNS(g,"parent-style-name"),d=f(a,"paragraph",[b]);return(d=f(a,"paragraph",[c]))?a:null};this.hasParagraphStyle=function(a){return Boolean(f(a,"paragraph"))};this.getAppliedStyles=function(a){var c={},d=[];a.forEach(function(a){b(a,c)});Object.keys(c).forEach(function(a){d.push(k(c[a]))});
-return d};this.getAppliedStylesForElement=function(a){return(a=b(a))?k(a):void 0};this.applyStyle=function(a,b,c,d){(new odf.TextStyleApplicator(new odf.StyleNameGenerator("auto"+x.hashString(a)+"_",p),p,e.rootElement.automaticStyles)).applyStyle(b,c,d)};this.getAllStyleNames=function(){var a,b=[];[e.rootElement.automaticStyles,e.rootElement.styles].forEach(function(c){for(a=c.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&(a.namespaceURI===g&&"style"===a.localName||a.namespaceURI===l&&"list-style"===
-a.localName)&&b.push(a.getAttributeNS(g,"name")),a=a.nextSibling});return b};this.updateStyle=function(a,b){var d,k;c(a,b);(d=b["style:text-properties"]&&b["style:text-properties"]["style:font-name"])&&!h().hasOwnProperty(d)&&(k=a.ownerDocument.createElementNS(g,"style:font-face"),k.setAttributeNS(g,"style:name",d),k.setAttributeNS(n,"svg:font-family",d),e.rootElement.fontFaceDecls.appendChild(k))};this.createDerivedStyleObject=function(b,c,d){var k=f(b,c);runtime.assert(Boolean(k),"No style element found for '"+
-b+"' of family '"+c+"'");b=k.parentNode===e.rootElement.automaticStyles?a(k):{"style:parent-style-name":b};b["style:family"]=c;x.mergeObjects(b,d);return b};this.getDefaultTabStopDistance=function(){var a=m("paragraph");(a=(a=a&&a.getAttributeNS(g,"paragraph-properties"))&&a.getAttributeNS(g,"tab-stop-distance"))||(a="1.25cm");return q.parseNonNegativeLength(a)}};
+runtime.loadClass("core.DomUtils");runtime.loadClass("core.Utils");
+odf.ObjectNameGenerator=function(e,h){function f(a,b){var d={};this.generateName=function(){var c=b(),e=0,f;do f=a+e,e+=1;while(d[f]||c[f]);d[f]=!0;return f}}function n(){var a,b={};[e.rootElement.automaticStyles,e.rootElement.styles].forEach(function(d){for(a=d.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&a.namespaceURI===m&&"style"===a.localName&&(b[a.getAttributeNS(m,"name")]=!0),a=a.nextSibling});return b}var m=odf.Namespaces.stylens,p=odf.Namespaces.drawns,c=odf.Namespaces.xlinkns,b=new core.DomUtils,
+a=(new core.Utils).hashString(h),d=null,k=null,g=null,q={},l={};this.generateStyleName=function(){null===d&&(d=new f("auto"+a+"_",function(){return n()}));return d.generateName()};this.generateFrameName=function(){null===k&&(b.getElementsByTagNameNS(e.rootElement.body,p,"frame").forEach(function(a){q[a.getAttributeNS(p,"name")]=!0}),k=new f("fr"+a+"_",function(){return q}));return k.generateName()};this.generateImageName=function(){null===g&&(b.getElementsByTagNameNS(e.rootElement.body,p,"image").forEach(function(a){a=
+a.getAttributeNS(c,"href");a=a.substring(9,a.lastIndexOf("."));l[a]=!0}),g=new f("img"+a+"_",function(){return l}));return g.generateName()}};
 // Input 37
 /*
 
@@ -895,6 +902,9 @@ b+"' of family '"+c+"'");b=k.parentNode===e.rootElement.automaticStyles?a(k):{"s
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -915,77 +925,24 @@ b+"' of family '"+c+"'");b=k.parentNode===e.rootElement.automaticStyles?a(k):{"s
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.DomUtils");runtime.loadClass("odf.OdfContainer");runtime.loadClass("odf.Formatting");runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.FontLoader");runtime.loadClass("odf.Style2CSS");runtime.loadClass("odf.OdfUtils");runtime.loadClass("gui.AnnotationViewManager");
-odf.OdfCanvas=function(){function h(){function a(d){c=!0;runtime.setTimeout(function(){try{d()}catch(e){runtime.log(e)}c=!1;0<b.length&&a(b.pop())},10)}var b=[],c=!1;this.clearQueue=function(){b.length=0};this.addToQueue=function(d){if(0===b.length&&!c)return a(d);b.push(d)}}function m(a){function b(){for(;0<c.cssRules.length;)c.deleteRule(0);c.insertRule("#shadowContent draw|page {display:none;}",0);c.insertRule("office|presentation draw|page {display:none;}",1);c.insertRule("#shadowContent draw|page:nth-of-type("+
-d+") {display:block;}",2);c.insertRule("office|presentation draw|page:nth-of-type("+d+") {display:block;}",3)}var c=a.sheet,d=1;this.showFirstPage=function(){d=1;b()};this.showNextPage=function(){d+=1;b()};this.showPreviousPage=function(){1<d&&(d-=1,b())};this.showPage=function(a){0<a&&(d=a,b())};this.css=a;this.destroy=function(b){a.parentNode.removeChild(a);b()}}function f(a,b,c){a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent?a.attachEvent("on"+b,c):a["on"+b]=c}function a(a,b,c){var d=
-"on"+b;a.removeEventListener?a.removeEventListener(b,c,!1):a.detachEvent?a.detachEvent(d,c):a[d]===c&&(a[d]=null)}function c(b){function c(a,b){for(;b;){if(b===a)return!0;b=b.parentNode}return!1}function d(){var a=[],g=runtime.getWindow().getSelection(),f,l;for(f=0;f<g.rangeCount;f+=1)l=g.getRangeAt(f),null!==l&&(c(b,l.startContainer)&&c(b,l.endContainer))&&a.push(l);if(a.length===e.length){for(g=0;g<a.length&&(f=a[g],l=e[g],f=f===l?!1:null===f||null===l?!0:f.startContainer!==l.startContainer||f.startOffset!==
-l.startOffset||f.endContainer!==l.endContainer||f.endOffset!==l.endOffset,!f);g+=1);if(g===a.length)return}e=a;var g=[a.length],h,m=b.ownerDocument;for(f=0;f<a.length;f+=1)l=a[f],h=m.createRange(),h.setStart(l.startContainer,l.startOffset),h.setEnd(l.endContainer,l.endOffset),g[f]=h;e=g;g=k.length;for(a=0;a<g;a+=1)k[a](b,e)}var e=[],k=[];this.addListener=function(a,b){var c,d=k.length;for(c=0;c<d;c+=1)if(k[c]===b)return;k.push(b)};this.destroy=function(c){a(b,"mouseup",d);a(b,"keyup",d);a(b,"keydown",
-d);c()};f(b,"mouseup",d);f(b,"keyup",d);f(b,"keydown",d)}function d(a,b,c){(new odf.Style2CSS).style2css(a.getDocumentType(),c.sheet,b.getFontMap(),a.rootElement.styles,a.rootElement.automaticStyles)}function b(a,c,d,e){d.setAttribute("styleid",c);var k,g=d.getAttributeNS(v,"anchor-type"),f=d.getAttributeNS(t,"x"),l=d.getAttributeNS(t,"y"),h=d.getAttributeNS(t,"width"),m=d.getAttributeNS(t,"height"),n=d.getAttributeNS(x,"min-height"),r=d.getAttributeNS(x,"min-width"),p=d.getAttributeNS(q,"master-page-name"),
-s=null,u,w;u=0;var K,C=a.rootElement.ownerDocument;if(p){s=a.rootElement.masterStyles.getElementsByTagNameNS(y,"master-page");u=null;for(w=0;w<s.length;w+=1)if(s[w].getAttributeNS(y,"name")===p){u=s[w];break}s=u}else s=null;if(s){p=C.createElementNS(q,"draw:page");K=s.firstElementChild;for(u=0;K;)"true"!==K.getAttributeNS(E,"placeholder")&&(w=K.cloneNode(!0),p.appendChild(w),b(a,c+"_"+u,w,e)),K=K.nextElementSibling,u+=1;L.appendChild(p);u=L.getElementsByTagNameNS(q,"page").length;if(w=p.getElementsByTagNameNS(v,
-"page-number")[0]){for(;w.firstChild;)w.removeChild(w.firstChild);w.appendChild(C.createTextNode(u))}b(a,c,p,e);p.setAttributeNS(q,"draw:master-page-name",s.getAttributeNS(y,"name"))}if("as-char"===g)k="display: inline-block;";else if(g||f||l)k="position: absolute;";else if(h||m||n||r)k="display: block;";f&&(k+="left: "+f+";");l&&(k+="top: "+l+";");h&&(k+="width: "+h+";");m&&(k+="height: "+m+";");n&&(k+="min-height: "+n+";");r&&(k+="min-width: "+r+";");k&&(k="draw|"+d.localName+'[styleid="'+c+'"] {'+
-k+"}",e.insertRule(k,e.cssRules.length))}function k(a){for(a=a.firstChild;a;){if(a.namespaceURI===r&&"binary-data"===a.localName)return"data:image/png;base64,"+a.textContent.replace(/[\r\n\s]/g,"");a=a.nextSibling}return""}function p(a,b,c,d){function e(b){b&&(b='draw|image[styleid="'+a+'"] {'+("background-image: url("+b+");")+"}",d.insertRule(b,d.cssRules.length))}c.setAttribute("styleid",a);var g=c.getAttributeNS(C,"href"),f;if(g)try{f=b.getPart(g),f.onchange=function(a){e(a.url)},f.load()}catch(l){runtime.log("slight problem: "+
-l)}else g=k(c),e(g)}function e(a){function b(c){var d,e;c.hasAttributeNS(C,"href")&&(d=c.getAttributeNS(C,"href"),"#"===d[0]?(d=d.substring(1),e=function(){var b=B.getODFElementsWithXPath(a,"//text:bookmark-start[@text:name='"+d+"']",odf.Namespaces.resolvePrefix);0===b.length&&(b=B.getODFElementsWithXPath(a,"//text:bookmark[@text:name='"+d+"']",odf.Namespaces.resolvePrefix));0<b.length&&b[0].scrollIntoView(!0);return!1}):e=function(){K.open(d)},c.onclick=e)}var c,d,e;d=a.getElementsByTagNameNS(v,
-"a");for(c=0;c<d.length;c+=1)e=d.item(c),b(e)}function s(a){var b=a.ownerDocument;H.getElementsByTagNameNS(a,v,"s").forEach(function(a){for(var c,d;a.firstChild;)a.removeChild(a.firstChild);a.appendChild(b.createTextNode(" "));d=parseInt(a.getAttributeNS(v,"c"),10);if(1<d)for(a.removeAttributeNS(v,"c"),c=1;c<d;c+=1)a.parentNode.insertBefore(a.cloneNode(!0),a)})}function n(a){H.getElementsByTagNameNS(a,v,"tab").forEach(function(a){a.textContent="\t"})}function g(a,b){function c(a,k){var g=f.documentElement.namespaceURI;
-"video/"===k.substr(0,6)?(d=f.createElementNS(g,"video"),d.setAttribute("controls","controls"),e=f.createElementNS(g,"source"),e.setAttribute("src",a),e.setAttribute("type",k),d.appendChild(e),b.parentNode.appendChild(d)):b.innerHtml="Unrecognised Plugin"}var d,e,g,f=b.ownerDocument,l;if(g=b.getAttributeNS(C,"href"))try{l=a.getPart(g),l.onchange=function(a){c(a.url,a.mimetype)},l.load()}catch(h){runtime.log("slight problem: "+h)}else runtime.log("using MP4 data fallback"),g=k(b),c(g,"video/mp4")}
-function l(a){var b=a.getElementsByTagName("head")[0],c;"undefined"!==String(typeof webodf_css)?(c=a.createElementNS(b.namespaceURI,"style"),c.setAttribute("media","screen, print, handheld, projection"),c.appendChild(a.createTextNode(webodf_css))):(c=a.createElementNS(b.namespaceURI,"link"),a="webodf.css",runtime.currentDirectory&&(a=runtime.currentDirectory()+"/../"+a),c.setAttribute("href",a),c.setAttribute("rel","stylesheet"));c.setAttribute("type","text/css");b.appendChild(c);return c}function u(a){var b=
-a.getElementsByTagName("head")[0],c=a.createElementNS(b.namespaceURI,"style"),d="";c.setAttribute("type","text/css");c.setAttribute("media","screen, print, handheld, projection");odf.Namespaces.forEachPrefix(function(a,b){d+="@namespace "+a+" url("+b+");\n"});c.appendChild(a.createTextNode(d));b.appendChild(c);return c}var q=odf.Namespaces.drawns,x=odf.Namespaces.fons,r=odf.Namespaces.officens,y=odf.Namespaces.stylens,t=odf.Namespaces.svgns,w=odf.Namespaces.tablens,v=odf.Namespaces.textns,C=odf.Namespaces.xlinkns,
-J=odf.Namespaces.xmlns,E=odf.Namespaces.presentationns,K=runtime.getWindow(),B=new xmldom.XPath,N=new odf.OdfUtils,H=new core.DomUtils,L;odf.OdfCanvas=function(a){function k(a,b,c){function d(a,b,c,e){A.addToQueue(function(){p(a,b,c,e)})}var e,g;e=b.getElementsByTagNameNS(q,"image");for(b=0;b<e.length;b+=1)g=e.item(b),d("image"+String(b),a,g,c)}function x(a,b){function c(a,b){A.addToQueue(function(){g(a,b)})}var d,e,k;e=b.getElementsByTagNameNS(q,"plugin");for(d=0;d<e.length;d+=1)k=e.item(d),c(a,
-k)}function t(){P.firstChild&&(1<I?(P.style.MozTransformOrigin="center top",P.style.WebkitTransformOrigin="center top",P.style.OTransformOrigin="center top",P.style.msTransformOrigin="center top"):(P.style.MozTransformOrigin="left top",P.style.WebkitTransformOrigin="left top",P.style.OTransformOrigin="left top",P.style.msTransformOrigin="left top"),P.style.WebkitTransform="scale("+I+")",P.style.MozTransform="scale("+I+")",P.style.OTransform="scale("+I+")",P.style.msTransform="scale("+I+")",a.style.width=
-Math.round(I*P.offsetWidth)+"px",a.style.height=Math.round(I*P.offsetHeight)+"px")}function C(a){function b(a){return d===a.getAttributeNS(r,"name")}var c=H.getElementsByTagNameNS(a,r,"annotation");a=H.getElementsByTagNameNS(a,r,"annotation-end");var d,e;for(e=0;e<c.length;e+=1)d=c[e].getAttributeNS(r,"name"),U.addAnnotation({node:c[e],end:a.filter(b)[0]||null});U.rerenderAnnotations()}function E(a){ca?($.parentNode||(P.appendChild($),t()),U&&U.forgetAnnotations(),U=new gui.AnnotationViewManager(F,
-a.body,$),C(a.body)):$.parentNode&&(P.removeChild($),U.forgetAnnotations(),t())}function O(c){function g(){for(var f=a;f.firstChild;)f.removeChild(f.firstChild);a.style.display="inline-block";f=D.rootElement;a.ownerDocument.importNode(f,!0);T.setOdfContainer(D);var l=D,h=z;(new odf.FontLoader).loadFonts(l,h.sheet);d(D,T,ga);for(var h=D,l=da.sheet,m=a;m.firstChild;)m.removeChild(m.firstChild);P=G.createElementNS(a.namespaceURI,"div");P.style.display="inline-block";P.style.background="white";P.appendChild(f);
-a.appendChild(P);$=G.createElementNS(a.namespaceURI,"div");$.id="annotationsPane";L=G.createElementNS(a.namespaceURI,"div");L.id="shadowContent";L.style.position="absolute";L.style.top=0;L.style.left=0;h.getContentElement().appendChild(L);var m=f.body,r,p,u;p=[];for(r=m.firstChild;r&&r!==m;)if(r.namespaceURI===q&&(p[p.length]=r),r.firstChild)r=r.firstChild;else{for(;r&&r!==m&&!r.nextSibling;)r=r.parentNode;r&&r.nextSibling&&(r=r.nextSibling)}for(u=0;u<p.length;u+=1)r=p[u],b(h,"frame"+String(u),r,
-l);p=B.getODFElementsWithXPath(m,".//*[*[@text:anchor-type='paragraph']]",odf.Namespaces.resolvePrefix);for(r=0;r<p.length;r+=1)m=p[r],m.setAttributeNS&&m.setAttributeNS("urn:webodf","containsparagraphanchor",!0);r=f.body.getElementsByTagNameNS(w,"table-cell");for(m=0;m<r.length;m+=1)p=r.item(m),p.hasAttributeNS(w,"number-columns-spanned")&&p.setAttribute("colspan",p.getAttributeNS(w,"number-columns-spanned")),p.hasAttributeNS(w,"number-rows-spanned")&&p.setAttribute("rowspan",p.getAttributeNS(w,
-"number-rows-spanned"));e(f.body);s(f.body);n(f.body);k(h,f.body,l);x(h,f.body);p=f.body;var S,C,H,Z,m={};r={};var A;u=K.document.getElementsByTagNameNS(v,"list-style");for(h=0;h<u.length;h+=1)S=u.item(h),(H=S.getAttributeNS(y,"name"))&&(r[H]=S);p=p.getElementsByTagNameNS(v,"list");for(h=0;h<p.length;h+=1)if(S=p.item(h),u=S.getAttributeNS(J,"id")){C=S.getAttributeNS(v,"continue-list");S.setAttribute("id",u);Z="text|list#"+u+" > text|list-item > *:first-child:before {";if(H=S.getAttributeNS(v,"style-name")){S=
-r[H];A=N.getFirstNonWhitespaceChild(S);S=void 0;if(A)if("list-level-style-number"===A.localName){S=A.getAttributeNS(y,"num-format");H=A.getAttributeNS(y,"num-suffix");var F="",F={1:"decimal",a:"lower-latin",A:"upper-latin",i:"lower-roman",I:"upper-roman"},I=void 0,I=A.getAttributeNS(y,"num-prefix")||"",I=F.hasOwnProperty(S)?I+(" counter(list, "+F[S]+")"):S?I+("'"+S+"';"):I+" ''";H&&(I+=" '"+H+"'");S=F="content: "+I+";"}else"list-level-style-image"===A.localName?S="content: none;":"list-level-style-bullet"===
-A.localName&&(S="content: '"+A.getAttributeNS(v,"bullet-char")+"';");A=S}if(C){for(S=m[C];S;)C=S,S=m[C];Z+="counter-increment:"+C+";";A?(A=A.replace("list",C),Z+=A):Z+="content:counter("+C+");"}else C="",A?(A=A.replace("list",u),Z+=A):Z+="content: counter("+u+");",Z+="counter-increment:"+u+";",l.insertRule("text|list#"+u+" {counter-reset:"+u+"}",l.cssRules.length);Z+="}";m[u]=C;Z&&l.insertRule(Z,l.cssRules.length)}P.insertBefore(L,P.firstChild);t();E(f);if(!c&&(f=[D],ia.hasOwnProperty("statereadychange")))for(l=
-ia.statereadychange,A=0;A<l.length;A+=1)l[A].apply(null,f)}D.state===odf.OdfContainer.DONE?g():(runtime.log("WARNING: refreshOdf called but ODF was not DONE."),runtime.setTimeout(function oa(){D.state===odf.OdfContainer.DONE?g():(runtime.log("will be back later..."),runtime.setTimeout(oa,500))},100))}function R(b){A.clearQueue();a.innerHTML="loading "+b;a.removeAttribute("style");D=new odf.OdfContainer(b,function(a){D=a;O(!1)})}runtime.assert(null!==a&&void 0!==a,"odf.OdfCanvas constructor needs DOM element");
-runtime.assert(null!==a.ownerDocument&&void 0!==a.ownerDocument,"odf.OdfCanvas constructor needs DOM");var F=this,G=a.ownerDocument,D,T=new odf.Formatting,X=new c(a),Q,P,$,ca=!1,U,V,z,ga,da,I=1,ia={},A=new h;this.refreshCSS=function(){d(D,T,ga);t()};this.refreshSize=function(){t()};this.odfContainer=function(){return D};this.slidevisibilitycss=function(){return Q.css};this.setOdfContainer=function(a,b){D=a;O(!0===b)};this.load=this.load=R;this.save=function(a){D.save(a)};this.addListener=function(b,
-c){switch(b){case "selectionchange":X.addListener(b,c);break;case "click":f(a,b,c);break;default:var d=ia[b];void 0===d&&(d=ia[b]=[]);c&&-1===d.indexOf(c)&&d.push(c)}};this.getFormatting=function(){return T};this.getAnnotationManager=function(){return U};this.refreshAnnotations=function(){E(D.rootElement)};this.rerenderAnnotations=function(){U&&U.rerenderAnnotations()};this.getSizer=function(){return P};this.enableAnnotations=function(a){a!==ca&&(ca=a,D&&E(D.rootElement))};this.addAnnotation=function(a){U&&
-U.addAnnotation(a)};this.forgetAnnotations=function(){U&&U.forgetAnnotations()};this.setZoomLevel=function(a){I=a;t()};this.getZoomLevel=function(){return I};this.fitToContainingElement=function(b,c){var d=a.offsetHeight/I;I=b/(a.offsetWidth/I);c/d<I&&(I=c/d);t()};this.fitToWidth=function(b){I=b/(a.offsetWidth/I);t()};this.fitSmart=function(b,c){var d,e;d=a.offsetWidth/I;e=a.offsetHeight/I;d=b/d;void 0!==c&&c/e<d&&(d=c/e);I=Math.min(1,d);t()};this.fitToHeight=function(b){I=b/(a.offsetHeight/I);t()};
-this.showFirstPage=function(){Q.showFirstPage()};this.showNextPage=function(){Q.showNextPage()};this.showPreviousPage=function(){Q.showPreviousPage()};this.showPage=function(a){Q.showPage(a);t()};this.getElement=function(){return a};this.destroy=function(b){var c=G.getElementsByTagName("head")[0];$&&$.parentNode&&$.parentNode.removeChild($);P&&a.removeChild(P);c.removeChild(V);c.removeChild(z);c.removeChild(ga);c.removeChild(da);X.destroy(function(a){a?b(a):Q.destroy(b)})};V=l(G);Q=new m(u(G));z=
-u(G);ga=u(G);da=u(G)};return odf.OdfCanvas}();
+runtime.loadClass("core.Utils");runtime.loadClass("odf.ObjectNameGenerator");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfContainer");runtime.loadClass("odf.StyleInfo");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.TextStyleApplicator");
+odf.Formatting=function(){function e(){for(var a=k.rootElement.fontFaceDecls,b={},d,c,a=a&&a.firstChild;a;)a.nodeType===Node.ELEMENT_NODE&&(d=a.getAttributeNS(l,"name"))&&((c=a.getAttributeNS(q,"font-family"))||a.getElementsByTagNameNS(q,"font-face-uri")[0])&&(b[d]=c),a=a.nextSibling;return b}function h(a){for(var b=k.rootElement.styles.firstChild;b;){if(b.nodeType===Node.ELEMENT_NODE&&b.namespaceURI===l&&"default-style"===b.localName&&b.getAttributeNS(l,"family")===a)return b;b=b.nextSibling}return null}
+function f(a,b,d){var c,e;d=d||[k.rootElement.automaticStyles,k.rootElement.styles];for(c=d.shift();c;){for(c=c.firstChild;c;){if(c.nodeType===Node.ELEMENT_NODE&&(e=c.getAttributeNS(l,"name"),c.namespaceURI===l&&"style"===c.localName&&c.getAttributeNS(l,"family")===b&&e===a||"list-style"===b&&c.namespaceURI===r&&"list-style"===c.localName&&e===a||"data"===b&&c.namespaceURI===t&&e===a))return c;c=c.nextSibling}c=d.shift()}return null}function n(a){for(var b,d={},c=a.firstChild;c;){if(c.nodeType===
+Node.ELEMENT_NODE&&c.namespaceURI===l)for(d[c.nodeName]={},b=0;b<c.attributes.length;b+=1)d[c.nodeName][c.attributes[b].name]=c.attributes[b].value;c=c.nextSibling}for(b=0;b<a.attributes.length;b+=1)d[a.attributes[b].name]=a.attributes[b].value;return d}function m(a,b){Object.keys(b).forEach(function(d){var c=d.split(":"),e=c[1],f=odf.Namespaces.resolvePrefix(c[0]),c=b[d];"object"===typeof c&&Object.keys(c).length?(d=a.getElementsByTagNameNS(f,e)[0]||a.ownerDocument.createElementNS(f,d),a.appendChild(d),
+m(d,c)):f&&a.setAttributeNS(f,d,c)})}function p(a,b){for(var d=k.rootElement.styles,c,e={},g=a.getAttributeNS(l,"family"),m=a;m;)c=n(m),e=x.mergeObjects(c,e),m=(c=m.getAttributeNS(l,"parent-style-name"))?f(c,g,[d]):null;if(m=h(g))c=n(m),e=x.mergeObjects(c,e);b&&(c=(d=u[g])?x.mergeObjects({},d):null)&&(e=x.mergeObjects(c,e));return e}function c(a,b){for(var d=a.nodeType===Node.TEXT_NODE?a.parentNode:a,c,e=[],f="",k=!1;d;)!k&&v.isGroupingElement(d)&&(k=!0),(c=g.determineStylesForNode(d))&&e.push(c),
+d=d.parentNode;k&&(e.forEach(function(a){Object.keys(a).forEach(function(b){Object.keys(a[b]).forEach(function(a){f+="|"+b+":"+a+"|"})})}),b&&(b[f]=e));return k?e:void 0}function b(a){var b={orderedStyles:[]};a.forEach(function(a){Object.keys(a).forEach(function(d){var c=Object.keys(a[d])[0],e,g;(e=f(c,d))?(g=p(e),b=x.mergeObjects(g,b),g=e.getAttributeNS(l,"display-name")):runtime.log("No style element found for '"+c+"' of family '"+d+"'");b.orderedStyles.push({name:c,family:d,displayName:g})})});
+return b}function a(a,b){var d=v.parseLength(a),c=b;if(d)switch(d.unit){case "cm":c=d.value;break;case "mm":c=0.1*d.value;break;case "in":c=2.54*d.value;break;case "pt":c=0.035277778*d.value;break;case "pc":case "px":case "em":break;default:runtime.log("Unit identifier: "+d.unit+" is not supported.")}return c}var d=this,k,g=new odf.StyleInfo,q=odf.Namespaces.svgns,l=odf.Namespaces.stylens,r=odf.Namespaces.textns,t=odf.Namespaces.numberns,w=odf.Namespaces.fons,v=new odf.OdfUtils,y=new core.DomUtils,
+x=new core.Utils,u={paragraph:{"style:paragraph-properties":{"fo:text-align":"left"}}};this.setOdfContainer=function(a){k=a};this.getFontMap=e;this.getAvailableParagraphStyles=function(){for(var a=k.rootElement.styles&&k.rootElement.styles.firstChild,b,d,c=[];a;)a.nodeType===Node.ELEMENT_NODE&&"style"===a.localName&&a.namespaceURI===l&&(d=a,b=d.getAttributeNS(l,"family"),"paragraph"===b&&(b=d.getAttributeNS(l,"name"),d=d.getAttributeNS(l,"display-name")||b,b&&d&&c.push({name:b,displayName:d}))),a=
+a.nextSibling;return c};this.isStyleUsed=function(a){var b;b=g.hasDerivedStyles(k.rootElement,odf.Namespaces.resolvePrefix,a);a=(new g.UsedStyleList(k.rootElement.styles)).uses(a)||(new g.UsedStyleList(k.rootElement.automaticStyles)).uses(a)||(new g.UsedStyleList(k.rootElement.body)).uses(a);return b||a};this.getDefaultStyleElement=h;this.getStyleElement=f;this.getStyleAttributes=n;this.getInheritedStyleAttributes=p;this.getFirstCommonParentStyleNameOrSelf=function(a){var b=k.rootElement.automaticStyles,
+d=k.rootElement.styles,c;for(c=f(a,"paragraph",[b]);c;)a=c.getAttributeNS(l,"parent-style-name"),c=f(a,"paragraph",[b]);return(c=f(a,"paragraph",[d]))?a:null};this.hasParagraphStyle=function(a){return Boolean(f(a,"paragraph"))};this.getAppliedStyles=function(a){var d={},e=[];a.forEach(function(a){c(a,d)});Object.keys(d).forEach(function(a){e.push(b(d[a]))});return e};this.getAppliedStylesForElement=function(a){return(a=c(a))?b(a):void 0};this.applyStyle=function(a,b,c,e){(new odf.TextStyleApplicator(new odf.ObjectNameGenerator(k,
+a),d,k.rootElement.automaticStyles)).applyStyle(b,c,e)};this.updateStyle=function(a,b){var d,c;m(a,b);(d=b["style:text-properties"]&&b["style:text-properties"]["style:font-name"])&&!e().hasOwnProperty(d)&&(c=a.ownerDocument.createElementNS(l,"style:font-face"),c.setAttributeNS(l,"style:name",d),c.setAttributeNS(q,"svg:font-family",d),k.rootElement.fontFaceDecls.appendChild(c))};this.createDerivedStyleObject=function(a,b,d){var c=f(a,b);runtime.assert(Boolean(c),"No style element found for '"+a+"' of family '"+
+b+"'");a=c.parentNode===k.rootElement.automaticStyles?n(c):{"style:parent-style-name":a};a["style:family"]=b;x.mergeObjects(a,d);return a};this.getDefaultTabStopDistance=function(){var a=h("paragraph");(a=(a=a&&a.getAttributeNS(l,"paragraph-properties"))&&a.getAttributeNS(l,"tab-stop-distance"))||(a="1.25cm");return v.parseNonNegativeLength(a)};this.getContentSize=function(b,d){var c,e,g,h,m,n,p,t,q,r,u,v;a:{c=f(b,d);var x,U,O;runtime.assert("paragraph"===d||"table"===d,"styleFamily has to be either paragraph or table");
+if(c){x=c.getAttributeNS(l,"master-page-name")||"Standard";for(c=k.rootElement.masterStyles.lastChild;c&&c.previousSibling&&c.getAttributeNS(l,"name")!==x;)c=c.previousSibling;x=c.getAttributeNS(l,"page-layout-name");U=y.getElementsByTagNameNS(k.rootElement.automaticStyles,l,"page-layout");for(O=0;O<U.length;O+=1)if(c=U[O],c.getAttributeNS(l,"name")===x)break a}c=null}c||(c=k.rootElement.styles.getElementsByTagNameNS(l,"default-page-layout")[0]);c&&(e=c.getElementsByTagNameNS(l,"page-layout-properties")[0]);
+e&&(g=e.getAttributeNS(l,"print-orientation")||"portrait","portrait"===g?(g=21.001,h=29.7):(g=29.7,h=21.001),g=a(e.getAttributeNS(w,"page-width"),g),h=a(e.getAttributeNS(w,"page-height"),h),m=a(e.getAttributeNS(w,"margin"),null),null===m?(m=a(e.getAttributeNS(w,"margin-left"),2),n=a(e.getAttributeNS(w,"margin-right"),2),p=a(e.getAttributeNS(w,"margin-top"),2),t=a(e.getAttributeNS(w,"margin-bottom"),2)):m=n=p=t=m,q=a(e.getAttributeNS(w,"padding"),null),null===q?(q=a(e.getAttributeNS(w,"padding-left"),
+0),r=a(e.getAttributeNS(w,"padding-right"),0),u=a(e.getAttributeNS(w,"padding-top"),0),v=a(e.getAttributeNS(w,"padding-bottom"),0)):q=r=u=v=q);return{width:g-m-n-q-r,height:h-p-t-u-v}}};
 // Input 38
-runtime.loadClass("odf.OdfCanvas");
-odf.CommandLineTools=function(){this.roundTrip=function(h,m,f){return new odf.OdfContainer(h,function(a){if(a.state===odf.OdfContainer.INVALID)return f("Document "+h+" is invalid.");a.state===odf.OdfContainer.DONE?a.saveAs(m,function(a){f(a)}):f("Document was not completely loaded.")})};this.render=function(h,m,f){for(m=m.getElementsByTagName("body")[0];m.firstChild;)m.removeChild(m.firstChild);m=new odf.OdfCanvas(m);m.addListener("statereadychange",function(a){f(a)});m.load(h)}};
-// Input 39
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-ops.Server=function(){};ops.Server.prototype.connect=function(h,m){};ops.Server.prototype.networkStatus=function(){};ops.Server.prototype.login=function(h,m,f,a){};ops.Server.prototype.joinSession=function(h,m,f,a){};ops.Server.prototype.leaveSession=function(h,m,f,a){};ops.Server.prototype.getGenesisUrl=function(h){};
-// Input 40
 /*
 
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
@@ -998,6 +955,9 @@ ops.Server=function(){};ops.Server.prototype.connect=function(h,m){};ops.Server.
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1018,9 +978,81 @@ ops.Server=function(){};ops.Server.prototype.connect=function(h,m){};ops.Server.
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.Operation=function(){};ops.Operation.prototype.init=function(h){};ops.Operation.prototype.transform=function(h,m){};ops.Operation.prototype.execute=function(h){};ops.Operation.prototype.spec=function(){};
+runtime.loadClass("core.DomUtils");runtime.loadClass("odf.OdfContainer");runtime.loadClass("odf.Formatting");runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.FontLoader");runtime.loadClass("odf.Style2CSS");runtime.loadClass("odf.OdfUtils");runtime.loadClass("gui.AnnotationViewManager");
+odf.OdfCanvas=function(){function e(){function a(c){d=!0;runtime.setTimeout(function(){try{c()}catch(e){runtime.log(e)}d=!1;0<b.length&&a(b.pop())},10)}var b=[],d=!1;this.clearQueue=function(){b.length=0};this.addToQueue=function(c){if(0===b.length&&!d)return a(c);b.push(c)}}function h(a){function b(){for(;0<d.cssRules.length;)d.deleteRule(0);d.insertRule("#shadowContent draw|page {display:none;}",0);d.insertRule("office|presentation draw|page {display:none;}",1);d.insertRule("#shadowContent draw|page:nth-of-type("+
+c+") {display:block;}",2);d.insertRule("office|presentation draw|page:nth-of-type("+c+") {display:block;}",3)}var d=a.sheet,c=1;this.showFirstPage=function(){c=1;b()};this.showNextPage=function(){c+=1;b()};this.showPreviousPage=function(){1<c&&(c-=1,b())};this.showPage=function(a){0<a&&(c=a,b())};this.css=a;this.destroy=function(b){a.parentNode.removeChild(a);b()}}function f(a,b,d){a.addEventListener?a.addEventListener(b,d,!1):a.attachEvent?a.attachEvent("on"+b,d):a["on"+b]=d}function n(a,b,d){var c=
+"on"+b;a.removeEventListener?a.removeEventListener(b,d,!1):a.detachEvent?a.detachEvent(c,d):a[c]===d&&(a[c]=null)}function m(a){function b(a,d){for(;d;){if(d===a)return!0;d=d.parentNode}return!1}function d(){var f=[],g=runtime.getWindow().getSelection(),k,h;for(k=0;k<g.rangeCount;k+=1)h=g.getRangeAt(k),null!==h&&b(a,h.startContainer)&&b(a,h.endContainer)&&f.push(h);if(f.length===c.length){for(g=0;g<f.length&&(k=f[g],h=c[g],k=k===h?!1:null===k||null===h?!0:k.startContainer!==h.startContainer||k.startOffset!==
+h.startOffset||k.endContainer!==h.endContainer||k.endOffset!==h.endOffset,!k);g+=1);if(g===f.length)return}c=f;var g=[f.length],l,m=a.ownerDocument;for(k=0;k<f.length;k+=1)h=f[k],l=m.createRange(),l.setStart(h.startContainer,h.startOffset),l.setEnd(h.endContainer,h.endOffset),g[k]=l;c=g;g=e.length;for(f=0;f<g;f+=1)e[f](a,c)}var c=[],e=[];this.addListener=function(a,b){var d,c=e.length;for(d=0;d<c;d+=1)if(e[d]===b)return;e.push(b)};this.destroy=function(b){n(a,"mouseup",d);n(a,"keyup",d);n(a,"keydown",
+d);b()};f(a,"mouseup",d);f(a,"keyup",d);f(a,"keydown",d)}function p(a){for(;a.firstChild;)a.removeChild(a.firstChild)}function c(a,b,d){(new odf.Style2CSS).style2css(a.getDocumentType(),d.sheet,b.getFontMap(),a.rootElement.styles,a.rootElement.automaticStyles)}function b(a,b,d){var c=null;a=a.rootElement.body.getElementsByTagNameNS(G,d+"-decl");if((d=b.getAttributeNS(G,"use-"+d+"-name"))&&0<a.length)for(b=0;b<a.length;b+=1)if(a[b].getAttributeNS(G,"name")===d){c=a[b].textContent;break}return c}function a(a,
+b,d,c){var e=a.ownerDocument;b=a.getElementsByTagNameNS(b,d);for(a=0;a<b.length;a+=1)p(b[a]),c&&b[a].appendChild(e.createTextNode(c))}function d(a,b,d){b.setAttributeNS("urn:webodf:names:helper","styleid",a);var c,e=b.getAttributeNS(I,"anchor-type"),f=b.getAttributeNS(B,"x"),g=b.getAttributeNS(B,"y"),k=b.getAttributeNS(B,"width"),h=b.getAttributeNS(B,"height"),l=b.getAttributeNS(u,"min-height"),m=b.getAttributeNS(u,"min-width");if("as-char"===e)c="display: inline-block;";else if(e||f||g)c="position: absolute;";
+else if(k||h||l||m)c="display: block;";f&&(c+="left: "+f+";");g&&(c+="top: "+g+";");k&&(c+="width: "+k+";");h&&(c+="height: "+h+";");l&&(c+="min-height: "+l+";");m&&(c+="min-width: "+m+";");c&&(c="draw|"+b.localName+'[webodfhelper|styleid="'+a+'"] {'+c+"}",d.insertRule(c,d.cssRules.length))}function k(a){for(a=a.firstChild;a;){if(a.namespaceURI===s&&"binary-data"===a.localName)return"data:image/png;base64,"+a.textContent.replace(/[\r\n\s]/g,"");a=a.nextSibling}return""}function g(a,b,d,c){function e(b){b&&
+(b='draw|image[webodfhelper|styleid="'+a+'"] {'+("background-image: url("+b+");")+"}",c.insertRule(b,c.cssRules.length))}d.setAttributeNS("urn:webodf:names:helper","styleid",a);var f=d.getAttributeNS(z,"href"),g;if(f)try{g=b.getPart(f),g.onchange=function(a){e(a.url)},g.load()}catch(h){runtime.log("slight problem: "+h)}else f=k(d),e(f)}function q(a){function b(d){var c,e;d.hasAttributeNS(z,"href")&&(c=d.getAttributeNS(z,"href"),"#"===c[0]?(c=c.substring(1),e=function(){var b=Z.getODFElementsWithXPath(a,
+"//text:bookmark-start[@text:name='"+c+"']",odf.Namespaces.resolvePrefix);0===b.length&&(b=Z.getODFElementsWithXPath(a,"//text:bookmark[@text:name='"+c+"']",odf.Namespaces.resolvePrefix));0<b.length&&b[0].scrollIntoView(!0);return!1}):e=function(){R.open(c)},d.onclick=e)}var d,c,e;c=a.getElementsByTagNameNS(I,"a");for(d=0;d<c.length;d+=1)e=c.item(d),b(e)}function l(a){var b=a.ownerDocument;T.getElementsByTagNameNS(a,I,"line-break").forEach(function(a){a.hasChildNodes()||a.appendChild(b.createElement("br"))})}
+function r(a){var b=a.ownerDocument;T.getElementsByTagNameNS(a,I,"s").forEach(function(a){for(var d,c;a.firstChild;)a.removeChild(a.firstChild);a.appendChild(b.createTextNode(" "));c=parseInt(a.getAttributeNS(I,"c"),10);if(1<c)for(a.removeAttributeNS(I,"c"),d=1;d<c;d+=1)a.parentNode.insertBefore(a.cloneNode(!0),a)})}function t(a){T.getElementsByTagNameNS(a,I,"tab").forEach(function(a){a.textContent="\t"})}function w(a,b){function d(a,f){var k=g.documentElement.namespaceURI;"video/"===f.substr(0,6)?
+(c=g.createElementNS(k,"video"),c.setAttribute("controls","controls"),e=g.createElementNS(k,"source"),e.setAttribute("src",a),e.setAttribute("type",f),c.appendChild(e),b.parentNode.appendChild(c)):b.innerHtml="Unrecognised Plugin"}var c,e,f,g=b.ownerDocument,h;if(f=b.getAttributeNS(z,"href"))try{h=a.getPart(f),h.onchange=function(a){d(a.url,a.mimetype)},h.load()}catch(l){runtime.log("slight problem: "+l)}else runtime.log("using MP4 data fallback"),f=k(b),d(f,"video/mp4")}function v(a){var b=a.getElementsByTagName("head")[0],
+d;"undefined"!==String(typeof webodf_css)?(d=a.createElementNS(b.namespaceURI,"style"),d.setAttribute("media","screen, print, handheld, projection"),d.appendChild(a.createTextNode(webodf_css))):(d=a.createElementNS(b.namespaceURI,"link"),a="webodf.css",runtime.currentDirectory&&(a=runtime.currentDirectory()+"/../"+a),d.setAttribute("href",a),d.setAttribute("rel","stylesheet"));d.setAttribute("type","text/css");b.appendChild(d);return d}function y(a){var b=a.getElementsByTagName("head")[0],d=a.createElementNS(b.namespaceURI,
+"style"),c="";d.setAttribute("type","text/css");d.setAttribute("media","screen, print, handheld, projection");odf.Namespaces.forEachPrefix(function(a,b){c+="@namespace "+a+" url("+b+");\n"});c+="@namespace webodfhelper url(urn:webodf:names:helper);\n";d.appendChild(a.createTextNode(c));b.appendChild(d);return d}var x=odf.Namespaces.drawns,u=odf.Namespaces.fons,s=odf.Namespaces.officens,C=odf.Namespaces.stylens,B=odf.Namespaces.svgns,A=odf.Namespaces.tablens,I=odf.Namespaces.textns,z=odf.Namespaces.xlinkns,
+N=odf.Namespaces.xmlns,G=odf.Namespaces.presentationns,R=runtime.getWindow(),Z=new xmldom.XPath,ka=new odf.OdfUtils,T=new core.DomUtils;odf.OdfCanvas=function(k){function n(a,b,d){function c(a,b,d,e){la.addToQueue(function(){g(a,b,d,e)})}var e,f;e=b.getElementsByTagNameNS(x,"image");for(b=0;b<e.length;b+=1)f=e.item(b),c("image"+String(b),a,f,d)}function u(a,b){function d(a,b){la.addToQueue(function(){w(a,b)})}var c,e,f;e=b.getElementsByTagNameNS(x,"plugin");for(c=0;c<e.length;c+=1)f=e.item(c),d(a,
+f)}function B(){V.firstChild&&(1<Y?(V.style.MozTransformOrigin="center top",V.style.WebkitTransformOrigin="center top",V.style.OTransformOrigin="center top",V.style.msTransformOrigin="center top"):(V.style.MozTransformOrigin="left top",V.style.WebkitTransformOrigin="left top",V.style.OTransformOrigin="left top",V.style.msTransformOrigin="left top"),V.style.WebkitTransform="scale("+Y+")",V.style.MozTransform="scale("+Y+")",V.style.OTransform="scale("+Y+")",V.style.msTransform="scale("+Y+")",k.style.width=
+Math.round(Y*V.offsetWidth)+"px",k.style.height=Math.round(Y*V.offsetHeight)+"px")}function z(a){function b(a){return c===a.getAttributeNS(s,"name")}var d=T.getElementsByTagNameNS(a,s,"annotation");a=T.getElementsByTagNameNS(a,s,"annotation-end");var c,e;for(e=0;e<d.length;e+=1)c=d[e].getAttributeNS(s,"name"),ea.addAnnotation({node:d[e],end:a.filter(b)[0]||null});ea.rerenderAnnotations()}function W(a){J?(Q.parentNode||(V.appendChild(Q),B()),ea&&ea.forgetAnnotations(),ea=new gui.AnnotationViewManager(M,
+a.body,Q),z(a.body)):Q.parentNode&&(V.removeChild(Q),ea.forgetAnnotations(),B())}function E(e){function f(){p(k);k.style.display="inline-block";var g=P.rootElement;k.ownerDocument.importNode(g,!0);aa.setOdfContainer(P);var h=P,m=D;(new odf.FontLoader).loadFonts(h,m.sheet);c(P,aa,fa);m=P;h=F.sheet;p(k);V=S.createElementNS(k.namespaceURI,"div");V.style.display="inline-block";V.style.background="white";V.appendChild(g);k.appendChild(V);Q=S.createElementNS(k.namespaceURI,"div");Q.id="annotationsPane";
+ia=S.createElementNS(k.namespaceURI,"div");ia.id="shadowContent";ia.style.position="absolute";ia.style.top=0;ia.style.left=0;m.getContentElement().appendChild(ia);var w=g.body,v,y,z;y=[];for(v=w.firstChild;v&&v!==w;)if(v.namespaceURI===x&&(y[y.length]=v),v.firstChild)v=v.firstChild;else{for(;v&&v!==w&&!v.nextSibling;)v=v.parentNode;v&&v.nextSibling&&(v=v.nextSibling)}for(z=0;z<y.length;z+=1)v=y[z],d("frame"+String(z),v,h);y=Z.getODFElementsWithXPath(w,".//*[*[@text:anchor-type='paragraph']]",odf.Namespaces.resolvePrefix);
+for(v=0;v<y.length;v+=1)w=y[v],w.setAttributeNS&&w.setAttributeNS("urn:webodf:names:helper","containsparagraphanchor",!0);var w=ia,T,E,K;K=0;var H,J;y=m.rootElement.ownerDocument;if((v=g.body.firstElementChild)&&v.namespaceURI===s&&("presentation"===v.localName||"drawing"===v.localName))for(v=v.firstElementChild;v;){z=v.getAttributeNS(x,"master-page-name");if(z){T=m.rootElement.masterStyles.getElementsByTagNameNS(C,"master-page");E=null;K=void 0;for(K=0;K<T.length;K+=1)if(T[K].getAttributeNS(C,"name")===
+z){E=T[K];break}z=E}else z=null;if(z){T=v.getAttributeNS("urn:webodf:names:helper","styleid");E=y.createElementNS(x,"draw:page");J=z.firstElementChild;for(H=0;J;)"true"!==J.getAttributeNS(G,"placeholder")&&(K=J.cloneNode(!0),E.appendChild(K),d(T+"_"+H,K,h)),J=J.nextElementSibling,H+=1;J=H=K=void 0;var M=E.getElementsByTagNameNS(x,"frame");for(K=0;K<M.length;K+=1)H=M[K],(J=H.getAttributeNS(G,"class"))&&!/^(date-time|footer|header|page-number')$/.test(J)&&H.parentNode.removeChild(H);w.appendChild(E);
+K=String(w.getElementsByTagNameNS(x,"page").length);a(E,I,"page-number",K);a(E,G,"header",b(m,v,"header"));a(E,G,"footer",b(m,v,"footer"));d(T,E,h);E.setAttributeNS(x,"draw:master-page-name",z.getAttributeNS(C,"name"))}v=v.nextElementSibling}v=g.body.getElementsByTagNameNS(A,"table-cell");for(w=0;w<v.length;w+=1)y=v.item(w),y.hasAttributeNS(A,"number-columns-spanned")&&y.setAttribute("colspan",y.getAttributeNS(A,"number-columns-spanned")),y.hasAttributeNS(A,"number-rows-spanned")&&y.setAttribute("rowspan",
+y.getAttributeNS(A,"number-rows-spanned"));q(g.body);l(g.body);r(g.body);t(g.body);n(m,g.body,h);u(m,g.body);y=g.body;w={};v={};var O;z=R.document.getElementsByTagNameNS(I,"list-style");for(m=0;m<z.length;m+=1)K=z.item(m),(H=K.getAttributeNS(C,"name"))&&(v[H]=K);y=y.getElementsByTagNameNS(I,"list");for(m=0;m<y.length;m+=1)if(K=y.item(m),z=K.getAttributeNS(N,"id")){T=K.getAttributeNS(I,"continue-list");K.setAttribute("id",z);E="text|list#"+z+" > text|list-item > *:first-child:before {";if(H=K.getAttributeNS(I,
+"style-name"))K=v[H],O=ka.getFirstNonWhitespaceChild(K),K=void 0,O&&("list-level-style-number"===O.localName?(K=O.getAttributeNS(C,"num-format"),H=O.getAttributeNS(C,"num-suffix"),J="",J={1:"decimal",a:"lower-latin",A:"upper-latin",i:"lower-roman",I:"upper-roman"},M=void 0,M=O.getAttributeNS(C,"num-prefix")||"",M=J.hasOwnProperty(K)?M+(" counter(list, "+J[K]+")"):K?M+("'"+K+"';"):M+" ''",H&&(M+=" '"+H+"'"),K=J="content: "+M+";"):"list-level-style-image"===O.localName?K="content: none;":"list-level-style-bullet"===
+O.localName&&(K="content: '"+O.getAttributeNS(I,"bullet-char")+"';")),O=K;if(T){for(K=w[T];K;)T=K,K=w[T];E+="counter-increment:"+T+";";O?(O=O.replace("list",T),E+=O):E+="content:counter("+T+");"}else T="",O?(O=O.replace("list",z),E+=O):E+="content: counter("+z+");",E+="counter-increment:"+z+";",h.insertRule("text|list#"+z+" {counter-reset:"+z+"}",h.cssRules.length);E+="}";w[z]=T;E&&h.insertRule(E,h.cssRules.length)}V.insertBefore(ia,V.firstChild);B();W(g);if(!e&&(g=[P],ba.hasOwnProperty("statereadychange")))for(h=
+ba.statereadychange,O=0;O<h.length;O+=1)h[O].apply(null,g)}P.state===odf.OdfContainer.DONE?f():(runtime.log("WARNING: refreshOdf called but ODF was not DONE."),runtime.setTimeout(function ma(){P.state===odf.OdfContainer.DONE?f():(runtime.log("will be back later..."),runtime.setTimeout(ma,500))},100))}function H(a){la.clearQueue();k.innerHTML=runtime.tr("Loading")+" "+a+"...";k.removeAttribute("style");P=new odf.OdfContainer(a,function(a){P=a;E(!1)})}runtime.assert(null!==k&&void 0!==k,"odf.OdfCanvas constructor needs DOM element");
+runtime.assert(null!==k.ownerDocument&&void 0!==k.ownerDocument,"odf.OdfCanvas constructor needs DOM");var M=this,S=k.ownerDocument,P,aa=new odf.Formatting,na=new m(k),da,V,Q,J=!1,ea,oa,D,fa,F,ia,Y=1,ba={},la=new e;this.refreshCSS=function(){c(P,aa,fa);B()};this.refreshSize=function(){B()};this.odfContainer=function(){return P};this.slidevisibilitycss=function(){return da.css};this.setOdfContainer=function(a,b){P=a;E(!0===b)};this.load=this.load=H;this.save=function(a){P.save(a)};this.addListener=
+function(a,b){switch(a){case "selectionchange":na.addListener(a,b);break;case "click":f(k,a,b);break;default:var d=ba[a];void 0===d&&(d=ba[a]=[]);b&&-1===d.indexOf(b)&&d.push(b)}};this.getFormatting=function(){return aa};this.getAnnotationManager=function(){return ea};this.refreshAnnotations=function(){W(P.rootElement)};this.rerenderAnnotations=function(){ea&&ea.rerenderAnnotations()};this.getSizer=function(){return V};this.enableAnnotations=function(a){a!==J&&(J=a,P&&W(P.rootElement))};this.addAnnotation=
+function(a){ea&&ea.addAnnotation(a)};this.forgetAnnotations=function(){ea&&ea.forgetAnnotations()};this.setZoomLevel=function(a){Y=a;B()};this.getZoomLevel=function(){return Y};this.fitToContainingElement=function(a,b){var d=k.offsetHeight/Y;Y=a/(k.offsetWidth/Y);b/d<Y&&(Y=b/d);B()};this.fitToWidth=function(a){Y=a/(k.offsetWidth/Y);B()};this.fitSmart=function(a,b){var d,c;d=k.offsetWidth/Y;c=k.offsetHeight/Y;d=a/d;void 0!==b&&b/c<d&&(d=b/c);Y=Math.min(1,d);B()};this.fitToHeight=function(a){Y=a/(k.offsetHeight/
+Y);B()};this.showFirstPage=function(){da.showFirstPage()};this.showNextPage=function(){da.showNextPage()};this.showPreviousPage=function(){da.showPreviousPage()};this.showPage=function(a){da.showPage(a);B()};this.getElement=function(){return k};this.addCssForFrameWithImage=function(a){var b=a.getAttributeNS(x,"name");d(b,a,F.sheet);g(b+"img",P,a.firstChild,F.sheet)};this.destroy=function(a){var b=S.getElementsByTagName("head")[0];Q&&Q.parentNode&&Q.parentNode.removeChild(Q);V&&k.removeChild(V);b.removeChild(oa);
+b.removeChild(D);b.removeChild(fa);b.removeChild(F);na.destroy(function(b){b?a(b):da.destroy(a)})};oa=v(S);da=new h(y(S));D=y(S);fa=y(S);F=y(S)};return odf.OdfCanvas}();
+// Input 39
+runtime.loadClass("odf.OdfCanvas");
+odf.CommandLineTools=function(){this.roundTrip=function(e,h,f){return new odf.OdfContainer(e,function(n){if(n.state===odf.OdfContainer.INVALID)return f("Document "+e+" is invalid.");n.state===odf.OdfContainer.DONE?n.saveAs(h,function(e){f(e)}):f("Document was not completely loaded.")})};this.render=function(e,h,f){for(h=h.getElementsByTagName("body")[0];h.firstChild;)h.removeChild(h.firstChild);h=new odf.OdfCanvas(h);h.addListener("statereadychange",function(e){f(e)});h.load(e)}};
+// Input 40
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.Server=function(){};ops.Server.prototype.connect=function(e,h){};ops.Server.prototype.networkStatus=function(){};ops.Server.prototype.login=function(e,h,f,n){};ops.Server.prototype.joinSession=function(e,h,f,n){};ops.Server.prototype.leaveSession=function(e,h,f,n){};ops.Server.prototype.getGenesisUrl=function(e){};
 // Input 41
 /*
 
@@ -1034,6 +1066,9 @@ ops.Operation=function(){};ops.Operation.prototype.init=function(h){};ops.Operat
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1054,9 +1089,9 @@ ops.Operation=function(){};ops.Operation.prototype.init=function(h){};ops.Operat
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpAddCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;f=a.timestamp};this.transform=function(a,c){return[h]};this.execute=function(a){var c=a.getCursor(m);if(c)return!1;c=new ops.OdtCursor(m,a);a.addCursor(c);a.emit(ops.OdtDocument.signalCursorAdded,c);return!0};this.spec=function(){return{optype:"AddCursor",memberid:m,timestamp:f}}};
+ops.Operation=function(){};ops.Operation.prototype.init=function(e){};ops.Operation.prototype.execute=function(e){};ops.Operation.prototype.spec=function(){};
 // Input 42
 /*
 
@@ -1070,6 +1105,9 @@ ops.OpAddCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;f=a
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1090,13 +1128,9 @@ ops.OpAddCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;f=a
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.DomUtils");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");
-gui.StyleHelper=function(h){function m(a){var b;a.collapsed?(b=a.startContainer,b.hasChildNodes()&&a.startOffset<b.childNodes.length&&(b=b.childNodes[a.startOffset]),a=[b]):a=d.getTextNodes(a,!0);return h.getAppliedStyles(a)}function f(a,b,c){var d=!0,f;a=m(a);for(f=0;f<a.length&&!(d=a[f]["style:text-properties"],d=!d||d[b]!==c);f+=1);return!d}function a(a,c,e){a=d.getParagraphElements(a);for(var f={},m=!1,g,l;0<a.length;){(g=a[0].getAttributeNS(b,"style-name"))?f[g]||(l=h.getStyleElement(g,"paragraph"),
-f[g]=!0):m?l=void 0:(m=!0,l=h.getDefaultStyleElement("paragraph"));if(l&&(g=h.getInheritedStyleAttributes(l,!0),(g=g["style:paragraph-properties"])&&-1===e.indexOf(g[c])))return!1;a.pop()}return!0}var c=new core.DomUtils,d=new odf.OdfUtils,b=odf.Namespaces.textns;this.getAppliedStyles=m;this.applyStyle=function(a,b,e){var f=c.splitBoundaries(b),m=d.getTextNodes(b,!1);h.applyStyle(a,m,{startContainer:b.startContainer,startOffset:b.startOffset,endContainer:b.endContainer,endOffset:b.endOffset},e);f.forEach(c.normalizeTextNodes)};
-this.isBold=function(a){return f(a,"fo:font-weight","bold")};this.isItalic=function(a){return f(a,"fo:font-style","italic")};this.hasUnderline=function(a){return f(a,"style:text-underline-style","solid")};this.hasStrikeThrough=function(a){return f(a,"style:text-line-through-style","solid")};this.isAlignedLeft=function(b){return a(b,"fo:text-align",["left","start"])};this.isAlignedCenter=function(b){return a(b,"fo:text-align",["center"])};this.isAlignedRight=function(b){return a(b,"fo:text-align",
-["right","end"])};this.isAlignedJustified=function(b){return a(b,"fo:text-align",["justify"])}};
+ops.OpAddCursor=function(){var e,h;this.init=function(f){e=f.memberid;h=f.timestamp};this.execute=function(f){var h=f.getCursor(e);if(h)return!1;h=new ops.OdtCursor(e,f);f.addCursor(h);f.emit(ops.OdtDocument.signalCursorAdded,h);return!0};this.spec=function(){return{optype:"AddCursor",memberid:e,timestamp:h}}};
 // Input 43
 /*
 
@@ -1110,6 +1144,9 @@ this.isBold=function(a){return f(a,"fo:font-weight","bold")};this.isItalic=funct
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1130,11 +1167,13 @@ this.isBold=function(a){return f(a,"fo:font-weight","bold")};this.isItalic=funct
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("gui.StyleHelper");runtime.loadClass("odf.OdfUtils");
-ops.OpApplyDirectStyling=function(){function h(b){var d=0<=c?a+c:a,e=b.getIteratorAtPosition(0<=c?a:a+c),d=c?b.getIteratorAtPosition(d):e;b=b.getDOM().createRange();b.setStart(e.container(),e.unfilteredDomOffset());b.setEnd(d.container(),d.unfilteredDomOffset());return b}var m,f,a,c,d,b=new odf.OdfUtils;this.init=function(b){m=b.memberid;f=b.timestamp;a=parseInt(b.position,10);c=parseInt(b.length,10);d=b.setProperties};this.transform=function(a,b){return null};this.execute=function(a){var c=h(a),
-e=b.getImpactedParagraphs(c);(new gui.StyleHelper(a.getFormatting())).applyStyle(m,c,d);c.detach();a.getOdfCanvas().refreshCSS();e.forEach(function(b){a.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:b,memberId:m,timeStamp:f})});a.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"ApplyDirectStyling",memberid:m,timestamp:f,position:a,length:c,setProperties:d}}};
+runtime.loadClass("core.DomUtils");runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");
+gui.StyleHelper=function(e){function h(c,b,a){var d=!0,e;for(e=0;e<c.length&&!(d=c[e]["style:text-properties"],d=!d||d[b]!==a);e+=1);return!d}function f(c,b,a){c=m.getParagraphElements(c);for(var d={},f=!1,g,h;0<c.length;){(g=c[0].getAttributeNS(p,"style-name"))?d[g]||(h=e.getStyleElement(g,"paragraph"),d[g]=!0):f?h=void 0:(f=!0,h=e.getDefaultStyleElement("paragraph"));if(h&&(g=e.getInheritedStyleAttributes(h,!0),(g=g["style:paragraph-properties"])&&-1===a.indexOf(g[b])))return!1;c.pop()}return!0}
+var n=new core.DomUtils,m=new odf.OdfUtils,p=odf.Namespaces.textns;this.getAppliedStyles=function(c){var b;c.collapsed?(b=c.startContainer,b.hasChildNodes()&&c.startOffset<b.childNodes.length&&(b=b.childNodes[c.startOffset]),c=[b]):c=m.getTextNodes(c,!0);return e.getAppliedStyles(c)};this.applyStyle=function(c,b,a){var d=n.splitBoundaries(b),f=m.getTextNodes(b,!1);e.applyStyle(c,f,{startContainer:b.startContainer,startOffset:b.startOffset,endContainer:b.endContainer,endOffset:b.endOffset},a);d.forEach(n.normalizeTextNodes)};
+this.isBold=function(c){return h(c,"fo:font-weight","bold")};this.isItalic=function(c){return h(c,"fo:font-style","italic")};this.hasUnderline=function(c){return h(c,"style:text-underline-style","solid")};this.hasStrikeThrough=function(c){return h(c,"style:text-line-through-style","solid")};this.isAlignedLeft=function(c){return f(c,"fo:text-align",["left","start"])};this.isAlignedCenter=function(c){return f(c,"fo:text-align",["center"])};this.isAlignedRight=function(c){return f(c,"fo:text-align",
+["right","end"])};this.isAlignedJustified=function(c){return f(c,"fo:text-align",["justify"])}};
 // Input 44
 /*
 
@@ -1148,6 +1187,9 @@ e=b.getImpactedParagraphs(c);(new gui.StyleHelper(a.getFormatting())).applyStyle
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1168,9 +1210,11 @@ e=b.getImpactedParagraphs(c);(new gui.StyleHelper(a.getFormatting())).applyStyle
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpRemoveCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;f=a.timestamp};this.transform=function(a,c){var d=a.spec(),b=[h];"RemoveCursor"===d.optype&&d.memberid===m&&(b=[]);return b};this.execute=function(a){return a.removeCursor(m)?!0:!1};this.spec=function(){return{optype:"RemoveCursor",memberid:m,timestamp:f}}};
+runtime.loadClass("gui.StyleHelper");runtime.loadClass("odf.OdfUtils");
+ops.OpApplyDirectStyling=function(){function e(b){var a=0<=m?n+m:n,d=b.getIteratorAtPosition(0<=m?n:n+m),a=m?b.getIteratorAtPosition(a):d;b=b.getDOM().createRange();b.setStart(d.container(),d.unfilteredDomOffset());b.setEnd(a.container(),a.unfilteredDomOffset());return b}var h,f,n,m,p,c=new odf.OdfUtils;this.init=function(b){h=b.memberid;f=b.timestamp;n=parseInt(b.position,10);m=parseInt(b.length,10);p=b.setProperties};this.execute=function(b){var a=e(b),d=c.getImpactedParagraphs(a);(new gui.StyleHelper(b.getFormatting())).applyStyle(h,
+a,p);a.detach();b.getOdfCanvas().refreshCSS();b.fixCursorPositions();d.forEach(function(a){b.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:a,memberId:h,timeStamp:f})});b.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"ApplyDirectStyling",memberid:h,timestamp:f,position:n,length:m,setProperties:p}}};
 // Input 45
 /*
 
@@ -1184,6 +1228,9 @@ ops.OpRemoveCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1204,15 +1251,13 @@ ops.OpRemoveCursor=function(){var h=this,m,f;this.init=function(a){m=a.memberid;
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpMoveCursor=function(){var h=this,m,f,a,c;this.init=function(d){m=d.memberid;f=d.timestamp;a=parseInt(d.position,10);c=void 0!==d.length?parseInt(d.length,10):0};this.merge=function(d){return"MoveCursor"===d.optype&&d.memberid===m?(a=d.position,c=d.length,f=d.timestamp,!0):!1};this.transform=function(d,b){var k=d.spec(),f=a+c,e,s=[h];switch(k.optype){case "RemoveText":e=k.position+k.length;e<=a?a-=k.length:k.position<f&&(a<k.position?c=e<f?c-k.length:k.position-a:(a=k.position,c=e<f?f-e:0));
-break;case "SplitParagraph":k.position<a?a+=1:k.position<=f&&(c+=1);break;case "AddAnnotation":k.position<a?a+=1:k.position<f&&(c+=1);break;case "InsertText":k.position<a?a+=k.text.length:k.position<=f&&(c+=k.text.length);break;case "RemoveCursor":k.memberid===m&&(s=[]);break;case "InsertTable":s=null}return s};this.execute=function(d){var b=d.getCursor(m),k=d.getCursorPosition(m),f=d.getPositionFilter(),e=a-k;if(!b)return!1;k=b.getStepCounter();e=0<e?k.countForwardSteps(e,f):0>e?-k.countBackwardSteps(-e,
-f):0;b.move(e);c&&(f=0<c?k.countForwardSteps(c,f):0>c?-k.countBackwardSteps(-c,f):0,b.move(f,!0));d.emit(ops.OdtDocument.signalCursorMoved,b);return!0};this.spec=function(){return{optype:"MoveCursor",memberid:m,timestamp:f,position:a,length:c}}};
+ops.OpRemoveCursor=function(){var e,h;this.init=function(f){e=f.memberid;h=f.timestamp};this.execute=function(f){return f.removeCursor(e)?!0:!1};this.spec=function(){return{optype:"RemoveCursor",memberid:e,timestamp:h}}};
 // Input 46
 /*
 
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -1222,6 +1267,9 @@ f):0;b.move(e);c&&(f=0<c?k.countForwardSteps(c,f):0>c?-k.countBackwardSteps(-c,f
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1242,13 +1290,10 @@ f):0;b.move(e);c&&(f=0<c?k.countForwardSteps(c,f):0>c?-k.countBackwardSteps(-c,f
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpInsertTable=function(){function h(a,b){var e;if(1===s.length)e=s[0];else if(3===s.length)switch(a){case 0:e=s[0];break;case c-1:e=s[2];break;default:e=s[1]}else e=s[a];if(1===e.length)return e[0];if(3===e.length)switch(b){case 0:return e[0];case d-1:return e[2];default:return e[1]}return e[b]}var m=this,f,a,c,d,b,k,p,e,s;this.init=function(h){f=h.memberid;a=h.timestamp;b=parseInt(h.position,10);c=parseInt(h.initialRows,10);d=parseInt(h.initialColumns,10);k=h.tableName;p=h.tableStyleName;e=h.tableColumnStyleName;
-s=h.tableCellStyleMatrix};this.transform=function(a,c){var d=a.spec(),e=[m];switch(d.optype){case "InsertTable":e=null;break;case "AddAnnotation":d.position<b&&(b+=1);break;case "SplitParagraph":d.position<b?b+=1:d.position!==b||c||(b+=1,e=null);break;case "InsertText":d.position<b?b+=d.text.length:d.position!==b||c||(b+=d.text.length,e=null);break;case "RemoveText":d.position+d.length<=b?b-=d.length:d.position<b&&(b=d.position)}return e};this.execute=function(m){var g=m.getPositionInTextNode(b),
-l=m.getRootNode();if(g){var s=m.getDOM(),q=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table"),x=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-column"),r,y,t,w;p&&q.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",p);k&&q.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:name",k);x.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:number-columns-repeated",
-d);e&&x.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",e);q.appendChild(x);for(t=0;t<c;t+=1){x=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-row");for(w=0;w<d;w+=1)r=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-cell"),(y=h(t,w))&&r.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",y),y=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0","text:p"),
-r.appendChild(y),x.appendChild(r);q.appendChild(x)}g=m.getParagraphElement(g.textNode);l.insertBefore(q,g?g.nextSibling:void 0);m.getOdfCanvas().refreshSize();m.emit(ops.OdtDocument.signalTableAdded,{tableElement:q,memberId:f,timeStamp:a});m.getOdfCanvas().rerenderAnnotations();return!0}return!1};this.spec=function(){return{optype:"InsertTable",memberid:f,timestamp:a,position:b,initialRows:c,initialColumns:d,tableName:k,tableStyleName:p,tableColumnStyleName:e,tableCellStyleMatrix:s}}};
+ops.OpMoveCursor=function(){var e,h,f,n,m;this.init=function(p){e=p.memberid;h=p.timestamp;f=p.position;n=p.length||0;m=p.selectionType||ops.OdtCursor.RangeSelection};this.execute=function(h){var c=h.getCursor(e),b=h.getCursorPosition(e),a=h.getPositionFilter(),d=f-b;if(!c)return!1;b=c.getStepCounter();d=b.countSteps(d,a);c.move(d);n&&(a=b.countSteps(n,a),c.move(a,!0));c.setSelectionType(m);h.emit(ops.OdtDocument.signalCursorMoved,c);return!0};this.spec=function(){return{optype:"MoveCursor",memberid:e,
+timestamp:h,position:f,length:n,selectionType:m}}};
 // Input 47
 /*
 
@@ -1262,6 +1307,9 @@ r.appendChild(y),x.appendChild(r);q.appendChild(x)}g=m.getParagraphElement(g.tex
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1282,12 +1330,9 @@ r.appendChild(y),x.appendChild(r);q.appendChild(x)}g=m.getParagraphElement(g.tex
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpInsertText=function(){var h=this,m,f,a,c;this.init=function(d){m=d.memberid;f=d.timestamp;a=parseInt(d.position,10);c=d.text};this.merge=function(d){return"InsertText"===d.optype&&d.memberid===m&&d.position===a+c.length?(c+=d.text,f=d.timestamp,!0):!1};this.transform=function(c,b){var f=c.spec(),m=[h];switch(f.optype){case "InsertText":f.position<a?a+=f.text.length:f.position!==a||b||(a+=f.text.length,m=null);break;case "AddAnnotation":f.position<a&&(a+=1);break;case "SplitParagraph":f.position<
-a?a+=1:f.position!==a||b||(a+=1,m=null);break;case "InsertTable":m=null;break;case "RemoveText":f.position+f.length<=a?a-=f.length:f.position<a&&(a=f.position)}return m};this.execute=function(d){var b,k,h,e,s=d.getDOM(),n,g=0,l,u;d.upgradeWhitespacesAtPosition(a);if(b=d.getPositionInTextNode(a,m)){k=b.textNode;e=k.nextSibling;h=k.parentNode;n=d.getParagraphElement(k);for(u=0;u<c.length;u+=1)if(" "===c[u]&&(0===u||" "===c[u-1])||"\t"===c[u])0===g?(b.offset!==k.length&&(e=k.splitText(b.offset)),0<u&&
-k.appendData(c.substring(0,u))):g<u&&(g=c.substring(g,u),h.insertBefore(s.createTextNode(g),e)),g=u+1,l=" "===c[u]?"text:s":"text:tab",l=s.createElementNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0",l),l.appendChild(s.createTextNode(c[u])),h.insertBefore(l,e);0===g?k.insertData(b.offset,c):g<c.length&&(b=c.substring(g),h.insertBefore(s.createTextNode(b),e));h=k.parentNode;e=k.nextSibling;h.removeChild(k);h.insertBefore(k,e);0===k.length&&k.parentNode.removeChild(k);0<a&&(d.downgradeWhitespacesAtPosition(a-
-1),1<a&&d.downgradeWhitespacesAtPosition(a-2));d.downgradeWhitespacesAtPosition(a);d.downgradeWhitespacesAtPosition(a+c.length);d.getOdfCanvas().refreshSize();d.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:n,memberId:m,timeStamp:f});d.getOdfCanvas().rerenderAnnotations();return!0}return!1};this.spec=function(){return{optype:"InsertText",memberid:m,timestamp:f,position:a,text:c}}};
+ops.OpSetBlob=function(){var e,h,f,n,m;this.init=function(p){e=p.memberid;h=p.timestamp;f=p.filename;n=p.mimetype;m=p.content};this.execute=function(e){e.getOdfCanvas().odfContainer().setBlob(f,n,m);return!0};this.spec=function(){return{optype:"SetBlob",memberid:e,timestamp:h,filename:f,mimetype:n,content:m}}};
 // Input 48
 /*
 
@@ -1301,6 +1346,9 @@ k.appendData(c.substring(0,u))):g<u&&(g=c.substring(g,u),h.insertBefore(s.create
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1321,15 +1369,9 @@ k.appendData(c.substring(0,u))):g<u&&(g=c.substring(g,u),h.insertBefore(s.create
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");runtime.loadClass("core.DomUtils");
-ops.OpRemoveText=function(){function h(a){function b(a){if(k.isCharacterElement(a))return!1;if(a.nodeType===Node.TEXT_NODE)return 0===a.textContent.length;for(a=a.firstChild;a;){if(!b(a))return!1;a=a.nextSibling}return!0}function c(d){d=p.mergeIntoParent(d);return!k.isParagraph(d)&&d!==a&&b(d)?c(d):d}this.isEmpty=b;this.mergeChildrenIntoParent=c}function m(a){var c=a.getPositionFilter(),f,g,k,h,m=b,x=a.getDOM().createRange();a=a.getIteratorAtPosition(d);f=a.container();for(g=a.unfilteredDomOffset();m&&
-a.nextPosition();)k=a.container(),h=a.unfilteredDomOffset(),c.acceptPosition(a)===NodeFilter.FILTER_ACCEPT&&(m-=1);x.setStart(f,g);x.setEnd(k,h);p.splitBoundaries(x);return x}var f=this,a,c,d,b,k,p;this.init=function(e){runtime.assert(0<=e.length,"OpRemoveText only supports positive lengths");a=e.memberid;c=e.timestamp;d=parseInt(e.position,10);b=parseInt(e.length,10);k=new odf.OdfUtils;p=new core.DomUtils};this.transform=function(e,k){var h=e.spec(),g=d+b,l,m=[f];switch(h.optype){case "RemoveText":l=
-h.position+h.length;l<=d?d-=h.length:h.position<g&&(d<h.position?b=l<g?b-h.length:h.position-d:l<g?(d=h.position,b=g-l):m=[]);break;case "InsertText":h.position<=d?d+=h.text.length:h.position<g&&(b=h.position-d,l=new ops.OpRemoveText,l.init({memberid:a,timestamp:c,position:h.position+h.text.length,length:g-h.position}),m=[l,f]);break;case "SplitParagraph":h.position<=d?d+=1:h.position<g&&(b=h.position-d,l=new ops.OpRemoveText,l.init({memberid:a,timestamp:c,position:h.position+1,length:g-h.position}),
-m=[l,f]);break;case "InsertTable":m=null;break;case "AddAnnotation":case "RemoveAnnotation":m=null;break;case "ApplyDirectStyling":m=null}return m};this.execute=function(e){var f,k,g,l,p=new h(e.getRootNode());e.upgradeWhitespacesAtPosition(d);e.upgradeWhitespacesAtPosition(d+b);k=m(e);f=e.getParagraphElement(k.startContainer);g=e.getTextElements(k,!0);l=e.getParagraphElements(k);k.detach();g.forEach(function(a){p.mergeChildrenIntoParent(a)});k=l.reduce(function(a,b){var c,d,e=a,g=b,f,k;p.isEmpty(a)&&
-(d=!0,b.parentNode!==a.parentNode&&(f=b.parentNode,a.parentNode.insertBefore(b,a.nextSibling)),g=a,e=b,k=e.getElementsByTagNameNS("urn:webodf:names:editinfo","editinfo")[0]||e.firstChild);for(;g.hasChildNodes();)c=d?g.lastChild:g.firstChild,g.removeChild(c),"editinfo"!==c.localName&&e.insertBefore(c,k);f&&p.isEmpty(f)&&p.mergeChildrenIntoParent(f);p.mergeChildrenIntoParent(g);return e});e.downgradeWhitespacesAtPosition(d);e.fixCursorPositions();e.getOdfCanvas().refreshSize();e.emit(ops.OdtDocument.signalParagraphChanged,
-{paragraphElement:k||f,memberId:a,timeStamp:c});e.emit(ops.OdtDocument.signalCursorMoved,e.getCursor(a));e.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"RemoveText",memberid:a,timestamp:c,position:d,length:b}}};
+ops.OpRemoveBlob=function(){var e,h,f;this.init=function(n){e=n.memberid;h=n.timestamp;f=n.filename};this.execute=function(e){e.getOdfCanvas().odfContainer().removeBlob(f);return!0};this.spec=function(){return{optype:"RemoveBlob",memberid:e,timestamp:h,filename:f}}};
 // Input 49
 /*
 
@@ -1343,6 +1385,9 @@ m=[l,f]);break;case "InsertTable":m=null;break;case "AddAnnotation":case "Remove
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1363,16 +1408,15 @@ m=[l,f]);break;case "InsertTable":m=null;break;case "AddAnnotation":case "Remove
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpSplitParagraph=function(){var h=this,m,f,a,c=new odf.OdfUtils;this.init=function(c){m=c.memberid;f=c.timestamp;a=parseInt(c.position,10)};this.transform=function(c,b){var f=c.spec(),m=[h];switch(f.optype){case "SplitParagraph":f.position<a?a+=1:f.position!==a||b||(a+=1,m=null);break;case "AddAnnotation":f.position<a&&(a+=1);break;case "InsertText":f.position<a?a+=f.text.length:f.position!==a||b||(a+=f.text.length,m=null);break;case "InsertTable":m=null;break;case "RemoveText":f.position+f.length<=
-a?a-=f.length:f.position<a&&(a=f.position)}return m};this.execute=function(d){var b,k,h,e,s,n,g;d.upgradeWhitespacesAtPosition(a);b=d.getPositionInTextNode(a,m);if(!b)return!1;k=d.getParagraphElement(b.textNode);if(!k)return!1;h=c.isListItem(k.parentNode)?k.parentNode:k;0===b.offset?(g=b.textNode.previousSibling,n=null):(g=b.textNode,n=b.offset>=b.textNode.length?null:b.textNode.splitText(b.offset));for(e=b.textNode;e!==h;)if(e=e.parentNode,s=e.cloneNode(!1),g){for(n&&s.appendChild(n);g.nextSibling;)s.appendChild(g.nextSibling);
-e.parentNode.insertBefore(s,e.nextSibling);g=e;n=s}else e.parentNode.insertBefore(s,e),g=s,n=e;c.isListItem(n)&&(n=n.childNodes[0]);0===b.textNode.length&&b.textNode.parentNode.removeChild(b.textNode);d.fixCursorPositions(m);d.getOdfCanvas().refreshSize();d.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:k,memberId:m,timeStamp:f});d.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:n,memberId:m,timeStamp:f});d.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"SplitParagraph",
-memberid:m,timestamp:f,position:a}}};
+ops.OpInsertImage=function(){var e,h,f,n,m,p,c,b,a=odf.Namespaces.drawns,d=odf.Namespaces.svgns,k=odf.Namespaces.textns,g=odf.Namespaces.xlinkns;this.init=function(a){e=a.memberid;h=a.timestamp;f=a.position;n=a.filename;m=a.frameWidth;p=a.frameHeight;c=a.frameStyleName;b=a.frameName};this.execute=function(q){var l=q.getOdfCanvas(),r=q.getPositionInTextNode(f,e),t,w;if(!r)return!1;t=r.textNode;w=q.getParagraphElement(t);var r=r.offset!==t.length?t.splitText(r.offset):t.nextSibling,v=q.getDOM(),y=v.createElementNS(a,
+"draw:image"),v=v.createElementNS(a,"draw:frame");y.setAttributeNS(g,"xlink:href",n);y.setAttributeNS(g,"xlink:type","simple");y.setAttributeNS(g,"xlink:show","embed");y.setAttributeNS(g,"xlink:actuate","onLoad");v.setAttributeNS(a,"draw:style-name",c);v.setAttributeNS(a,"draw:name",b);v.setAttributeNS(k,"text:anchor-type","as-char");v.setAttributeNS(d,"svg:width",m);v.setAttributeNS(d,"svg:height",p);v.appendChild(y);t.parentNode.insertBefore(v,r);0===t.length&&t.parentNode.removeChild(t);l.addCssForFrameWithImage(v);
+l.refreshCSS();q.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:w,memberId:e,timeStamp:h});l.rerenderAnnotations();return!0};this.spec=function(){return{optype:"InsertImage",memberid:e,timestamp:h,filename:n,position:f,frameWidth:m,frameHeight:p,frameStyleName:c,frameName:b}}};
 // Input 50
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -1382,6 +1426,9 @@ memberid:m,timestamp:f,position:a}}};
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1402,10 +1449,12 @@ memberid:m,timestamp:f,position:a}}};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpSetParagraphStyle=function(){var h=this,m,f,a,c;this.init=function(d){m=d.memberid;f=d.timestamp;a=d.position;c=d.styleName};this.transform=function(a,b){var f=a.spec(),m=[h];switch(f.optype){case "RemoveStyle":f.styleName===c&&"paragraph"===f.styleFamily&&(c="")}return m};this.execute=function(d){var b;b=d.getIteratorAtPosition(a);return(b=d.getParagraphElement(b.container()))?(""!==c?b.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0","text:style-name",c):b.removeAttributeNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0",
-"style-name"),d.getOdfCanvas().refreshSize(),d.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:b,timeStamp:f,memberId:m}),d.getOdfCanvas().rerenderAnnotations(),!0):!1};this.spec=function(){return{optype:"SetParagraphStyle",memberid:m,timestamp:f,position:a,styleName:c}}};
+ops.OpInsertTable=function(){function e(a,b){var c;if(1===d.length)c=d[0];else if(3===d.length)switch(a){case 0:c=d[0];break;case n-1:c=d[2];break;default:c=d[1]}else c=d[a];if(1===c.length)return c[0];if(3===c.length)switch(b){case 0:return c[0];case m-1:return c[2];default:return c[1]}return c[b]}var h,f,n,m,p,c,b,a,d;this.init=function(e){h=e.memberid;f=e.timestamp;p=e.position;n=e.initialRows;m=e.initialColumns;c=e.tableName;b=e.tableStyleName;a=e.tableColumnStyleName;d=e.tableCellStyleMatrix};
+this.execute=function(d){var g=d.getPositionInTextNode(p),q=d.getRootNode();if(g){var l=d.getDOM(),r=l.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table"),t=l.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-column"),w,v,y,x;b&&r.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",b);c&&r.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:name",c);t.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0",
+"table:number-columns-repeated",m);a&&t.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",a);r.appendChild(t);for(y=0;y<n;y+=1){t=l.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-row");for(x=0;x<m;x+=1)w=l.createElementNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:table-cell"),(v=e(y,x))&&w.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:table:1.0","table:style-name",v),v=l.createElementNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0",
+"text:p"),w.appendChild(v),t.appendChild(w);r.appendChild(t)}g=d.getParagraphElement(g.textNode);q.insertBefore(r,g.nextSibling);d.getOdfCanvas().refreshSize();d.emit(ops.OdtDocument.signalTableAdded,{tableElement:r,memberId:h,timeStamp:f});d.getOdfCanvas().rerenderAnnotations();return!0}return!1};this.spec=function(){return{optype:"InsertTable",memberid:h,timestamp:f,position:p,initialRows:n,initialColumns:m,tableName:c,tableStyleName:b,tableColumnStyleName:a,tableCellStyleMatrix:d}}};
 // Input 51
 /*
 
@@ -1419,6 +1468,9 @@ ops.OpSetParagraphStyle=function(){var h=this,m,f,a,c;this.init=function(d){m=d.
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1439,14 +1491,11 @@ ops.OpSetParagraphStyle=function(){var h=this,m,f,a,c;this.init=function(d){m=d.
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("odf.Namespaces");
-ops.OpUpdateParagraphStyle=function(){function h(a,b){var c,d,e=b?b.split(","):[];for(c=0;c<e.length;c+=1)d=e[c].split(":"),a.removeAttributeNS(odf.Namespaces.resolvePrefix(d[0]),d[1])}function m(a,b,c,d){var e,f,g,k=d&&d.attributes?d.attributes.split(","):[];a&&(c||0<k.length)&&Object.keys(a).forEach(function(b){e=a[b];(c&&void 0!==c[b]||k&&-1!==k.indexOf(b))&&"object"!==typeof e&&delete a[b]});if(b&&b.attributes&&(c||0<k.length)){g=b.attributes.split(",");for(d=0;d<g.length;d+=1)if(f=g[d],c&&void 0!==
-c[f]||k&&-1!==k.indexOf(f))g.splice(d,1),d-=1;0<g.length?b.attributes=g.join(","):delete b.attributes}}function f(a){for(var b in a)if(a.hasOwnProperty(b))return!0;return!1}function a(a){for(var b in a)if(a.hasOwnProperty(b)&&("attributes"!==b||0<a.attributes.length))return!0;return!1}function c(b,c){var d=s?s[c]:null,e=n?n[c]:null;m(d,e,b.setProperties?b.setProperties[c]:null,b.removedProperties?b.removedProperties[c]:null);d&&!f(d)&&delete s[c];e&&!a(e)&&delete n[c]}function d(a){s&&["style:parent-style-name",
-"style:next-style-name"].forEach(function(b){s[b]===a&&delete s[b]})}var b=this,k,p,e,s,n,g=odf.Namespaces.stylens;this.init=function(a){k=a.memberid;p=a.timestamp;e=a.styleName;s=a.setProperties;n=a.removedProperties};this.transform=function(g,k){var h=g.spec(),x=[b];switch(h.optype){case "UpdateParagraphStyle":h.styleName!==e||k||(c(h,"style:paragraph-properties"),c(h,"style:text-properties"),m(s||null,n||null,h.setProperties||null,h.removedProperties||null),s&&f(s)||n&&a(n)||(x=[]));break;case "RemoveStyle":"paragraph"===
-h.styleFamily&&(h.styleName===e?x=[]:d(h.styleName))}return x};this.execute=function(a){var b=a.getFormatting(),c,d,f;return(c=""!==e?a.getParagraphStyleElement(e):b.getDefaultStyleElement("paragraph"))?(d=c.getElementsByTagNameNS(g,"paragraph-properties")[0],f=c.getElementsByTagNameNS(g,"text-properties")[0],s&&b.updateStyle(c,s),n&&(n["style:paragraph-properties"]&&(h(d,n["style:paragraph-properties"].attributes),0===d.attributes.length&&c.removeChild(d)),n["style:text-properties"]&&(h(f,n["style:text-properties"].attributes),
-0===f.attributes.length&&c.removeChild(f)),h(c,n.attributes)),a.getOdfCanvas().refreshCSS(),a.emit(ops.OdtDocument.signalParagraphStyleModified,e),a.getOdfCanvas().rerenderAnnotations(),!0):!1};this.spec=function(){return{optype:"UpdateParagraphStyle",memberid:k,timestamp:p,styleName:e,setProperties:s,removedProperties:n}}};
+ops.OpInsertText=function(){var e,h,f,n;this.init=function(m){e=m.memberid;h=m.timestamp;f=m.position;n=m.text};this.execute=function(m){var p,c,b,a=null,d=m.getDOM(),k,g=0,q,l;m.upgradeWhitespacesAtPosition(f);if(p=m.getPositionInTextNode(f,e)){c=p.textNode;a=c.nextSibling;b=c.parentNode;k=m.getParagraphElement(c);for(l=0;l<n.length;l+=1)if(" "===n[l]&&(0===l||l===n.length-1||" "===n[l-1])||"\t"===n[l])0===g?(p.offset!==c.length&&(a=c.splitText(p.offset)),0<l&&c.appendData(n.substring(0,l))):g<l&&
+(g=n.substring(g,l),b.insertBefore(d.createTextNode(g),a)),g=l+1,q=" "===n[l]?"text:s":"text:tab",q=d.createElementNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0",q),q.appendChild(d.createTextNode(n[l])),b.insertBefore(q,a);0===g?c.insertData(p.offset,n):g<n.length&&(p=n.substring(g),b.insertBefore(d.createTextNode(p),a));b=c.parentNode;a=c.nextSibling;b.removeChild(c);b.insertBefore(c,a);0===c.length&&c.parentNode.removeChild(c);0<f&&(1<f&&m.downgradeWhitespacesAtPosition(f-2),m.downgradeWhitespacesAtPosition(f-
+1));m.downgradeWhitespacesAtPosition(f);m.downgradeWhitespacesAtPosition(f+n.length-1);m.downgradeWhitespacesAtPosition(f+n.length);m.getOdfCanvas().refreshSize();m.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:k,memberId:e,timeStamp:h});m.getOdfCanvas().rerenderAnnotations();return!0}return!1};this.spec=function(){return{optype:"InsertText",memberid:e,timestamp:h,position:f,text:n}}};
 // Input 52
 /*
 
@@ -1460,6 +1509,9 @@ h.styleFamily&&(h.styleName===e?x=[]:d(h.styleName))}return x};this.execute=func
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1480,11 +1532,15 @@ h.styleFamily&&(h.styleName===e?x=[]:d(h.styleName))}return x};this.execute=func
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("odf.Namespaces");
-ops.OpAddStyle=function(){function h(a){k&&["style:parent-style-name","style:next-style-name"].forEach(function(b){k[b]===a&&delete k[b]})}var m=this,f,a,c,d,b,k,p=odf.Namespaces.stylens;this.init=function(e){f=e.memberid;a=e.timestamp;c=e.styleName;d=e.styleFamily;b="true"===e.isAutomaticStyle||!0===e.isAutomaticStyle;k=e.setProperties};this.transform=function(a,b){var c=a.spec();"RemoveStyle"===c.optype&&c.styleFamily===d&&h(c.styleName);return[m]};this.execute=function(a){var f=a.getOdfCanvas().odfContainer(),
-h=a.getFormatting(),g=a.getDOM().createElementNS(p,"style:style");if(!g)return!1;k&&h.updateStyle(g,k);g.setAttributeNS(p,"style:family",d);g.setAttributeNS(p,"style:name",c);b?f.rootElement.automaticStyles.appendChild(g):f.rootElement.styles.appendChild(g);a.getOdfCanvas().refreshCSS();b||a.emit(ops.OdtDocument.signalCommonStyleCreated,{name:c,family:d});return!0};this.spec=function(){return{optype:"AddStyle",memberid:f,timestamp:a,styleName:c,styleFamily:d,isAutomaticStyle:b,setProperties:k}}};
+runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.OdfUtils");runtime.loadClass("core.DomUtils");
+ops.OpRemoveText=function(){function e(a){function e(a){return d.hasOwnProperty(a.namespaceURI)||"br"===a.localName&&c.isLineBreak(a.parentNode)||a.nodeType===Node.TEXT_NODE&&d.hasOwnProperty(a.parentNode.namespaceURI)}function f(a){if(c.isCharacterElement(a))return!1;if(a.nodeType===Node.TEXT_NODE)return 0===a.textContent.length;for(a=a.firstChild;a;){if(d.hasOwnProperty(a.namespaceURI)||!f(a))return!1;a=a.nextSibling}return!0}function h(d){var m;d.nodeType===Node.TEXT_NODE?(m=d.parentNode,m.removeChild(d)):
+m=b.removeUnwantedNodes(d,e);return!c.isParagraph(m)&&m!==a&&f(m)?h(m):m}this.isEmpty=f;this.mergeChildrenIntoParent=h}function h(d){var c=d.getPositionFilter(),e,f,h,n,w=p,v=d.getDOM().createRange();d=d.getIteratorAtPosition(m);e=d.container();for(f=d.unfilteredDomOffset();w&&d.nextPosition();)h=d.container(),n=d.unfilteredDomOffset(),c.acceptPosition(d)===a&&(w-=1);v.setStart(e,f);v.setEnd(h,n);b.splitBoundaries(v);return v}var f,n,m,p,c,b,a=core.PositionFilter.FilterResult.FILTER_ACCEPT,d={};this.init=
+function(a){runtime.assert(0<=a.length,"OpRemoveText only supports positive lengths");f=a.memberid;n=a.timestamp;m=parseInt(a.position,10);p=parseInt(a.length,10);c=new odf.OdfUtils;b=new core.DomUtils;d[odf.Namespaces.dbns]=!0;d[odf.Namespaces.dcns]=!0;d[odf.Namespaces.dr3dns]=!0;d[odf.Namespaces.drawns]=!0;d[odf.Namespaces.chartns]=!0;d[odf.Namespaces.formns]=!0;d[odf.Namespaces.numberns]=!0;d[odf.Namespaces.officens]=!0;d[odf.Namespaces.presentationns]=!0;d[odf.Namespaces.stylens]=!0;d[odf.Namespaces.svgns]=
+!0;d[odf.Namespaces.tablens]=!0;d[odf.Namespaces.textns]=!0};this.execute=function(a){var b,d,l,r,t=a.getCursor(f),w=new e(a.getRootNode());a.upgradeWhitespacesAtPosition(m);a.upgradeWhitespacesAtPosition(m+p);d=h(a);b=a.getParagraphElement(d.startContainer);l=c.getTextElements(d,!1,!0);r=c.getParagraphElements(d);d.detach();l.forEach(function(a){w.mergeChildrenIntoParent(a)});d=r.reduce(function(a,b){var d,c=!1,e=a,f=b,g,h=null;w.isEmpty(a)&&(c=!0,b.parentNode!==a.parentNode&&(g=b.parentNode,a.parentNode.insertBefore(b,
+a.nextSibling)),f=a,e=b,h=e.getElementsByTagNameNS("urn:webodf:names:editinfo","editinfo")[0]||e.firstChild);for(;f.hasChildNodes();)d=c?f.lastChild:f.firstChild,f.removeChild(d),"editinfo"!==d.localName&&e.insertBefore(d,h);g&&w.isEmpty(g)&&w.mergeChildrenIntoParent(g);w.mergeChildrenIntoParent(f);return e});a.downgradeWhitespacesAtPosition(m);a.fixCursorPositions();a.getOdfCanvas().refreshSize();a.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:d||b,memberId:f,timeStamp:n});t&&(t.resetSelectionType(),
+a.emit(ops.OdtDocument.signalCursorMoved,t));a.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"RemoveText",memberid:f,timestamp:n,position:m,length:p}}};
 // Input 53
 /*
 
@@ -1498,6 +1554,9 @@ h=a.getFormatting(),g=a.getDOM().createElementNS(p,"style:style");if(!g)return!1
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1518,11 +1577,11 @@ h=a.getFormatting(),g=a.getDOM().createElementNS(p,"style:style");if(!g)return!1
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpRemoveStyle=function(){function h(a){var d=[];a&&["style:parent-style-name","style:next-style-name"].forEach(function(f){a[f]===c&&d.push(f)});return d}var m=this,f,a,c,d;this.init=function(b){f=b.memberid;a=b.timestamp;c=b.styleName;d=b.styleFamily};this.transform=function(b,k){var p=b.spec(),e,s;e=[m];switch(p.optype){case "RemoveStyle":p.styleName===c&&p.styleFamily===d&&(e=[]);break;case "UpdateParagraphStyle":"paragraph"===d&&(s=h(p.setProperties),0<s.length&&(e=new ops.OpUpdateParagraphStyle,
-e.init({memberid:f,timestamp:a,styleName:p.styleName,removedProperties:{attributes:s.join(",")}}),e=[e,m]));break;case "AddStyle":p.styleFamily===d&&(s=h(p.setProperties),0<s.length&&(e=new ops.OpUpdateParagraphStyle,e.init({memberid:f,timestamp:a,styleName:p.styleName,removedProperties:{attributes:s.join(",")}}),e=[e,m]));break;case "SetParagraphStyle":"paragraph"===d&&p.styleName===c&&(p.styleName="",e=new ops.OpSetParagraphStyle,e.init(p),e=[e,m])}return e};this.execute=function(a){var f=a.getStyleElement(c,
-d);if(!f)return!1;f.parentNode.removeChild(f);a.getOdfCanvas().refreshCSS();a.emit(ops.OdtDocument.signalCommonStyleDeleted,{name:c,family:d});return!0};this.spec=function(){return{optype:"RemoveStyle",memberid:f,timestamp:a,styleName:c,styleFamily:d}}};
+ops.OpSplitParagraph=function(){var e,h,f,n;this.init=function(m){e=m.memberid;h=m.timestamp;f=m.position;n=new odf.OdfUtils};this.execute=function(m){var p,c,b,a,d,k,g;m.upgradeWhitespacesAtPosition(f);p=m.getPositionInTextNode(f,e);if(!p)return!1;c=m.getParagraphElement(p.textNode);if(!c)return!1;b=n.isListItem(c.parentNode)?c.parentNode:c;0===p.offset?(g=p.textNode.previousSibling,k=null):(g=p.textNode,k=p.offset>=p.textNode.length?null:p.textNode.splitText(p.offset));for(a=p.textNode;a!==b;)if(a=
+a.parentNode,d=a.cloneNode(!1),g){for(k&&d.appendChild(k);g.nextSibling;)d.appendChild(g.nextSibling);a.parentNode.insertBefore(d,a.nextSibling);g=a;k=d}else a.parentNode.insertBefore(d,a),g=d,k=a;n.isListItem(k)&&(k=k.childNodes[0]);0===p.textNode.length&&p.textNode.parentNode.removeChild(p.textNode);m.fixCursorPositions();m.getOdfCanvas().refreshSize();m.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:c,memberId:e,timeStamp:h});m.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:k,
+memberId:e,timeStamp:h});m.getOdfCanvas().rerenderAnnotations();return!0};this.spec=function(){return{optype:"SplitParagraph",memberid:e,timestamp:h,position:f}}};
 // Input 54
 /*
 
@@ -1536,6 +1595,9 @@ d);if(!f)return!1;f.parentNode.removeChild(f);a.getOdfCanvas().refreshCSS();a.em
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1556,13 +1618,10 @@ d);if(!f)return!1;f.parentNode.removeChild(f);a.getOdfCanvas().refreshCSS();a.em
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OpAddAnnotation=function(){function h(a,b,c){var d=a.getPositionInTextNode(c,f);d&&(a=d.textNode,c=a.parentNode,d.offset!==a.length&&a.splitText(d.offset),c.insertBefore(b,a.nextSibling),0===a.length&&c.removeChild(a))}var m=this,f,a,c,d,b;this.init=function(k){f=k.memberid;a=parseInt(k.timestamp,10);c=parseInt(k.position,10);d=parseInt(k.length,10)||0;b=k.name};this.transform=function(a,b){var e=a.spec(),f=c+d,h=[m];switch(e.optype){case "AddAnnotation":e.position<c?c+=1:e.position!==c||b||(c+=
-1,h=null);break;case "InsertText":e.position<=c?c+=e.text.length:e.position<=f&&(d+=e.text.length);break;case "SplitParagraph":e.position<=c?c+=1:e.position<=f&&(d+=1);break;case "InsertTable":h=null;break;case "RemoveText":e.position+e.length<=c?c-=e.length:e.position<c&&(c=e.position)}return h};this.execute=function(k){var m={},e=k.getPositionFilter(),s=k.getCursor(f),n=k.getCursorPosition(f),n=c-n-1,g=new Date(a),l,u,q,x,r;r=k.getDOM();l=r.createElementNS(odf.Namespaces.officens,"office:annotation");
-l.setAttributeNS(odf.Namespaces.officens,"office:name",b);u=r.createElementNS(odf.Namespaces.dcns,"dc:creator");u.setAttributeNS(odf.Namespaces.webodfns+":names:editinfo","editinfo:memberid",f);q=r.createElementNS(odf.Namespaces.dcns,"dc:date");q.appendChild(r.createTextNode(g.toISOString()));g=r.createElementNS(odf.Namespaces.textns,"text:list");x=r.createElementNS(odf.Namespaces.textns,"text:list-item");r=r.createElementNS(odf.Namespaces.textns,"text:p");x.appendChild(r);g.appendChild(x);l.appendChild(u);
-l.appendChild(q);l.appendChild(g);m.node=l;if(!m.node)return!1;if(d){l=k.getDOM().createElementNS(odf.Namespaces.officens,"office:annotation-end");l.setAttributeNS(odf.Namespaces.officens,"office:name",b);m.end=l;if(!m.end)return!1;h(k,m.end,c+d)}h(k,m.node,c);s&&(l=s.getStepCounter(),e=0<n?l.countForwardSteps(n,e):0>n?-l.countBackwardSteps(-n,e):0,s.move(e),k.emit(ops.OdtDocument.signalCursorMoved,s));k.getOdfCanvas().addAnnotation(m);return!0};this.spec=function(){return{optype:"AddAnnotation",
-memberid:f,timestamp:a,position:c,length:d,name:b}}};
+ops.OpSetParagraphStyle=function(){var e,h,f,n;this.init=function(m){e=m.memberid;h=m.timestamp;f=m.position;n=m.styleName};this.execute=function(m){var p;p=m.getIteratorAtPosition(f);return(p=m.getParagraphElement(p.container()))?(""!==n?p.setAttributeNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0","text:style-name",n):p.removeAttributeNS("urn:oasis:names:tc:opendocument:xmlns:text:1.0","style-name"),m.getOdfCanvas().refreshSize(),m.emit(ops.OdtDocument.signalParagraphChanged,{paragraphElement:p,
+timeStamp:h,memberId:e}),m.getOdfCanvas().rerenderAnnotations(),!0):!1};this.spec=function(){return{optype:"SetParagraphStyle",memberid:e,timestamp:h,position:f,styleName:n}}};
 // Input 55
 /*
 
@@ -1576,6 +1635,9 @@ memberid:f,timestamp:a,position:c,length:d,name:b}}};
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1596,12 +1658,12 @@ memberid:f,timestamp:a,position:c,length:d,name:b}}};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("odf.Namespaces");runtime.loadClass("core.DomUtils");
-ops.OpRemoveAnnotation=function(){var h,m,f,a,c;this.init=function(d){h=d.memberid;m=d.timestamp;f=parseInt(d.position,10);a=parseInt(d.length,10);c=new core.DomUtils};this.transform=function(a,b){return null};this.execute=function(a){for(var b=a.getIteratorAtPosition(f).container(),k,h=null,e=null;b.namespaceURI!==odf.Namespaces.officens||"annotation"!==b.localName;)b=b.parentNode;if(null===b)return!1;h=b;(k=h.getAttributeNS(odf.Namespaces.officens,"name"))&&(e=c.getElementsByTagNameNS(a.getRootNode(),
-odf.Namespaces.officens,"annotation-end").filter(function(a){return k===a.getAttributeNS(odf.Namespaces.officens,"name")})[0]||null);a.getOdfCanvas().forgetAnnotations();for(b=c.getElementsByTagNameNS(h,odf.Namespaces.webodfns+":names:cursor","cursor");b.length;)h.parentNode.insertBefore(b.pop(),h);h.parentNode.removeChild(h);e&&e.parentNode.removeChild(e);a.fixCursorPositions();a.getOdfCanvas().refreshAnnotations();return!0};this.spec=function(){return{optype:"RemoveAnnotation",memberid:h,timestamp:m,
-position:f,length:a}}};
+runtime.loadClass("odf.Namespaces");
+ops.OpUpdateParagraphStyle=function(){function e(b,a){var d,c,e=a?a.split(","):[];for(d=0;d<e.length;d+=1)c=e[d].split(":"),b.removeAttributeNS(odf.Namespaces.resolvePrefix(c[0]),c[1])}var h,f,n,m,p,c=odf.Namespaces.stylens;this.init=function(b){h=b.memberid;f=b.timestamp;n=b.styleName;m=b.setProperties;p=b.removedProperties};this.execute=function(b){var a=b.getFormatting(),d,f,g;return(d=""!==n?b.getParagraphStyleElement(n):a.getDefaultStyleElement("paragraph"))?(f=d.getElementsByTagNameNS(c,"paragraph-properties")[0],
+g=d.getElementsByTagNameNS(c,"text-properties")[0],m&&a.updateStyle(d,m),p&&(p["style:paragraph-properties"]&&(e(f,p["style:paragraph-properties"].attributes),0===f.attributes.length&&d.removeChild(f)),p["style:text-properties"]&&(e(g,p["style:text-properties"].attributes),0===g.attributes.length&&d.removeChild(g)),e(d,p.attributes)),b.getOdfCanvas().refreshCSS(),b.emit(ops.OdtDocument.signalParagraphStyleModified,n),b.getOdfCanvas().rerenderAnnotations(),!0):!1};this.spec=function(){return{optype:"UpdateParagraphStyle",
+memberid:h,timestamp:f,styleName:n,setProperties:m,removedProperties:p}}};
 // Input 56
 /*
 
@@ -1615,6 +1677,9 @@ position:f,length:a}}};
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1635,29 +1700,15 @@ position:f,length:a}}};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("ops.OpAddCursor");runtime.loadClass("ops.OpApplyDirectStyling");runtime.loadClass("ops.OpRemoveCursor");runtime.loadClass("ops.OpMoveCursor");runtime.loadClass("ops.OpInsertTable");runtime.loadClass("ops.OpInsertText");runtime.loadClass("ops.OpRemoveText");runtime.loadClass("ops.OpSplitParagraph");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("ops.OpUpdateParagraphStyle");runtime.loadClass("ops.OpAddStyle");runtime.loadClass("ops.OpRemoveStyle");runtime.loadClass("ops.OpAddAnnotation");
-runtime.loadClass("ops.OpRemoveAnnotation");
-ops.OperationFactory=function(){function h(f){return function(){return new f}}var m;this.register=function(f,a){m[f]=a};this.create=function(f){var a=null,c=m[f.optype];c&&(a=c(f),a.init(f));return a};m={AddCursor:h(ops.OpAddCursor),ApplyDirectStyling:h(ops.OpApplyDirectStyling),InsertTable:h(ops.OpInsertTable),InsertText:h(ops.OpInsertText),RemoveText:h(ops.OpRemoveText),SplitParagraph:h(ops.OpSplitParagraph),SetParagraphStyle:h(ops.OpSetParagraphStyle),UpdateParagraphStyle:h(ops.OpUpdateParagraphStyle),
-AddStyle:h(ops.OpAddStyle),RemoveStyle:h(ops.OpRemoveStyle),MoveCursor:h(ops.OpMoveCursor),RemoveCursor:h(ops.OpRemoveCursor),AddAnnotation:h(ops.OpAddAnnotation),RemoveAnnotation:h(ops.OpRemoveAnnotation)}};
+runtime.loadClass("odf.Namespaces");
+ops.OpAddStyle=function(){var e,h,f,n,m,p,c=odf.Namespaces.stylens;this.init=function(b){e=b.memberid;h=b.timestamp;f=b.styleName;n=b.styleFamily;m="true"===b.isAutomaticStyle||!0===b.isAutomaticStyle;p=b.setProperties};this.execute=function(b){var a=b.getOdfCanvas().odfContainer(),d=b.getFormatting(),e=b.getDOM().createElementNS(c,"style:style");if(!e)return!1;p&&d.updateStyle(e,p);e.setAttributeNS(c,"style:family",n);e.setAttributeNS(c,"style:name",f);m?a.rootElement.automaticStyles.appendChild(e):a.rootElement.styles.appendChild(e);
+b.getOdfCanvas().refreshCSS();m||b.emit(ops.OdtDocument.signalCommonStyleCreated,{name:f,family:n});return!0};this.spec=function(){return{optype:"AddStyle",memberid:e,timestamp:h,styleName:f,styleFamily:n,isAutomaticStyle:m,setProperties:p}}};
 // Input 57
-runtime.loadClass("core.Cursor");runtime.loadClass("core.DomUtils");runtime.loadClass("core.PositionIterator");runtime.loadClass("core.PositionFilter");runtime.loadClass("core.LoopWatchDog");runtime.loadClass("odf.OdfUtils");
-gui.SelectionMover=function(h,m){function f(){r.setUnfilteredPosition(h.getNode(),0);return r}function a(a,b){var c,d=null;a&&(c=b?a[a.length-1]:a[0]);c&&(d={top:c.top,left:b?c.right:c.left,bottom:c.bottom});return d}function c(b,d,e,f){var g=b.nodeType;e.setStart(b,d);e.collapse(!f);f=a(e.getClientRects(),!0===f);!f&&0<d&&(e.setStart(b,d-1),e.setEnd(b,d),f=a(e.getClientRects(),!0));f||(g===Node.ELEMENT_NODE&&b.childNodes[d-1]?f=c(b,d-1,e,!0):b.nodeType===Node.TEXT_NODE&&0<d?f=c(b,d-1,e,!0):b.previousSibling?
-f=c(b.previousSibling,b.previousSibling.nodeType===Node.TEXT_NODE?b.previousSibling.textContent.length:b.previousSibling.childNodes.length,e,!0):b.parentNode&&b.parentNode!==m?f=c(b.parentNode,0,e,!1):(e.selectNode(m),f=a(e.getClientRects(),!1)));runtime.assert(Boolean(f),"No visible rectangle found");return f}function d(a,b,d){var e=a,g=f(),k,l=m.ownerDocument.createRange(),q=h.getSelectedRange()?h.getSelectedRange().cloneRange():m.ownerDocument.createRange(),r,n=runtime.getWindow();for(k=c(g.container(),
-g.unfilteredDomOffset(),l);0<e&&d();)e-=1;b?(b=g.container(),g=g.unfilteredDomOffset(),-1===q.comparePoint(b,g)?(q.setStart(b,g),r=!1):q.setEnd(b,g)):(q.setStart(g.container(),g.unfilteredDomOffset()),q.collapse(!0));h.setSelectedRange(q,r);g=f();q=c(g.container(),g.unfilteredDomOffset(),l);if(q.top===k.top||void 0===y)y=q.left;n.clearTimeout(t);t=n.setTimeout(function(){y=void 0},2E3);l.detach();return a-e}function b(a){var b=f();return a.acceptPosition(b)===w?!0:!1}function k(a,b){for(var c=f(),
-d=new core.LoopWatchDog(1E3),e=0,g=0;0<a&&c.nextPosition();)e+=1,d.check(),b.acceptPosition(c)===w&&(g+=e,e=0,a-=1);return g}function p(a,b,c){for(var d=f(),e=new core.LoopWatchDog(1E3),g=0,k=0;0<a&&d.nextPosition();)e.check(),c.acceptPosition(d)===w&&(g+=1,b.acceptPosition(d)===w&&(k+=g,g=0,a-=1));return k}function e(a,b,c){for(var d=f(),e=new core.LoopWatchDog(1E3),g=0,k=0;0<a&&d.previousPosition();)e.check(),c.acceptPosition(d)===w&&(g+=1,b.acceptPosition(d)===w&&(k+=g,g=0,a-=1));return k}function s(a,
-b){for(var c=f(),d=new core.LoopWatchDog(1E3),e=0,g=0;0<a&&c.previousPosition();)e+=1,d.check(),b.acceptPosition(c)===w&&(g+=e,e=0,a-=1);return g}function n(a){var b=f(),c=q.getParagraphElement(b.getCurrentNode()),d;d=-s(1,a);if(0===d||c&&c!==q.getParagraphElement(b.getCurrentNode()))d=k(1,a);return d}function g(a,b){var d=f(),e=0,g=0,k=0>a?-1:1;for(a=Math.abs(a);0<a;){for(var h=b,l=k,q=d,r=q.container(),n=0,x=null,p=void 0,s=10,t=void 0,u=0,R=void 0,F=void 0,G=void 0,t=void 0,D=m.ownerDocument.createRange(),
-T=new core.LoopWatchDog(1E3),t=c(r,q.unfilteredDomOffset(),D),R=t.top,F=void 0===y?t.left:y,G=R;!0===(0>l?q.previousPosition():q.nextPosition());)if(T.check(),h.acceptPosition(q)===w&&(n+=1,r=q.container(),t=c(r,q.unfilteredDomOffset(),D),t.top!==R)){if(t.top!==G&&G!==R)break;G=t.top;t=Math.abs(F-t.left);if(null===x||t<s)x=r,p=q.unfilteredDomOffset(),s=t,u=n}null!==x?(q.setUnfilteredPosition(x,p),n=u):n=0;D.detach();e+=n;if(0===e)break;g+=e;a-=1}return g*k}function l(a,b){var d,e,g,k,h=f(),l=q.getParagraphElement(h.getCurrentNode()),
-r=0,n=m.ownerDocument.createRange();0>a?(d=h.previousPosition,e=-1):(d=h.nextPosition,e=1);for(g=c(h.container(),h.unfilteredDomOffset(),n);d.call(h);)if(b.acceptPosition(h)===w){if(q.getParagraphElement(h.getCurrentNode())!==l)break;k=c(h.container(),h.unfilteredDomOffset(),n);if(k.bottom!==g.bottom&&(g=k.top>=g.top&&k.bottom<g.bottom||k.top<=g.top&&k.bottom>g.bottom,!g))break;r+=e;g=k}n.detach();return r}function u(a,b,c){runtime.assert(null!==a,"SelectionMover.countStepsToPosition called with element===null");
-var d=f(),e=d.container(),g=d.unfilteredDomOffset(),k=0,h=new core.LoopWatchDog(1E3);d.setUnfilteredPosition(a,b);a=d.container();runtime.assert(Boolean(a),"SelectionMover.countStepsToPosition: positionIterator.container() returned null");b=d.unfilteredDomOffset();d.setUnfilteredPosition(e,g);e=x.comparePoints(a,b,d.container(),d.unfilteredDomOffset());if(0>e)for(;d.nextPosition()&&(h.check(),c.acceptPosition(d)===w&&(k+=1),d.container()!==a||d.unfilteredDomOffset()!==b););else if(0<e)for(;d.previousPosition()&&
-!(h.check(),c.acceptPosition(d)===w&&(k-=1,0>=x.comparePoints(a,b,d.container(),d.unfilteredDomOffset()))););return k}var q,x,r,y,t,w=core.PositionFilter.FilterResult.FILTER_ACCEPT;this.movePointForward=function(a,b){return d(a,b,r.nextPosition)};this.movePointBackward=function(a,b){return d(a,b,r.previousPosition)};this.getStepCounter=function(){return{countForwardSteps:k,countBackwardSteps:s,convertForwardStepsBetweenFilters:p,convertBackwardStepsBetweenFilters:e,countLinesSteps:g,countStepsToLineBoundary:l,
-countStepsToPosition:u,isPositionWalkable:b,countStepsToValidPosition:n}};(function(){q=new odf.OdfUtils;x=new core.DomUtils;r=gui.SelectionMover.createPositionIterator(m);var a=m.ownerDocument.createRange();a.setStart(r.container(),r.unfilteredDomOffset());a.collapse(!0);h.setSelectedRange(a)})()};
-gui.SelectionMover.createPositionIterator=function(h){var m=new function(){this.acceptNode=function(f){return"urn:webodf:names:cursor"===f.namespaceURI||"urn:webodf:names:editinfo"===f.namespaceURI?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}};return new core.PositionIterator(h,5,m,!1)};(function(){return gui.SelectionMover})();
-// Input 58
 /*
 
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -1667,6 +1718,9 @@ gui.SelectionMover.createPositionIterator=function(h){var m=new function(){this.
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -1687,16 +1741,257 @@ gui.SelectionMover.createPositionIterator=function(h){var m=new function(){this.
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("ops.OpAddCursor");runtime.loadClass("ops.OpRemoveCursor");runtime.loadClass("ops.OpMoveCursor");runtime.loadClass("ops.OpInsertTable");runtime.loadClass("ops.OpInsertText");runtime.loadClass("ops.OpRemoveText");runtime.loadClass("ops.OpSplitParagraph");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("ops.OpAddStyle");runtime.loadClass("ops.OpUpdateParagraphStyle");runtime.loadClass("ops.OpRemoveStyle");
-ops.OperationTransformer=function(){function h(f,a){for(var c,d,b,k=[],p=[];0<f.length&&a;){c=f.shift();d=a;var e=void 0;b=e=void 0;runtime.log("Crosstransforming:");runtime.log(runtime.toJson(c.spec()));runtime.log(runtime.toJson(d.spec()));e=m.create(d.spec());b=d.transform(c,!0);d=(e=c.transform(e,!1))&&b?{opsA:e,opsB:b}:null;if(!d)return null;k=k.concat(d.opsA);if(0===d.opsB.length){k=k.concat(f);a=null;break}if(1<d.opsB.length)for(c=0;c<d.opsB.length-1;c+=1){b=h(f,d.opsB[c]);if(!b)return null;
-p=p.concat(b.opsB);f=b.opsA}a=d.opsB.pop()}a&&p.push(a);return{opsA:k,opsB:p}}var m;this.setOperationFactory=function(f){m=f};this.transform=function(f,a){var c,d=[],b,k=[];for(c=0;c<f.length;c+=1){b=m.create(f[c]);if(!b)return null;d.push(b)}for(c=0;c<a.length;c+=1){b=m.create(a[c]);b=h(d,b);if(!b)return null;d=b.opsA;k=k.concat(b.opsB)}return{opsA:d,opsB:k}}};
+ops.OpRemoveStyle=function(){var e,h,f,n;this.init=function(m){e=m.memberid;h=m.timestamp;f=m.styleName;n=m.styleFamily};this.execute=function(e){var h=e.getStyleElement(f,n);if(!h)return!1;h.parentNode.removeChild(h);e.getOdfCanvas().refreshCSS();e.emit(ops.OdtDocument.signalCommonStyleDeleted,{name:f,family:n});return!0};this.spec=function(){return{optype:"RemoveStyle",memberid:e,timestamp:h,styleName:f,styleFamily:n}}};
+// Input 58
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.OpAddAnnotation=function(){function e(c,b,a){var d=c.getPositionInTextNode(a,h);d&&(c=d.textNode,a=c.parentNode,d.offset!==c.length&&c.splitText(d.offset),a.insertBefore(b,c.nextSibling),0===c.length&&a.removeChild(c))}var h,f,n,m,p;this.init=function(c){h=c.memberid;f=parseInt(c.timestamp,10);n=parseInt(c.position,10);m=parseInt(c.length,10)||0;p=c.name};this.execute=function(c){var b={},a=c.getPositionFilter(),d=c.getCursor(h),k=c.getCursorPosition(h),k=n-k-1,g=new Date(f),q,l,r,t,w;w=c.getDOM();
+q=w.createElementNS(odf.Namespaces.officens,"office:annotation");q.setAttributeNS(odf.Namespaces.officens,"office:name",p);l=w.createElementNS(odf.Namespaces.dcns,"dc:creator");l.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",h);r=w.createElementNS(odf.Namespaces.dcns,"dc:date");r.appendChild(w.createTextNode(g.toISOString()));g=w.createElementNS(odf.Namespaces.textns,"text:list");t=w.createElementNS(odf.Namespaces.textns,"text:list-item");w=w.createElementNS(odf.Namespaces.textns,
+"text:p");t.appendChild(w);g.appendChild(t);q.appendChild(l);q.appendChild(r);q.appendChild(g);b.node=q;if(!b.node)return!1;if(m){q=c.getDOM().createElementNS(odf.Namespaces.officens,"office:annotation-end");q.setAttributeNS(odf.Namespaces.officens,"office:name",p);b.end=q;if(!b.end)return!1;e(c,b.end,n+m)}e(c,b.node,n);d&&(a=d.getStepCounter().countSteps(k,a),d.move(a),d.resetSelectionType(),c.emit(ops.OdtDocument.signalCursorMoved,d));c.getOdfCanvas().addAnnotation(b);c.fixCursorPositions();return!0};
+this.spec=function(){return{optype:"AddAnnotation",memberid:h,timestamp:f,position:n,length:m,name:p}}};
 // Input 59
-runtime.loadClass("core.Cursor");runtime.loadClass("gui.SelectionMover");
-ops.OdtCursor=function(h,m){var f=this,a,c;this.removeFromOdtDocument=function(){c.remove()};this.move=function(c,b){var k=0;0<c?k=a.movePointForward(c,b):0>=c&&(k=-a.movePointBackward(-c,b));f.handleUpdate();return k};this.handleUpdate=function(){};this.getStepCounter=function(){return a.getStepCounter()};this.getMemberId=function(){return h};this.getNode=function(){return c.getNode()};this.getAnchorNode=function(){return c.getAnchorNode()};this.getSelectedRange=function(){return c.getSelectedRange()};
-this.getOdtDocument=function(){return m};c=new core.Cursor(m.getDOM(),h);a=new gui.SelectionMover(c,m.getRootNode())};
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("odf.Namespaces");runtime.loadClass("core.DomUtils");
+ops.OpRemoveAnnotation=function(){var e,h,f,n,m;this.init=function(p){e=p.memberid;h=p.timestamp;f=parseInt(p.position,10);n=parseInt(p.length,10);m=new core.DomUtils};this.execute=function(e){for(var c=e.getIteratorAtPosition(f).container(),b,a=null,d=null;c.namespaceURI!==odf.Namespaces.officens||"annotation"!==c.localName;)c=c.parentNode;if(null===c)return!1;a=c;(b=a.getAttributeNS(odf.Namespaces.officens,"name"))&&(d=m.getElementsByTagNameNS(e.getRootNode(),odf.Namespaces.officens,"annotation-end").filter(function(a){return b===
+a.getAttributeNS(odf.Namespaces.officens,"name")})[0]||null);e.getOdfCanvas().forgetAnnotations();for(c=m.getElementsByTagNameNS(a,"urn:webodf:names:cursor","cursor");c.length;)a.parentNode.insertBefore(c.pop(),a);a.parentNode.removeChild(a);d&&d.parentNode.removeChild(d);e.fixCursorPositions();e.getOdfCanvas().refreshAnnotations();return!0};this.spec=function(){return{optype:"RemoveAnnotation",memberid:e,timestamp:h,position:f,length:n}}};
 // Input 60
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("ops.OpAddCursor");runtime.loadClass("ops.OpApplyDirectStyling");runtime.loadClass("ops.OpRemoveCursor");runtime.loadClass("ops.OpMoveCursor");runtime.loadClass("ops.OpSetBlob");runtime.loadClass("ops.OpRemoveBlob");runtime.loadClass("ops.OpInsertImage");runtime.loadClass("ops.OpInsertTable");runtime.loadClass("ops.OpInsertText");runtime.loadClass("ops.OpRemoveText");runtime.loadClass("ops.OpSplitParagraph");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("ops.OpUpdateParagraphStyle");
+runtime.loadClass("ops.OpAddStyle");runtime.loadClass("ops.OpRemoveStyle");runtime.loadClass("ops.OpAddAnnotation");runtime.loadClass("ops.OpRemoveAnnotation");
+ops.OperationFactory=function(){function e(e){return function(){return new e}}var h;this.register=function(e,n){h[e]=n};this.create=function(e){var n=null,m=h[e.optype];m&&(n=m(e),n.init(e));return n};h={AddCursor:e(ops.OpAddCursor),ApplyDirectStyling:e(ops.OpApplyDirectStyling),SetBlob:e(ops.OpSetBlob),RemoveBlob:e(ops.OpRemoveBlob),InsertImage:e(ops.OpInsertImage),InsertTable:e(ops.OpInsertTable),InsertText:e(ops.OpInsertText),RemoveText:e(ops.OpRemoveText),SplitParagraph:e(ops.OpSplitParagraph),
+SetParagraphStyle:e(ops.OpSetParagraphStyle),UpdateParagraphStyle:e(ops.OpUpdateParagraphStyle),AddStyle:e(ops.OpAddStyle),RemoveStyle:e(ops.OpRemoveStyle),MoveCursor:e(ops.OpMoveCursor),RemoveCursor:e(ops.OpRemoveCursor),AddAnnotation:e(ops.OpAddAnnotation),RemoveAnnotation:e(ops.OpRemoveAnnotation)}};
+// Input 61
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("core.Cursor");runtime.loadClass("core.DomUtils");runtime.loadClass("core.PositionIterator");runtime.loadClass("core.PositionFilter");runtime.loadClass("core.LoopWatchDog");runtime.loadClass("odf.OdfUtils");
+gui.SelectionMover=function(e,h){function f(){v.setUnfilteredPosition(e.getNode(),0);return v}function n(a,b){var d,c=null;a&&(d=b?a[a.length-1]:a[0]);d&&(c={top:d.top,left:b?d.right:d.left,bottom:d.bottom});return c}function m(a,b,d,c){var e=a.nodeType;d.setStart(a,b);d.collapse(!c);c=n(d.getClientRects(),!0===c);!c&&0<b&&(d.setStart(a,b-1),d.setEnd(a,b),c=n(d.getClientRects(),!0));c||(e===Node.ELEMENT_NODE&&a.childNodes[b-1]?c=m(a,b-1,d,!0):a.nodeType===Node.TEXT_NODE&&0<b?c=m(a,b-1,d,!0):a.previousSibling?
+c=m(a.previousSibling,a.previousSibling.nodeType===Node.TEXT_NODE?a.previousSibling.textContent.length:a.previousSibling.childNodes.length,d,!0):a.parentNode&&a.parentNode!==h?c=m(a.parentNode,0,d,!1):(d.selectNode(h),c=n(d.getClientRects(),!1)));runtime.assert(Boolean(c),"No visible rectangle found");return c}function p(a,b,d){var c=a,g=f(),k,l=h.ownerDocument.createRange(),n=e.getSelectedRange()?e.getSelectedRange().cloneRange():h.ownerDocument.createRange(),p;for(k=m(g.container(),g.unfilteredDomOffset(),
+l);0<c&&d();)c-=1;b?(b=g.container(),g=g.unfilteredDomOffset(),-1===n.comparePoint(b,g)?(n.setStart(b,g),p=!1):n.setEnd(b,g)):(n.setStart(g.container(),g.unfilteredDomOffset()),n.collapse(!0));e.setSelectedRange(n,p);g=f();n=m(g.container(),g.unfilteredDomOffset(),l);if(n.top===k.top||void 0===y)y=n.left;runtime.clearTimeout(x);x=runtime.setTimeout(function(){y=void 0},2E3);l.detach();return a-c}function c(a){var b=f();return a.acceptPosition(b)===u&&(b.setUnfilteredPosition(e.getAnchorNode(),0),
+a.acceptPosition(b)===u)?!0:!1}function b(a,b,d){for(var c=new core.LoopWatchDog(1E3),e=0,f=0,g=0<=b?1:-1,h=0<=b?a.nextPosition:a.previousPosition;0!==b&&h();)c.check(),f+=g,d.acceptPosition(a)===u&&(b-=g,e+=f,f=0);return e}function a(a,b,d){for(var c=f(),e=new core.LoopWatchDog(1E3),g=0,h=0;0<a&&c.nextPosition();)e.check(),d.acceptPosition(c)===u&&(g+=1,b.acceptPosition(c)===u&&(h+=g,g=0,a-=1));return h}function d(a,b,d){for(var c=f(),e=new core.LoopWatchDog(1E3),g=0,h=0;0<a&&c.previousPosition();)e.check(),
+d.acceptPosition(c)===u&&(g+=1,b.acceptPosition(c)===u&&(h+=g,g=0,a-=1));return h}function k(a,d){var c=f();return b(c,a,d)}function g(a,d,c){var e=f(),g=t.getParagraphElement(e.getCurrentNode()),h=0;e.setUnfilteredPosition(a,d);c.acceptPosition(e)!==u&&(h=b(e,-1,c),0===h||g&&g!==t.getParagraphElement(e.getCurrentNode()))&&(e.setUnfilteredPosition(a,d),h=b(e,1,c));return h}function q(a,b){var d=f(),c=0,e=0,g=0>a?-1:1;for(a=Math.abs(a);0<a;){for(var k=b,l=g,n=d,p=n.container(),t=0,q=null,r=void 0,
+w=10,v=void 0,x=0,O=void 0,W=void 0,E=void 0,v=void 0,H=h.ownerDocument.createRange(),M=new core.LoopWatchDog(1E3),v=m(p,n.unfilteredDomOffset(),H),O=v.top,W=void 0===y?v.left:y,E=O;!0===(0>l?n.previousPosition():n.nextPosition());)if(M.check(),k.acceptPosition(n)===u&&(t+=1,p=n.container(),v=m(p,n.unfilteredDomOffset(),H),v.top!==O)){if(v.top!==E&&E!==O)break;E=v.top;v=Math.abs(W-v.left);if(null===q||v<w)q=p,r=n.unfilteredDomOffset(),w=v,x=t}null!==q?(n.setUnfilteredPosition(q,r),t=x):t=0;H.detach();
+c+=t;if(0===c)break;e+=c;a-=1}return e*g}function l(a,b){var d,c,e,g,k=f(),l=t.getParagraphElement(k.getCurrentNode()),n=0,p=h.ownerDocument.createRange();0>a?(d=k.previousPosition,c=-1):(d=k.nextPosition,c=1);for(e=m(k.container(),k.unfilteredDomOffset(),p);d.call(k);)if(b.acceptPosition(k)===u){if(t.getParagraphElement(k.getCurrentNode())!==l)break;g=m(k.container(),k.unfilteredDomOffset(),p);if(g.bottom!==e.bottom&&(e=g.top>=e.top&&g.bottom<e.bottom||g.top<=e.top&&g.bottom>e.bottom,!e))break;n+=
+c;e=g}p.detach();return n}function r(a,b,d){runtime.assert(null!==a,"SelectionMover.countStepsToPosition called with element===null");var c=f(),e=c.container(),g=c.unfilteredDomOffset(),h=0,k=new core.LoopWatchDog(1E3);for(c.setUnfilteredPosition(a,b);d.acceptPosition(c)!==u&&c.previousPosition();)k.check();a=c.container();runtime.assert(Boolean(a),"SelectionMover.countStepsToPosition: positionIterator.container() returned null");b=c.unfilteredDomOffset();for(c.setUnfilteredPosition(e,g);d.acceptPosition(c)!==
+u&&c.previousPosition();)k.check();e=w.comparePoints(a,b,c.container(),c.unfilteredDomOffset());if(0>e)for(;c.nextPosition()&&(k.check(),d.acceptPosition(c)===u&&(h+=1),c.container()!==a||c.unfilteredDomOffset()!==b););else if(0<e)for(;c.previousPosition()&&(k.check(),d.acceptPosition(c)!==u||(h-=1,c.container()!==a||c.unfilteredDomOffset()!==b)););return h}var t,w,v,y,x,u=core.PositionFilter.FilterResult.FILTER_ACCEPT;this.movePointForward=function(a,b){return p(a,b||!1,v.nextPosition)};this.movePointBackward=
+function(a,b){return p(a,b||!1,v.previousPosition)};this.getStepCounter=function(){return{countSteps:k,convertForwardStepsBetweenFilters:a,convertBackwardStepsBetweenFilters:d,countLinesSteps:q,countStepsToLineBoundary:l,countStepsToPosition:r,isPositionWalkable:c,countPositionsToNearestStep:g}};(function(){t=new odf.OdfUtils;w=new core.DomUtils;v=gui.SelectionMover.createPositionIterator(h);var a=h.ownerDocument.createRange();a.setStart(v.container(),v.unfilteredDomOffset());a.collapse(!0);e.setSelectedRange(a)})()};
+gui.SelectionMover.createPositionIterator=function(e){var h=new function(){this.acceptNode=function(e){return"urn:webodf:names:cursor"===e.namespaceURI||"urn:webodf:names:editinfo"===e.namespaceURI?NodeFilter.FILTER_REJECT:NodeFilter.FILTER_ACCEPT}};return new core.PositionIterator(e,5,h,!1)};(function(){return gui.SelectionMover})();
+// Input 62
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ This file is part of WebODF.
+
+ WebODF is free software: you can redistribute it and/or modify it
+ under the terms of the GNU Affero General Public License (GNU AGPL)
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ WebODF is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
+ @licend
+
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+ops.OperationTransformMatrix=function(){function e(a,b){return{opSpecsA:[a],opSpecsB:[b]}}function h(a,b){var c=[];a&&["style:parent-style-name","style:next-style-name"].forEach(function(e){a[e]===b&&c.push(e)});return c}function f(a,b){a&&["style:parent-style-name","style:next-style-name"].forEach(function(c){a[c]===b&&delete a[c]})}function n(a,b,c,e){var f,h,m,n=e&&e.attributes?e.attributes.split(","):[];a&&(c||0<n.length)&&Object.keys(a).forEach(function(b){f=a[b];(c&&void 0!==c[b]||n&&-1!==n.indexOf(b))&&
+"object"!==typeof f&&delete a[b]});if(b&&b.attributes&&(c||0<n.length)){m=b.attributes.split(",");for(e=0;e<m.length;e+=1)if(h=m[e],c&&void 0!==c[h]||n&&-1!==n.indexOf(h))m.splice(e,1),e-=1;0<m.length?b.attributes=m.join(","):delete b.attributes}}function m(a){for(var b in a)if(a.hasOwnProperty(b))return!0;return!1}function p(a){for(var b in a)if(a.hasOwnProperty(b)&&("attributes"!==b||0<a.attributes.length))return!0;return!1}function c(a,b,c){var e=a.setProperties?a.setProperties[c]:null,f=a.removedProperties?
+a.removedProperties[c]:null;n(e,f,b.setProperties?b.setProperties[c]:null,b.removedProperties?b.removedProperties[c]:null);e&&!m(e)&&delete a.setProperties[c];f&&!p(f)&&delete a.removedProperties[c]}var b={AddCursor:{AddCursor:e,AddStyle:e,InsertText:e,MoveCursor:e,RemoveCursor:e,RemoveStyle:e,RemoveText:e,SetParagraphStyle:e,SplitParagraph:e,UpdateParagraphStyle:e},AddStyle:{AddStyle:e,InsertText:e,MoveCursor:e,RemoveCursor:e,RemoveStyle:function(a,b){var c,e=[a],m=[b];a.styleFamily===b.styleFamily&&
+(c=h(a.setProperties,b.styleName),0<c.length&&(c={optype:"UpdateParagraphStyle",memberid:b.memberid,timestamp:b.timestamp,styleName:a.styleName,removedProperties:{attributes:c.join(",")}},m.unshift(c)),f(a.setProperties,b.styleName));return{opSpecsA:e,opSpecsB:m}},RemoveText:e,SetParagraphStyle:e,SplitParagraph:e,UpdateParagraphStyle:e},InsertText:{InsertText:function(a,b,c){if(a.position<b.position)b.position+=a.text.length;else if(a.position>b.position)a.position+=b.text.length;else return c?b.position+=
+a.text.length:a.position+=b.text.length,null;return{opSpecsA:[a],opSpecsB:[b]}},MoveCursor:function(a,b){a.position<b.position?b.position+=a.text.length:a.position<=b.position+b.length&&(b.length+=a.text.length);return{opSpecsA:[a],opSpecsB:[b]}},RemoveCursor:e,RemoveStyle:e,RemoveText:function(a,b){var c;c=b.position+b.length;var e=[a],f=[b];c<=a.position?a.position-=b.length:a.position<=b.position?b.position+=a.text.length:(b.length=a.position-b.position,c={optype:"RemoveText",memberid:b.memberid,
+timestamp:b.timestamp,position:a.position+a.text.length,length:c-a.position},f.unshift(c),a.position=b.position);return{opSpecsA:e,opSpecsB:f}},SplitParagraph:function(a,b,c){if(a.position<b.position)b.position+=a.text.length;else if(a.position>b.position)a.position+=1;else return c?b.position+=a.text.length:a.position+=1,null;return{opSpecsA:[a],opSpecsB:[b]}},UpdateParagraphStyle:e},MoveCursor:{MoveCursor:e,RemoveCursor:function(a,b){return{opSpecsA:a.memberid===b.memberid?[]:[a],opSpecsB:[b]}},
+RemoveStyle:e,RemoveText:function(a,b){var c=a.position+a.length,e=b.position+b.length;e<=a.position?a.position-=b.length:b.position<c&&(a.position<b.position?a.length=e<c?a.length-b.length:b.position-a.position:(a.position=b.position,a.length=e<c?c-e:0));return{opSpecsA:[a],opSpecsB:[b]}},SetParagraphStyle:e,SplitParagraph:function(a,b){b.position<a.position?a.position+=1:b.position<=a.position+a.length&&(a.length+=1);return{opSpecsA:[a],opSpecsB:[b]}},UpdateParagraphStyle:e},RemoveCursor:{RemoveCursor:function(a,
+b){var c=a.memberid===b.memberid;return{opSpecsA:c?[]:[a],opSpecsB:c?[]:[b]}},RemoveStyle:e,RemoveText:e,SetParagraphStyle:e,SplitParagraph:e,UpdateParagraphStyle:e},RemoveStyle:{RemoveStyle:function(a,b){var c=a.styleName===b.styleName&&a.styleFamily===b.styleFamily;return{opSpecsA:c?[]:[a],opSpecsB:c?[]:[b]}},RemoveText:e,SetParagraphStyle:function(a,b){var c,e=[a],f=[b];"paragraph"===a.styleFamily&&a.styleName===b.styleName&&(c={optype:"SetParagraphStyle",memberid:a.memberid,timestamp:a.timestamp,
+position:b.position,styleName:""},e.unshift(c),b.styleName="");return{opSpecsA:e,opSpecsB:f}},SplitParagraph:e,UpdateParagraphStyle:function(a,b){var c,e=[a],m=[b];"paragraph"===a.styleFamily&&(c=h(b.setProperties,a.styleName),0<c.length&&(c={optype:"UpdateParagraphStyle",memberid:a.memberid,timestamp:a.timestamp,styleName:b.styleName,removedProperties:{attributes:c.join(",")}},e.unshift(c)),a.styleName===b.styleName?m=[]:f(b.setProperties,a.styleName));return{opSpecsA:e,opSpecsB:m}}},RemoveText:{RemoveText:function(a,
+b){var c=a.position+a.length,e=b.position+b.length,f=[a],h=[b];e<=a.position?a.position-=b.length:c<=b.position?b.position-=a.length:b.position<c&&(a.position<b.position?(a.length=e<c?a.length-b.length:b.position-a.position,c<e?(b.position=a.position,b.length=e-c):h=[]):(c<e?b.length-=a.length:b.position<a.position?b.length=a.position-b.position:h=[],e<c?(a.position=b.position,a.length=c-e):f=[]));return{opSpecsA:f,opSpecsB:h}},SplitParagraph:function(a,b){var c=a.position+a.length,e=[a],f=[b];b.position<=
+a.position?a.position+=1:b.position<c&&(a.length=b.position-a.position,c={optype:"RemoveText",memberid:a.memberid,timestamp:a.timestamp,position:b.position+1,length:c-b.position},e.unshift(c));a.position+a.length<=b.position?b.position-=a.length:a.position<b.position&&(b.position=a.position);return{opSpecsA:e,opSpecsB:f}},UpdateParagraphStyle:e},SetParagraphStyle:{UpdateParagraphStyle:e},SplitParagraph:{SplitParagraph:function(a,b,c){if(a.position<b.position)b.position+=1;else if(a.position>b.position)a.position+=
+1;else if(a.position===b.position)return c?b.position+=1:a.position+=1,null;return{opSpecsA:[a],opSpecsB:[b]}},UpdateParagraphStyle:e},UpdateParagraphStyle:{UpdateParagraphStyle:function(a,b,e){var f,h=[a],l=[b];a.styleName===b.styleName&&(f=e?a:b,a=e?b:a,c(a,f,"style:paragraph-properties"),c(a,f,"style:text-properties"),n(a.setProperties||null,a.removedProperties||null,f.setProperties||null,f.removedProperties||null),a.setProperties&&m(a.setProperties)||a.removedProperties&&p(a.removedProperties)||
+(e?l=[]:h=[]));return{opSpecsA:h,opSpecsB:l}}}};this.passUnchanged=e;this.extendTransformations=function(a){Object.keys(a).forEach(function(c){var e=a[c],f,h=b.hasOwnProperty(c);runtime.log((h?"Extending":"Adding")+" map for optypeA: "+c);h||(b[c]={});f=b[c];Object.keys(e).forEach(function(a){var b=f.hasOwnProperty(a);runtime.assert(c<=a,"Wrong order:"+c+", "+a);runtime.log("  "+(b?"Overwriting":"Adding")+" entry for optypeB: "+a);f[a]=e[a]})})};this.transformOpspecVsOpspec=function(a,c){var e=a.optype<=
+c.optype,f;runtime.log("Crosstransforming:");runtime.log(runtime.toJson(a));runtime.log(runtime.toJson(c));e||(f=a,a=c,c=f);(f=(f=b[a.optype])&&f[c.optype])?(f=f(a,c,!e),e||null===f||(f={opSpecsA:f.opSpecsB,opSpecsB:f.opSpecsA})):f=null;runtime.log("result:");f?(runtime.log(runtime.toJson(f.opSpecsA)),runtime.log(runtime.toJson(f.opSpecsB))):runtime.log("null");return f}};
+// Input 63
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ This file is part of WebODF.
+
+ WebODF is free software: you can redistribute it and/or modify it
+ under the terms of the GNU Affero General Public License (GNU AGPL)
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ WebODF is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with WebODF.  If not, see <http://www.gnu.org/licenses/>.
+ @licend
+
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("ops.OperationFactory");runtime.loadClass("ops.OperationTransformMatrix");
+ops.OperationTransformer=function(){function e(e){var h=[];e.forEach(function(c){h.push(f.create(c))});return h}function h(e,f){for(var c,b,a=[],d=[];0<e.length&&f;){c=e.shift();c=n.transformOpspecVsOpspec(c,f);if(!c)return null;a=a.concat(c.opSpecsA);if(0===c.opSpecsB.length){a=a.concat(e);f=null;break}for(;1<c.opSpecsB.length;){b=h(e,c.opSpecsB.shift());if(!b)return null;d=d.concat(b.opSpecsB);e=b.opSpecsA}f=c.opSpecsB.pop()}f&&d.push(f);return{opSpecsA:a,opSpecsB:d}}var f,n=new ops.OperationTransformMatrix;
+this.setOperationFactory=function(e){f=e};this.getOperationTransformMatrix=function(){return n};this.transform=function(f,n){for(var c,b=[];0<n.length;){c=h(f,n.shift());if(!c)return null;f=c.opSpecsA;b=b.concat(c.opSpecsB)}return{opsA:e(f),opsB:e(b)}}};
+// Input 64
+runtime.loadClass("core.Cursor");runtime.loadClass("gui.SelectionMover");
+ops.OdtCursor=function(e,h){var f=this,n={},m,p,c;this.removeFromOdtDocument=function(){c.remove()};this.move=function(b,a){var c=0;0<b?c=p.movePointForward(b,a):0>=b&&(c=-p.movePointBackward(-b,a));f.handleUpdate();return c};this.handleUpdate=function(){};this.getStepCounter=function(){return p.getStepCounter()};this.getMemberId=function(){return e};this.getNode=function(){return c.getNode()};this.getAnchorNode=function(){return c.getAnchorNode()};this.getSelectedRange=function(){return c.getSelectedRange()};
+this.setSelectedRange=function(b,a){c.setSelectedRange(b,a)};this.hasForwardSelection=function(){return c.hasForwardSelection()};this.getOdtDocument=function(){return h};this.getSelectionType=function(){return m};this.setSelectionType=function(b){n.hasOwnProperty(b)?m=b:runtime.log("Invalid selection type: "+b)};this.resetSelectionType=function(){f.setSelectionType(ops.OdtCursor.RangeSelection)};c=new core.Cursor(h.getDOM(),e);p=new gui.SelectionMover(c,h.getRootNode());n[ops.OdtCursor.RangeSelection]=
+!0;n[ops.OdtCursor.RegionSelection]=!0;f.resetSelectionType()};ops.OdtCursor.RangeSelection="Range";ops.OdtCursor.RegionSelection="Region";(function(){return ops.OdtCursor})();
+// Input 65
 /*
 
  Copyright (C) 2012 KO GmbH <aditya.bhatt@kogmbh.com>
@@ -1709,51 +2004,8 @@ this.getOdtDocument=function(){return m};c=new core.Cursor(m.getDOM(),h);a=new g
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-ops.EditInfo=function(h,m){function f(){var a=[],b;for(b in c)c.hasOwnProperty(b)&&a.push({memberid:b,time:c[b].time});a.sort(function(a,b){return a.time-b.time});return a}var a,c={};this.getNode=function(){return a};this.getOdtDocument=function(){return m};this.getEdits=function(){return c};this.getSortedEdits=function(){return f()};this.addEdit=function(a,b){c[a]={time:b}};this.clearEdits=function(){c={}};this.destroy=function(c){h.parentNode&&h.removeChild(a);c()};a=m.getDOM().createElementNS("urn:webodf:names:editinfo",
-"editinfo");h.insertBefore(a,h.firstChild)};
-// Input 61
-gui.Avatar=function(h,m){var f=this,a,c,d;this.setColor=function(a){c.style.borderColor=a};this.setImageUrl=function(a){f.isVisible()?c.src=a:d=a};this.isVisible=function(){return"block"===a.style.display};this.show=function(){d&&(c.src=d,d=void 0);a.style.display="block"};this.hide=function(){a.style.display="none"};this.markAsFocussed=function(b){a.className=b?"active":""};this.destroy=function(b){h.removeChild(a);b()};(function(){var b=h.ownerDocument,d=b.documentElement.namespaceURI;a=b.createElementNS(d,
-"div");c=b.createElementNS(d,"img");c.width=64;c.height=64;a.appendChild(c);a.style.width="64px";a.style.height="70px";a.style.position="absolute";a.style.top="-80px";a.style.left="-34px";a.style.display=m?"block":"none";h.appendChild(a)})()};
-// Input 62
-runtime.loadClass("gui.Avatar");runtime.loadClass("ops.OdtCursor");
-gui.Caret=function(h,m,f){function a(d){k&&b.parentNode&&(!p||d)&&(d&&void 0!==e&&runtime.clearTimeout(e),p=!0,c.style.opacity=d||"0"===c.style.opacity?"1":"0",e=runtime.setTimeout(function(){p=!1;a(!1)},500))}var c,d,b,k=!1,p=!1,e;this.refreshCursorBlinking=function(){f||h.getSelectedRange().collapsed?(k=!0,a(!0)):(k=!1,c.style.opacity="0")};this.setFocus=function(){k=!0;d.markAsFocussed(!0);a(!0)};this.removeFocus=function(){k=!1;d.markAsFocussed(!1);c.style.opacity="1"};this.show=function(){c.style.visibility=
-"visible";d.markAsFocussed(!0)};this.hide=function(){c.style.visibility="hidden";d.markAsFocussed(!1)};this.setAvatarImageUrl=function(a){d.setImageUrl(a)};this.setColor=function(a){c.style.borderColor=a;d.setColor(a)};this.getCursor=function(){return h};this.getFocusElement=function(){return c};this.toggleHandleVisibility=function(){d.isVisible()?d.hide():d.show()};this.showHandle=function(){d.show()};this.hideHandle=function(){d.hide()};this.ensureVisible=function(){var a,b,d,e,f=h.getOdtDocument().getOdfCanvas().getElement().parentNode,
-k;d=f.offsetWidth-f.clientWidth+5;e=f.offsetHeight-f.clientHeight+5;k=c.getBoundingClientRect();a=k.left-d;b=k.top-e;d=k.right+d;e=k.bottom+e;k=f.getBoundingClientRect();b<k.top?f.scrollTop-=k.top-b:e>k.bottom&&(f.scrollTop+=e-k.bottom);a<k.left?f.scrollLeft-=k.left-a:d>k.right&&(f.scrollLeft+=d-k.right)};this.destroy=function(a){d.destroy(function(d){d?a(d):(b.removeChild(c),a())})};(function(){var a=h.getOdtDocument().getDOM();c=a.createElementNS(a.documentElement.namespaceURI,"span");b=h.getNode();
-b.appendChild(c);d=new gui.Avatar(b,m)})()};
-// Input 63
-/*
-
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -1775,202 +2027,28 @@ b.appendChild(c);d=new gui.Avatar(b,m)})()};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-gui.KeyboardHandler=function(){function h(a,d){d||(d=m.None);return a+":"+d}var m=gui.KeyboardHandler.Modifier,f=null,a={};this.setDefault=function(a){f=a};this.bind=function(c,d,b){c=h(c,d);runtime.assert(!1===a.hasOwnProperty(c),"tried to overwrite the callback handler of key combo: "+c);a[c]=b};this.unbind=function(c,d){var b=h(c,d);delete a[b]};this.reset=function(){f=null;a={}};this.handleEvent=function(c){var d=c.keyCode,b=m.None;c.metaKey&&(b|=m.Meta);c.ctrlKey&&(b|=m.Ctrl);c.altKey&&(b|=m.Alt);
-c.shiftKey&&(b|=m.Shift);d=h(d,b);d=a[d];b=!1;d?b=d():null!==f&&(b=f(c));b&&(c.preventDefault?c.preventDefault():c.returnValue=!1)}};gui.KeyboardHandler.Modifier={None:0,Meta:1,Ctrl:2,Alt:4,Shift:8,MetaShift:9,CtrlShift:10,AltShift:12};gui.KeyboardHandler.KeyCode={Backspace:8,Tab:9,Clear:12,Enter:13,End:35,Home:36,Left:37,Up:38,Right:39,Down:40,Delete:46,A:65,B:66,C:67,D:68,E:69,F:70,G:71,H:72,I:73,J:74,K:75,L:76,M:77,N:78,O:79,P:80,Q:81,R:82,S:83,T:84,U:85,V:86,W:87,X:88,Y:89,Z:90};(function(){return gui.KeyboardHandler})();
-// Input 64
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-runtime.loadClass("odf.Namespaces");runtime.loadClass("xmldom.LSSerializer");runtime.loadClass("odf.OdfNodeFilter");runtime.loadClass("odf.TextSerializer");
-gui.Clipboard=function(){var h,m,f;this.setDataFromRange=function(a,c){var d=!0,b,f=a.clipboardData;b=runtime.getWindow();var p=c.startContainer.ownerDocument;!f&&b&&(f=b.clipboardData);f?(p=p.createElement("span"),p.appendChild(c.cloneContents()),b=f.setData("text/plain",m.writeToString(p)),d=d&&b,b=f.setData("text/html",h.writeToString(p,odf.Namespaces.namespaceMap)),d=d&&b,a.preventDefault()):d=!1;return d};h=new xmldom.LSSerializer;m=new odf.TextSerializer;f=new odf.OdfNodeFilter;h.filter=f;m.filter=
-f};
-// Input 65
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-runtime.loadClass("core.EventNotifier");runtime.loadClass("ops.OpApplyDirectStyling");runtime.loadClass("gui.StyleHelper");
-gui.DirectTextStyler=function(h,m){function f(a,b){for(var c=0,d=b[c];d&&a;)a=a[d],c+=1,d=b[c];return b.length===c?a:void 0}function a(a,b){var c=f(a[0],b);return a.every(function(a){return c===f(a,b)})?c:void 0}function c(){function b(a,c,d){a!==c&&(void 0===e&&(e={}),e[d]=c);return c}var c=x.getCursor(m),d=c&&c.getSelectedRange(),c=d&&r.getAppliedStyles(d),e;t=b(t,d?r.isBold(d):!1,"isBold");w=b(w,d?r.isItalic(d):!1,"isItalic");v=b(v,d?r.hasUnderline(d):!1,"hasUnderline");C=b(C,d?r.hasStrikeThrough(d):
-!1,"hasStrikeThrough");d=c&&a(c,["style:text-properties","fo:font-size"]);J=b(J,d&&parseFloat(d),"fontSize");E=b(E,c&&a(c,["style:text-properties","style:font-name"]),"fontName");e&&y.emit(gui.DirectTextStyler.textStylingChanged,e)}function d(a){a.getMemberId()===m&&c()}function b(a){a===m&&c()}function k(a){a.getMemberId()===m&&c()}function p(){c()}function e(a){var b=x.getCursor(m);b&&x.getParagraphElement(b.getNode())===a.paragraphElement&&c()}function s(a,b){var c=x.getCursor(m);if(!c)return!1;
-b(!a(c.getSelectedRange()));return!0}function n(a,b){var c=x.getCursorSelection(m),d=new ops.OpApplyDirectStyling,e={};e[a]=b;d.init({memberid:m,position:c.position,length:c.length,setProperties:{"style:text-properties":e}});h.enqueue(d)}function g(a){n("fo:font-weight",a?"bold":"normal")}function l(a){n("fo:font-style",a?"italic":"normal")}function u(a){n("style:text-underline-style",a?"solid":"none")}function q(a){n("style:text-line-through-style",a?"solid":"none")}var x=h.getOdtDocument(),r=new gui.StyleHelper(x.getFormatting()),
-y=new core.EventNotifier([gui.DirectTextStyler.textStylingChanged]),t=!1,w=!1,v=!1,C=!1,J,E;this.setBold=g;this.setItalic=l;this.setHasUnderline=u;this.setHasStrikethrough=q;this.setFontSize=function(a){n("fo:font-size",a+"pt")};this.setFontName=function(a){n("style:font-name",a)};this.toggleBold=s.bind(this,r.isBold,g);this.toggleItalic=s.bind(this,r.isItalic,l);this.toggleUnderline=s.bind(this,r.hasUnderline,u);this.toggleStrikethrough=s.bind(this,r.hasStrikeThrough,q);this.isBold=function(){return t};
-this.isItalic=function(){return w};this.hasUnderline=function(){return v};this.hasStrikeThrough=function(){return C};this.fontSize=function(){return J};this.fontName=function(){return E};this.subscribe=function(a,b){y.subscribe(a,b)};this.unsubscribe=function(a,b){y.unsubscribe(a,b)};this.destroy=function(a){x.unsubscribe(ops.OdtDocument.signalCursorAdded,d);x.unsubscribe(ops.OdtDocument.signalCursorRemoved,b);x.unsubscribe(ops.OdtDocument.signalCursorMoved,k);x.unsubscribe(ops.OdtDocument.signalParagraphStyleModified,
-p);x.unsubscribe(ops.OdtDocument.signalParagraphChanged,e);a()};x.subscribe(ops.OdtDocument.signalCursorAdded,d);x.subscribe(ops.OdtDocument.signalCursorRemoved,b);x.subscribe(ops.OdtDocument.signalCursorMoved,k);x.subscribe(ops.OdtDocument.signalParagraphStyleModified,p);x.subscribe(ops.OdtDocument.signalParagraphChanged,e);c()};gui.DirectTextStyler.textStylingChanged="textStyling/changed";(function(){return gui.DirectTextStyler})();
+ops.EditInfo=function(e,h){function f(){var e=[],c;for(c in m)m.hasOwnProperty(c)&&e.push({memberid:c,time:m[c].time});e.sort(function(b,a){return b.time-a.time});return e}var n,m={};this.getNode=function(){return n};this.getOdtDocument=function(){return h};this.getEdits=function(){return m};this.getSortedEdits=function(){return f()};this.addEdit=function(e,c){m[e]={time:c}};this.clearEdits=function(){m={}};this.destroy=function(f){e.parentNode&&e.removeChild(n);f()};n=h.getDOM().createElementNS("urn:webodf:names:editinfo",
+"editinfo");e.insertBefore(n,e.firstChild)};
 // Input 66
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-runtime.loadClass("core.EventNotifier");runtime.loadClass("core.Utils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("ops.OpAddStyle");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("gui.StyleHelper");
-gui.DirectParagraphStyler=function(h,m,f){function a(){function a(b,d,e){b!==d&&(void 0===c&&(c={}),c[e]=d);return d}var b=l.getCursor(m),b=b&&b.getSelectedRange(),c;y=a(y,b?x.isAlignedLeft(b):!1,"isAlignedLeft");t=a(t,b?x.isAlignedCenter(b):!1,"isAlignedCenter");w=a(w,b?x.isAlignedRight(b):!1,"isAlignedRight");v=a(v,b?x.isAlignedJustified(b):!1,"isAlignedJustified");c&&r.emit(gui.DirectParagraphStyler.paragraphStylingChanged,c)}function c(b){b.getMemberId()===m&&a()}function d(b){b===m&&a()}function b(b){b.getMemberId()===
-m&&a()}function k(){a()}function p(b){var c=l.getCursor(m);c&&l.getParagraphElement(c.getNode())===b.paragraphElement&&a()}function e(a){var b=l.getCursor(m).getSelectedRange(),c=l.getCursorPosition(m),b=q.getParagraphElements(b),d=l.getFormatting();b.forEach(function(b){var e=c+l.getDistanceFromCursor(m,b,0),g=b.getAttributeNS(odf.Namespaces.textns,"style-name");b=f.generateName();var k,e=e+1;g&&(k=d.createDerivedStyleObject(g,"paragraph",{}));k=a(k||{});g=new ops.OpAddStyle;g.init({memberid:m,styleName:b,
-styleFamily:"paragraph",isAutomaticStyle:!0,setProperties:k});k=new ops.OpSetParagraphStyle;k.init({memberid:m,styleName:b,position:e});h.enqueue(g);h.enqueue(k)})}function s(a){e(function(b){return u.mergeObjects(b,a)})}function n(a){s({"style:paragraph-properties":{"fo:text-align":a}})}function g(a,b){var c=l.getFormatting().getDefaultTabStopDistance(),d=b["style:paragraph-properties"],d=(d=d&&d["fo:margin-left"])&&q.parseLength(d);return u.mergeObjects(b,{"style:paragraph-properties":{"fo:margin-left":d&&
-d.unit===c.unit?d.value+a*c.value+d.unit:a*c.value+c.unit}})}var l=h.getOdtDocument(),u=new core.Utils,q=new odf.OdfUtils,x=new gui.StyleHelper(l.getFormatting()),r=new core.EventNotifier([gui.DirectParagraphStyler.paragraphStylingChanged]),y,t,w,v;this.isAlignedLeft=function(){return y};this.isAlignedCenter=function(){return t};this.isAlignedRight=function(){return w};this.isAlignedJustified=function(){return v};this.alignParagraphLeft=function(){n("left");return!0};this.alignParagraphCenter=function(){n("center");
-return!0};this.alignParagraphRight=function(){n("right");return!0};this.alignParagraphJustified=function(){n("justify");return!0};this.indent=function(){e(g.bind(null,1));return!0};this.outdent=function(){e(g.bind(null,-1));return!0};this.subscribe=function(a,b){r.subscribe(a,b)};this.unsubscribe=function(a,b){r.unsubscribe(a,b)};this.destroy=function(a){l.unsubscribe(ops.OdtDocument.signalCursorAdded,c);l.unsubscribe(ops.OdtDocument.signalCursorRemoved,d);l.unsubscribe(ops.OdtDocument.signalCursorMoved,
-b);l.unsubscribe(ops.OdtDocument.signalParagraphStyleModified,k);l.unsubscribe(ops.OdtDocument.signalParagraphChanged,p);a()};l.subscribe(ops.OdtDocument.signalCursorAdded,c);l.subscribe(ops.OdtDocument.signalCursorRemoved,d);l.subscribe(ops.OdtDocument.signalCursorMoved,b);l.subscribe(ops.OdtDocument.signalParagraphStyleModified,k);l.subscribe(ops.OdtDocument.signalParagraphChanged,p);a()};gui.DirectParagraphStyler.paragraphStylingChanged="paragraphStyling/changed";(function(){return gui.DirectParagraphStyler})();
+runtime.loadClass("gui.SelectionMover");gui.ShadowCursor=function(e){var h=e.getDOM().createRange(),f=!0;this.removeFromOdtDocument=function(){};this.getMemberId=function(){return gui.ShadowCursor.ShadowCursorMemberId};this.getSelectedRange=function(){return h};this.setSelectedRange=function(e,m){h=e;f=!1!==m};this.hasForwardSelection=function(){return f};this.getOdtDocument=function(){return e};this.getSelectionType=function(){return ops.OdtCursor.RangeSelection};h.setStart(e.getRootNode(),0)};
+gui.ShadowCursor.ShadowCursorMemberId="";(function(){return gui.ShadowCursor})();
 // Input 67
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-gui.TextManipulator=function(h,m){function f(a){var b=new ops.OpRemoveText;b.init({memberid:m,position:a.position,length:a.length});return b}function a(a){0>a.length&&(a.position+=a.length,a.length=-a.length);return a}var c=h.getOdtDocument();this.enqueueParagraphSplittingOps=function(){var d=a(c.getCursorSelection(m)),b;0<d.length&&(b=f(d),h.enqueue(b));b=new ops.OpSplitParagraph;b.init({memberid:m,position:d.position});h.enqueue(b);return!0};this.removeTextByBackspaceKey=function(){var d=a(c.getCursorSelection(m)),
-b=null;0===d.length?0<d.position&&c.getPositionInTextNode(d.position-1)&&(b=new ops.OpRemoveText,b.init({memberid:m,position:d.position-1,length:1}),h.enqueue(b)):(b=f(d),h.enqueue(b));return null!==b};this.removeTextByDeleteKey=function(){var d=a(c.getCursorSelection(m)),b=null;0===d.length?c.getPositionInTextNode(d.position+1)&&(b=new ops.OpRemoveText,b.init({memberid:m,position:d.position,length:1}),h.enqueue(b)):(b=f(d),h.enqueue(b));return null!==b};this.removeCurrentSelection=function(){var d=
-a(c.getCursorSelection(m));0!==d.length&&(d=f(d),h.enqueue(d));return!0};this.insertText=function(d){var b=a(c.getCursorSelection(m)),k=null;0<b.length&&(k=f(b),h.enqueue(k));k=new ops.OpInsertText;k.init({memberid:m,position:b.position,text:d});h.enqueue(k)}};(function(){return gui.TextManipulator})();
+gui.Avatar=function(e,h){var f=this,n,m,p;this.setColor=function(c){m.style.borderColor=c};this.setImageUrl=function(c){f.isVisible()?m.src=c:p=c};this.isVisible=function(){return"block"===n.style.display};this.show=function(){p&&(m.src=p,p=void 0);n.style.display="block"};this.hide=function(){n.style.display="none"};this.markAsFocussed=function(c){n.className=c?"active":""};this.destroy=function(c){e.removeChild(n);c()};(function(){var c=e.ownerDocument,b=c.documentElement.namespaceURI;n=c.createElementNS(b,
+"div");m=c.createElementNS(b,"img");m.width=64;m.height=64;n.appendChild(m);n.style.width="64px";n.style.height="70px";n.style.position="absolute";n.style.top="-80px";n.style.left="-34px";n.style.display=h?"block":"none";e.appendChild(n)})()};
 // Input 68
-runtime.loadClass("core.DomUtils");runtime.loadClass("core.Utils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("ops.OpAddCursor");runtime.loadClass("ops.OpRemoveCursor");runtime.loadClass("ops.OpMoveCursor");runtime.loadClass("ops.OpInsertText");runtime.loadClass("ops.OpRemoveText");runtime.loadClass("ops.OpSplitParagraph");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("ops.OpRemoveAnnotation");runtime.loadClass("gui.Clipboard");runtime.loadClass("gui.KeyboardHandler");runtime.loadClass("gui.DirectTextStyler");
-runtime.loadClass("gui.DirectParagraphStyler");runtime.loadClass("gui.TextManipulator");
-gui.SessionController=function(){var h=core.PositionFilter.FilterResult.FILTER_ACCEPT;gui.SessionController=function(m,f,a){function c(a,b,c,d){var e="on"+b,f=!1;a.attachEvent&&(f=a.attachEvent(e,c));!f&&a.addEventListener&&(a.addEventListener(b,c,!1),f=!0);f&&!d||!a.hasOwnProperty(e)||(a[e]=c)}function d(a,b,c){var d="on"+b;a.detachEvent&&a.detachEvent(d,c);a.removeEventListener&&a.removeEventListener(b,c,!1);a[d]===c&&(a[d]=null)}function b(a){a.preventDefault?a.preventDefault():a.returnValue=!1}
-function k(a,b){var c=new ops.OpMoveCursor;c.init({memberid:f,position:a,length:b||0});return c}function p(a,b){var c=gui.SelectionMover.createPositionIterator(z.getRootNode()),d=z.getOdfCanvas().getElement(),e;e=a;if(!e)return null;for(;e!==d&&!("urn:webodf:names:cursor"===e.namespaceURI&&"cursor"===e.localName||"urn:webodf:names:editinfo"===e.namespaceURI&&"editinfo"===e.localName);)if(e=e.parentNode,!e)return null;e!==d&&a!==e&&(a=e.parentNode,b=Array.prototype.indexOf.call(a.childNodes,e));c.setUnfilteredPosition(a,
-b);return z.getDistanceFromCursor(f,c.container(),c.unfilteredDomOffset())}function e(a){var b=z.getOdfCanvas().getElement(),c=z.getRootNode(),d=0;b.compareDocumentPosition(a)&Node.DOCUMENT_POSITION_PRECEDING||(a=gui.SelectionMover.createPositionIterator(c),a.moveToEnd(),c=a.container(),d=a.unfilteredDomOffset());return{node:c,offset:d}}function s(a){runtime.setTimeout(function(){var b;a:{var c=z.getOdfCanvas().getElement();b=V.getSelection();b={anchorNode:b.anchorNode,anchorOffset:b.anchorOffset,
-focusNode:b.focusNode,focusOffset:b.focusOffset};var d=a.detail,g,h;if(null===b.anchorNode&&null===b.focusNode){h=a.clientX;g=a.clientY;var l=z.getDOM();l.caretRangeFromPoint?(h=l.caretRangeFromPoint(h,g),h={container:h.startContainer,offset:h.startOffset}):l.caretPositionFromPoint?(h=l.caretPositionFromPoint(h,g),h={container:h.offsetNode,offset:h.offset}):h=null;if(!h){b=null;break a}b.anchorNode=h.container;b.anchorOffset=h.offset;b.focusNode=b.anchorNode;b.focusOffset=b.anchorOffset}runtime.assert(null!==
-b.anchorNode&&null!==b.focusNode,"anchorNode is null or focusNode is null");g=da.containsNode(c,b.anchorNode);h=da.containsNode(c,b.focusNode);if(g||h){g||(g=e(b.anchorNode),b.anchorNode=g.node,b.anchorOffset=g.offset);h||(g=e(b.focusNode),b.focusNode=g.node,b.focusOffset=g.offset);if(2===d){var q=/[A-Za-z0-9]/,r=gui.SelectionMover.createPositionIterator(z.getRootNode()),n=0<da.comparePoints(b.anchorNode,b.anchorOffset,b.focusNode,b.focusOffset),x;n?(g=b.anchorNode,l=b.anchorOffset,d=b.focusNode,
-h=b.focusOffset):(g=b.focusNode,l=b.focusOffset,d=b.anchorNode,h=b.anchorOffset);for(r.setUnfilteredPosition(g,l);r.previousPosition();){x=r.getCurrentNode();if(x.nodeType===Node.TEXT_NODE){if(x=x.data[r.unfilteredDomOffset()],!q.test(x))break}else if(x.namespaceURI!==odf.Namespaces.textns||"span"!==x.localName)break;g=r.container();l=r.unfilteredDomOffset()}r.setUnfilteredPosition(d,h);do if(x=r.getCurrentNode(),x.nodeType===Node.TEXT_NODE){if(x=x.data[r.unfilteredDomOffset()],!q.test(x))break}else if(x.namespaceURI!==
-odf.Namespaces.textns||"span"!==x.localName)break;while(r.nextPosition());d=r.container();h=r.unfilteredDomOffset();n?(b.anchorNode=g,b.anchorOffset=l,b.focusNode=d,b.focusOffset=h):(b.focusNode=g,b.focusOffset=l,b.anchorNode=d,b.anchorOffset=h)}else 3===d&&(d=z.getParagraphElement(b.anchorNode),h=z.getParagraphElement(b.focusNode),d&&(b.anchorNode=d,b.anchorOffset=0),h&&(b.focusNode=h,b.focusOffset=h.childNodes.length));c.focus()}else b=null}null!==b&&(c=p(b.anchorNode,b.anchorOffset),d=b.focusNode===
-b.anchorNode&&b.focusOffset===b.anchorOffset?c:p(b.focusNode,b.focusOffset),null!==d&&0!==d||null!==c&&0!==c)&&(b=z.getCursorPosition(f),c=k(b+c,d-c),m.enqueue(c))},0)}function n(a){s(a)}function g(a){var b=z.getCursorSelection(f),c=z.getCursor(f).getStepCounter();0!==a&&(a=0<a?c.convertForwardStepsBetweenFilters(a,ja,ea):-c.convertBackwardStepsBetweenFilters(-a,ja,ea),a=b.length+a,m.enqueue(k(b.position,a)))}function l(a){var b=z.getCursorPosition(f),c=z.getCursor(f).getStepCounter();0!==a&&(a=0<
-a?c.convertForwardStepsBetweenFilters(a,ja,ea):-c.convertBackwardStepsBetweenFilters(-a,ja,ea),m.enqueue(k(b+a,0)))}function u(){l(-1);return!0}function q(){l(1);return!0}function x(){g(-1);return!0}function r(){g(1);return!0}function y(a,b){var c=z.getParagraphElement(z.getCursor(f).getNode());runtime.assert(Boolean(c),"SessionController: Cursor outside paragraph");c=z.getCursor(f).getStepCounter().countLinesSteps(a,ja);b?g(c):l(c)}function t(){y(-1,!1);return!0}function w(){y(1,!1);return!0}function v(){y(-1,
-!0);return!0}function C(){y(1,!0);return!0}function J(a,b){var c=z.getCursor(f).getStepCounter().countStepsToLineBoundary(a,ja);b?g(c):l(c)}function E(){J(-1,!1);return!0}function K(){J(1,!1);return!0}function B(){J(-1,!0);return!0}function N(){J(1,!0);return!0}function H(){var a=z.getParagraphElement(z.getCursor(f).getNode()),b,c;runtime.assert(Boolean(a),"SessionController: Cursor outside paragraph");c=z.getDistanceFromCursor(f,a,0);b=gui.SelectionMover.createPositionIterator(z.getRootNode());for(b.setUnfilteredPosition(a,
-0);0===c&&b.previousPosition();)a=b.getCurrentNode(),I.isParagraph(a)&&(c=z.getDistanceFromCursor(f,a,0));g(c);return!0}function L(){var a=z.getParagraphElement(z.getCursor(f).getNode()),b,c;runtime.assert(Boolean(a),"SessionController: Cursor outside paragraph");b=gui.SelectionMover.createPositionIterator(z.getRootNode());b.moveToEndOfNode(a);for(c=z.getDistanceFromCursor(f,b.container(),b.unfilteredDomOffset());0===c&&b.nextPosition();)a=b.getCurrentNode(),I.isParagraph(a)&&(b.moveToEndOfNode(a),
-c=z.getDistanceFromCursor(f,b.container(),b.unfilteredDomOffset()));g(c);return!0}function fa(a,b){var c=gui.SelectionMover.createPositionIterator(z.getRootNode());0<a&&c.moveToEnd();c=z.getDistanceFromCursor(f,c.container(),c.unfilteredDomOffset());b?g(c):l(c)}function ma(){fa(-1,!1);return!0}function M(){fa(1,!1);return!0}function pa(){fa(-1,!0);return!0}function W(){fa(1,!0);return!0}function aa(){var a=gui.SelectionMover.createPositionIterator(z.getRootNode()),b;b=-z.getDistanceFromCursor(f,a.container(),
-a.unfilteredDomOffset());a.moveToEnd();b+=z.getDistanceFromCursor(f,a.container(),a.unfilteredDomOffset());m.enqueue(k(0,b));return!0}function O(){var a=z.getCursor(f),b=V.getSelection();a&&(b.removeAllRanges(),b.addRange(a.getSelectedRange().cloneRange()))}function R(a){var b=z.getCursor(f);b.getSelectedRange().collapsed||(ia.setDataFromRange(a,b.getSelectedRange())?ka.removeCurrentSelection():runtime.log("Cut operation failed"))}function F(){return!1!==z.getCursor(f).getSelectedRange().collapsed}
-function G(a){var b=z.getCursor(f);b.getSelectedRange().collapsed||ia.setDataFromRange(a,b.getSelectedRange())||runtime.log("Cut operation failed")}function D(a){var b;V.clipboardData&&V.clipboardData.getData?b=V.clipboardData.getData("Text"):a.clipboardData&&a.clipboardData.getData&&(b=a.clipboardData.getData("text/plain"));b&&(ka.insertText(b),a.preventDefault?a.preventDefault():a.returnValue=!1)}function T(){return!1}function X(a){if(Y)Y.onOperationExecuted(a)}function Q(a){z.emit(ops.OdtDocument.signalUndoStackChanged,
-a)}function P(){return Y?(Y.moveBackward(1),O(),!0):!1}function $(){return Y?(Y.moveForward(1),O(),!0):!1}function ca(a){oa=a.target&&da.containsNode(z.getOdfCanvas().getElement(),a.target)}function U(a){var b=a.target,c=null;if("annotationRemoveButton"===b.className){a=c=da.getElementsByTagNameNS(b.parentNode,odf.Namespaces.officens,"annotation")[0];for(var b=0,c=gui.SelectionMover.createPositionIterator(z.getRootNode()),d=new core.LoopWatchDog(1E3),e=!1;c.nextPosition();)if(d.check(),e=Boolean(a.compareDocumentPosition(c.container())&
-Node.DOCUMENT_POSITION_CONTAINED_BY),ea.acceptPosition(c)===h){if(e)break;b+=1}c=0;d=gui.SelectionMover.createPositionIterator(z.getRootNode());e=!1;d.setUnfilteredPosition(a,0);do{e=Boolean(a.compareDocumentPosition(d.container())&Node.DOCUMENT_POSITION_CONTAINED_BY);if(!e&&a!==d.container())break;ea.acceptPosition(d)===h&&(c+=1)}while(d.nextPosition());a=c;c=new ops.OpRemoveAnnotation;c.init({memberid:f,position:b,length:a});m.enqueue(c)}else oa&&s(a)}var V=runtime.getWindow(),z=m.getOdtDocument(),
-ga=new core.Utils,da=new core.DomUtils,I=new odf.OdfUtils,ia=new gui.Clipboard,A=new gui.KeyboardHandler,na=new gui.KeyboardHandler,ja=new core.PositionFilterChain,ea=z.getPositionFilter(),oa=!1,ga=new odf.StyleNameGenerator("auto"+ga.hashString(f)+"_",z.getFormatting()),Y=null,ka=new gui.TextManipulator(m,f),ha=a&&a.directStylingEnabled?new gui.DirectTextStyler(m,f):null,ba=a&&a.directStylingEnabled?new gui.DirectParagraphStyler(m,f,ga):null;runtime.assert(null!==V,"Expected to be run in an environment which has a global window, like a browser.");
-ja.addFilter("BaseFilter",ea);ja.addFilter("RootFilter",z.createRootFilter(f));this.startEditing=function(){var a;a=z.getOdfCanvas().getElement();c(a,"keydown",A.handleEvent);c(a,"keypress",na.handleEvent);c(a,"keyup",b);c(a,"beforecut",F,!0);c(a,"cut",R);c(a,"copy",G);c(a,"beforepaste",T,!0);c(a,"paste",D);c(V,"mousedown",ca);c(V,"mouseup",U);c(a,"contextmenu",n);z.subscribe(ops.OdtDocument.signalOperationExecuted,O);z.subscribe(ops.OdtDocument.signalOperationExecuted,X);a=new ops.OpAddCursor;a.init({memberid:f});
-m.enqueue(a);Y&&Y.saveInitialState()};this.endEditing=function(){var a;z.unsubscribe(ops.OdtDocument.signalOperationExecuted,X);z.unsubscribe(ops.OdtDocument.signalOperationExecuted,O);a=z.getOdfCanvas().getElement();d(a,"keydown",A.handleEvent);d(a,"keypress",na.handleEvent);d(a,"keyup",b);d(a,"cut",R);d(a,"beforecut",F);d(a,"copy",G);d(a,"paste",D);d(a,"beforepaste",T);d(V,"mousedown",ca);d(V,"mouseup",U);d(a,"contextmenu",n);a=new ops.OpRemoveCursor;a.init({memberid:f});m.enqueue(a);Y&&Y.resetInitialState()};
-this.getInputMemberId=function(){return f};this.getSession=function(){return m};this.setUndoManager=function(a){Y&&Y.unsubscribe(gui.UndoManager.signalUndoStackChanged,Q);if(Y=a)Y.setOdtDocument(z),Y.setPlaybackFunction(function(a){a.execute(z)}),Y.subscribe(gui.UndoManager.signalUndoStackChanged,Q)};this.getUndoManager=function(){return Y};this.getDirectTextStyler=function(){return ha};this.getDirectParagraphStyler=function(){return ba};this.getTextManipulator=function(){return ka};this.destroy=
-function(a){var b=ba?ba.destroy:function(a){a()};(ha?ha.destroy:function(a){a()})(function(c){c?a(c):b(a)})};(function(){var a=-1!==V.navigator.appVersion.toLowerCase().indexOf("mac"),b=gui.KeyboardHandler.Modifier,c=gui.KeyboardHandler.KeyCode;A.bind(c.Tab,b.None,function(){ka.insertText("\t");return!0});A.bind(c.Left,b.None,u);A.bind(c.Right,b.None,q);A.bind(c.Up,b.None,t);A.bind(c.Down,b.None,w);A.bind(c.Backspace,b.None,ka.removeTextByBackspaceKey);A.bind(c.Delete,b.None,ka.removeTextByDeleteKey);
-A.bind(c.Left,b.Shift,x);A.bind(c.Right,b.Shift,r);A.bind(c.Up,b.Shift,v);A.bind(c.Down,b.Shift,C);A.bind(c.Home,b.None,E);A.bind(c.End,b.None,K);A.bind(c.Home,b.Ctrl,ma);A.bind(c.End,b.Ctrl,M);A.bind(c.Home,b.Shift,B);A.bind(c.End,b.Shift,N);A.bind(c.Up,b.CtrlShift,H);A.bind(c.Down,b.CtrlShift,L);A.bind(c.Home,b.CtrlShift,pa);A.bind(c.End,b.CtrlShift,W);a?(A.bind(c.Clear,b.None,ka.removeCurrentSelection),A.bind(c.Left,b.Meta,E),A.bind(c.Right,b.Meta,K),A.bind(c.Home,b.Meta,ma),A.bind(c.End,b.Meta,
-M),A.bind(c.Left,b.MetaShift,B),A.bind(c.Right,b.MetaShift,N),A.bind(c.Up,b.AltShift,H),A.bind(c.Down,b.AltShift,L),A.bind(c.Up,b.MetaShift,pa),A.bind(c.Down,b.MetaShift,W),A.bind(c.A,b.Meta,aa),ha&&(A.bind(c.B,b.Meta,ha.toggleBold),A.bind(c.I,b.Meta,ha.toggleItalic),A.bind(c.U,b.Meta,ha.toggleUnderline)),ba&&(A.bind(c.L,b.MetaShift,ba.alignParagraphLeft),A.bind(c.E,b.MetaShift,ba.alignParagraphCenter),A.bind(c.R,b.MetaShift,ba.alignParagraphRight),A.bind(c.J,b.MetaShift,ba.alignParagraphJustified)),
-A.bind(c.Z,b.Meta,P),A.bind(c.Z,b.MetaShift,$)):(A.bind(c.A,b.Ctrl,aa),ha&&(A.bind(c.B,b.Ctrl,ha.toggleBold),A.bind(c.I,b.Ctrl,ha.toggleItalic),A.bind(c.U,b.Ctrl,ha.toggleUnderline)),ba&&(A.bind(c.L,b.CtrlShift,ba.alignParagraphLeft),A.bind(c.E,b.CtrlShift,ba.alignParagraphCenter),A.bind(c.R,b.CtrlShift,ba.alignParagraphRight),A.bind(c.J,b.CtrlShift,ba.alignParagraphJustified)),A.bind(c.Z,b.Ctrl,P),A.bind(c.Z,b.CtrlShift,$));na.setDefault(function(a){var b;b=null===a.which?String.fromCharCode(a.keyCode):
-0!==a.which&&0!==a.charCode?String.fromCharCode(a.which):null;return!b||a.altKey||a.ctrlKey||a.metaKey?!1:(ka.insertText(b),!0)});na.bind(c.Enter,b.None,ka.enqueueParagraphSplittingOps)})()};return gui.SessionController}();
+runtime.loadClass("core.DomUtils");runtime.loadClass("gui.Avatar");runtime.loadClass("ops.OdtCursor");
+gui.Caret=function(e,h,f){function n(b){k&&a.parentNode&&(!g||b)&&(b&&void 0!==q&&runtime.clearTimeout(q),g=!0,c.style.opacity=b||"0"===c.style.opacity?"1":"0",q=runtime.setTimeout(function(){g=!1;n(!1)},500))}function m(a,b){var c=a.getBoundingClientRect(),d=0,e=0;c&&b&&(d=Math.max(c.top,b.top),e=Math.min(c.bottom,b.bottom));return e-d}function p(){var a;a=e.getSelectedRange().cloneRange();var b=e.getNode(),f,g=null;b.previousSibling&&(f=b.previousSibling.nodeType===Node.TEXT_NODE?b.previousSibling.textContent.length:
+b.previousSibling.childNodes.length,a.setStart(b.previousSibling,0<f?f-1:0),a.setEnd(b.previousSibling,f),(f=a.getBoundingClientRect())&&f.height&&(g=f));b.nextSibling&&(a.setStart(b.nextSibling,0),a.setEnd(b.nextSibling,0<(b.nextSibling.nodeType===Node.TEXT_NODE?b.nextSibling.textContent.length:b.nextSibling.childNodes.length)?1:0),(f=a.getBoundingClientRect())&&f.height&&(!g||m(b,f)>m(b,g))&&(g=f));a=g;b=e.getOdtDocument().getOdfCanvas().getZoomLevel();d&&e.getSelectionType()===ops.OdtCursor.RangeSelection?
+c.style.visibility="visible":c.style.visibility="hidden";a?(c.style.top="0",g=c.ownerDocument.createRange(),g.selectNode(c),f=g.getBoundingClientRect(),g.detach(),8>a.height&&(a={top:a.top-(8-a.height)/2,height:8}),c.style.height=l.adaptRangeDifferenceToZoomLevel(a.height,b)+"px",c.style.top=l.adaptRangeDifferenceToZoomLevel(a.top-f.top,b)+"px"):(c.style.height="1em",c.style.top="5%")}var c,b,a,d=!0,k=!1,g=!1,q,l=new core.DomUtils;this.handleUpdate=p;this.refreshCursorBlinking=function(){f||e.getSelectedRange().collapsed?
+(k=!0,n(!0)):(k=!1,c.style.opacity="0")};this.setFocus=function(){k=!0;b.markAsFocussed(!0);n(!0)};this.removeFocus=function(){k=!1;b.markAsFocussed(!1);c.style.opacity="1"};this.show=function(){d=!0;p();b.markAsFocussed(!0)};this.hide=function(){d=!1;p();b.markAsFocussed(!1)};this.setAvatarImageUrl=function(a){b.setImageUrl(a)};this.setColor=function(a){c.style.borderColor=a;b.setColor(a)};this.getCursor=function(){return e};this.getFocusElement=function(){return c};this.toggleHandleVisibility=function(){b.isVisible()?
+b.hide():b.show()};this.showHandle=function(){b.show()};this.hideHandle=function(){b.hide()};this.ensureVisible=function(){var a,b,d,f,g=e.getOdtDocument().getOdfCanvas().getElement().parentNode,h;d=g.offsetWidth-g.clientWidth+5;f=g.offsetHeight-g.clientHeight+5;h=c.getBoundingClientRect();a=h.left-d;b=h.top-f;d=h.right+d;f=h.bottom+f;h=g.getBoundingClientRect();b<h.top?g.scrollTop-=h.top-b:f>h.bottom&&(g.scrollTop+=f-h.bottom);a<h.left?g.scrollLeft-=h.left-a:d>h.right&&(g.scrollLeft+=d-h.right);
+p()};this.destroy=function(d){b.destroy(function(b){b?d(b):(a.removeChild(c),d())})};(function(){var d=e.getOdtDocument().getDOM();c=d.createElementNS(d.documentElement.namespaceURI,"span");c.style.top="5%";a=e.getNode();a.appendChild(c);b=new gui.Avatar(a,h);p()})()};
 // Input 69
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -1979,6 +2057,9 @@ A.bind(c.Z,b.Meta,P),A.bind(c.Z,b.MetaShift,$)):(A.bind(c.A,b.Ctrl,aa),ha&&(A.bi
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2000,13 +2081,15 @@ A.bind(c.Z,b.Meta,P),A.bind(c.Z,b.MetaShift,$)):(A.bind(c.A,b.Ctrl,aa),ha&&(A.bi
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.MemberModel=function(){};ops.MemberModel.prototype.getMemberDetailsAndUpdates=function(h,m){};ops.MemberModel.prototype.unsubscribeMemberDetailsUpdates=function(h,m){};ops.MemberModel.prototype.close=function(h){};
+runtime.loadClass("odf.Namespaces");runtime.loadClass("xmldom.LSSerializer");runtime.loadClass("odf.OdfNodeFilter");runtime.loadClass("odf.TextSerializer");
+gui.Clipboard=function(){var e,h,f;this.setDataFromRange=function(f,m){var p=!0,c,b=f.clipboardData;c=runtime.getWindow();var a=m.startContainer.ownerDocument;!b&&c&&(b=c.clipboardData);b?(a=a.createElement("span"),a.appendChild(m.cloneContents()),c=b.setData("text/plain",h.writeToString(a)),p=p&&c,c=b.setData("text/html",e.writeToString(a,odf.Namespaces.namespaceMap)),p=p&&c,f.preventDefault()):p=!1;return p};e=new xmldom.LSSerializer;h=new odf.TextSerializer;f=new odf.OdfNodeFilter;e.filter=f;h.filter=
+f};
 // Input 70
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -2015,6 +2098,9 @@ ops.MemberModel=function(){};ops.MemberModel.prototype.getMemberDetailsAndUpdate
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2036,9 +2122,17 @@ ops.MemberModel=function(){};ops.MemberModel.prototype.getMemberDetailsAndUpdate
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.TrivialMemberModel=function(){this.getMemberDetailsAndUpdates=function(h,m){m(h,{memberid:h,fullname:"Unknown",color:"black",imageurl:"avatar-joe.png"})};this.unsubscribeMemberDetailsUpdates=function(h,m){};this.close=function(h){h()}};
+runtime.loadClass("core.EventNotifier");runtime.loadClass("core.Utils");runtime.loadClass("ops.OpApplyDirectStyling");runtime.loadClass("gui.StyleHelper");
+gui.DirectTextStyler=function(e,h){function f(a,b){for(var c=0,d=b[c];d&&a;)a=a[d],c+=1,d=b[c];return b.length===c?a:void 0}function n(a,b){var c=f(a[0],b);return a.every(function(a){return c===f(a,b)})?c:void 0}function m(){var a=u.getCursor(h),a=(a=a&&a.getSelectedRange())&&s.getAppliedStyles(a)||[];a[0]&&B&&(a[0]=x.mergeObjects(a[0],B));return a}function p(){function a(b,d,e){b!==d&&(void 0===c&&(c={}),c[e]=d);return d}var b,c;A=m();I=a(I,A?s.isBold(A):!1,"isBold");z=a(z,A?s.isItalic(A):!1,"isItalic");
+N=a(N,A?s.hasUnderline(A):!1,"hasUnderline");G=a(G,A?s.hasStrikeThrough(A):!1,"hasStrikeThrough");b=A&&n(A,["style:text-properties","fo:font-size"]);R=a(R,b&&parseFloat(b),"fontSize");Z=a(Z,A&&n(A,["style:text-properties","style:font-name"]),"fontName");c&&C.emit(gui.DirectTextStyler.textStylingChanged,c)}function c(a){a.getMemberId()===h&&p()}function b(a){a===h&&p()}function a(a){a.getMemberId()===h&&p()}function d(){p()}function k(a){var b=u.getCursor(h);b&&u.getParagraphElement(b.getNode())===
+a.paragraphElement&&p()}function g(a,b){var c=u.getCursor(h);if(!c)return!1;c=s.getAppliedStyles(c.getSelectedRange());b(!a(c));return!0}function q(a){var b=u.getCursorSelection(h),c={"style:text-properties":a};0!==b.length?(a=new ops.OpApplyDirectStyling,a.init({memberid:h,position:b.position,length:b.length,setProperties:c}),e.enqueue([a])):(B=x.mergeObjects(B||{},c),p())}function l(a,b){var c={};c[a]=b;q(c)}function r(a){a=a.spec();B&&a.memberid===h&&"SplitParagraph"!==a.optype&&(B=null,p())}function t(a){l("fo:font-weight",
+a?"bold":"normal")}function w(a){l("fo:font-style",a?"italic":"normal")}function v(a){l("style:text-underline-style",a?"solid":"none")}function y(a){l("style:text-line-through-style",a?"solid":"none")}var x=new core.Utils,u=e.getOdtDocument(),s=new gui.StyleHelper(u.getFormatting()),C=new core.EventNotifier([gui.DirectTextStyler.textStylingChanged]),B,A=[],I=!1,z=!1,N=!1,G=!1,R,Z;this.formatTextSelection=q;this.createCursorStyleOp=function(a,b){var c=null;B&&(c=new ops.OpApplyDirectStyling,c.init({memberid:h,
+position:a,length:b,setProperties:B}),B=null,p());return c};this.setBold=t;this.setItalic=w;this.setHasUnderline=v;this.setHasStrikethrough=y;this.setFontSize=function(a){l("fo:font-size",a+"pt")};this.setFontName=function(a){l("style:font-name",a)};this.getAppliedStyles=function(){return A};this.toggleBold=g.bind(this,s.isBold,t);this.toggleItalic=g.bind(this,s.isItalic,w);this.toggleUnderline=g.bind(this,s.hasUnderline,v);this.toggleStrikethrough=g.bind(this,s.hasStrikeThrough,y);this.isBold=function(){return I};
+this.isItalic=function(){return z};this.hasUnderline=function(){return N};this.hasStrikeThrough=function(){return G};this.fontSize=function(){return R};this.fontName=function(){return Z};this.subscribe=function(a,b){C.subscribe(a,b)};this.unsubscribe=function(a,b){C.unsubscribe(a,b)};this.destroy=function(e){u.unsubscribe(ops.OdtDocument.signalCursorAdded,c);u.unsubscribe(ops.OdtDocument.signalCursorRemoved,b);u.unsubscribe(ops.OdtDocument.signalCursorMoved,a);u.unsubscribe(ops.OdtDocument.signalParagraphStyleModified,
+d);u.unsubscribe(ops.OdtDocument.signalParagraphChanged,k);u.unsubscribe(ops.OdtDocument.signalOperationExecuted,r);e()};u.subscribe(ops.OdtDocument.signalCursorAdded,c);u.subscribe(ops.OdtDocument.signalCursorRemoved,b);u.subscribe(ops.OdtDocument.signalCursorMoved,a);u.subscribe(ops.OdtDocument.signalParagraphStyleModified,d);u.subscribe(ops.OdtDocument.signalParagraphChanged,k);u.subscribe(ops.OdtDocument.signalOperationExecuted,r);p()};gui.DirectTextStyler.textStylingChanged="textStyling/changed";
+(function(){return gui.DirectTextStyler})();
 // Input 71
 /*
 
@@ -2052,6 +2146,9 @@ ops.TrivialMemberModel=function(){this.getMemberDetailsAndUpdates=function(h,m){
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -2072,51 +2169,18 @@ ops.TrivialMemberModel=function(){this.getMemberDetailsAndUpdates=function(h,m){
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-ops.OperationRouter=function(){};ops.OperationRouter.prototype.setOperationFactory=function(h){};ops.OperationRouter.prototype.setPlaybackFunction=function(h){};ops.OperationRouter.prototype.push=function(h){};ops.OperationRouter.prototype.close=function(h){};ops.OperationRouter.prototype.getHasLocalUnsyncedOpsAndUpdates=function(h){};ops.OperationRouter.prototype.unsubscribeHasLocalUnsyncedOpsUpdates=function(h){};
+runtime.loadClass("core.EventNotifier");runtime.loadClass("core.Utils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("ops.OpAddStyle");runtime.loadClass("ops.OpSetParagraphStyle");runtime.loadClass("gui.StyleHelper");
+gui.DirectParagraphStyler=function(e,h,f){function n(){function a(b,d,e){b!==d&&(void 0===c&&(c={}),c[e]=d);return d}var b=l.getCursor(h),b=b&&b.getSelectedRange(),c;y=a(y,b?w.isAlignedLeft(b):!1,"isAlignedLeft");x=a(x,b?w.isAlignedCenter(b):!1,"isAlignedCenter");u=a(u,b?w.isAlignedRight(b):!1,"isAlignedRight");s=a(s,b?w.isAlignedJustified(b):!1,"isAlignedJustified");c&&v.emit(gui.DirectParagraphStyler.paragraphStylingChanged,c)}function m(a){a.getMemberId()===h&&n()}function p(a){a===h&&n()}function c(a){a.getMemberId()===
+h&&n()}function b(){n()}function a(a){var b=l.getCursor(h);b&&l.getParagraphElement(b.getNode())===a.paragraphElement&&n()}function d(a){var b=l.getCursor(h).getSelectedRange(),c=l.getCursorPosition(h),b=t.getParagraphElements(b),d=l.getFormatting();b.forEach(function(b){var g=c+l.getDistanceFromCursor(h,b,0),k=b.getAttributeNS(odf.Namespaces.textns,"style-name");b=f.generateStyleName();var m,g=g+1;k&&(m=d.createDerivedStyleObject(k,"paragraph",{}));m=a(m||{});k=new ops.OpAddStyle;k.init({memberid:h,
+styleName:b,styleFamily:"paragraph",isAutomaticStyle:!0,setProperties:m});m=new ops.OpSetParagraphStyle;m.init({memberid:h,styleName:b,position:g});e.enqueue([k,m])})}function k(a){d(function(b){return r.mergeObjects(b,a)})}function g(a){k({"style:paragraph-properties":{"fo:text-align":a}})}function q(a,b){var c=l.getFormatting().getDefaultTabStopDistance(),d=b["style:paragraph-properties"],d=(d=d&&d["fo:margin-left"])&&t.parseLength(d);return r.mergeObjects(b,{"style:paragraph-properties":{"fo:margin-left":d&&
+d.unit===c.unit?d.value+a*c.value+d.unit:a*c.value+c.unit}})}var l=e.getOdtDocument(),r=new core.Utils,t=new odf.OdfUtils,w=new gui.StyleHelper(l.getFormatting()),v=new core.EventNotifier([gui.DirectParagraphStyler.paragraphStylingChanged]),y,x,u,s;this.isAlignedLeft=function(){return y};this.isAlignedCenter=function(){return x};this.isAlignedRight=function(){return u};this.isAlignedJustified=function(){return s};this.alignParagraphLeft=function(){g("left");return!0};this.alignParagraphCenter=function(){g("center");
+return!0};this.alignParagraphRight=function(){g("right");return!0};this.alignParagraphJustified=function(){g("justify");return!0};this.indent=function(){d(q.bind(null,1));return!0};this.outdent=function(){d(q.bind(null,-1));return!0};this.subscribe=function(a,b){v.subscribe(a,b)};this.unsubscribe=function(a,b){v.unsubscribe(a,b)};this.destroy=function(d){l.unsubscribe(ops.OdtDocument.signalCursorAdded,m);l.unsubscribe(ops.OdtDocument.signalCursorRemoved,p);l.unsubscribe(ops.OdtDocument.signalCursorMoved,
+c);l.unsubscribe(ops.OdtDocument.signalParagraphStyleModified,b);l.unsubscribe(ops.OdtDocument.signalParagraphChanged,a);d()};l.subscribe(ops.OdtDocument.signalCursorAdded,m);l.subscribe(ops.OdtDocument.signalCursorRemoved,p);l.subscribe(ops.OdtDocument.signalCursorMoved,c);l.subscribe(ops.OdtDocument.signalParagraphStyleModified,b);l.subscribe(ops.OdtDocument.signalParagraphChanged,a);n()};gui.DirectParagraphStyler.paragraphStylingChanged="paragraphStyling/changed";(function(){return gui.DirectParagraphStyler})();
 // Input 72
 /*
 
- Copyright (C) 2012 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
-
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-ops.TrivialOperationRouter=function(){var h,m;this.setOperationFactory=function(f){h=f};this.setPlaybackFunction=function(f){m=f};this.push=function(f){f=f.spec();f.timestamp=(new Date).getTime();f=h.create(f);m(f)};this.close=function(f){f()};this.getHasLocalUnsyncedOpsAndUpdates=function(f){f(!0)};this.unsubscribeHasLocalUnsyncedOpsUpdates=function(f){}};
-// Input 73
-gui.EditInfoHandle=function(h){var m=[],f,a=h.ownerDocument,c=a.documentElement.namespaceURI;this.setEdits=function(d){m=d;var b,k,h,e;f.innerHTML="";for(d=0;d<m.length;d+=1)b=a.createElementNS(c,"div"),b.className="editInfo",k=a.createElementNS(c,"span"),k.className="editInfoColor",k.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",m[d].memberid),h=a.createElementNS(c,"span"),h.className="editInfoAuthor",h.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",m[d].memberid),
-e=a.createElementNS(c,"span"),e.className="editInfoTime",e.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",m[d].memberid),e.innerHTML=m[d].time,b.appendChild(k),b.appendChild(h),b.appendChild(e),f.appendChild(b)};this.show=function(){f.style.display="block"};this.hide=function(){f.style.display="none"};this.destroy=function(a){h.removeChild(f);a()};f=a.createElementNS(c,"div");f.setAttribute("class","editInfoHandle");f.style.display="none";h.appendChild(f)};
-// Input 74
-/*
-
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
@@ -2127,6 +2191,9 @@ e=a.createElementNS(c,"span"),e.className="editInfoTime",e.setAttributeNS("urn:w
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -2147,16 +2214,25 @@ e=a.createElementNS(c,"span"),e.className="editInfoTime",e.setAttributeNS("urn:w
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("ops.EditInfo");runtime.loadClass("gui.EditInfoHandle");
-gui.EditInfoMarker=function(h,m){function f(a,c){return runtime.getWindow().setTimeout(function(){b.style.opacity=a},c)}var a=this,c,d,b,k,p;this.addEdit=function(a,c){var m=Date.now()-c;h.addEdit(a,c);d.setEdits(h.getSortedEdits());b.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",a);if(k){var g=k;runtime.getWindow().clearTimeout(g)}p&&(g=p,runtime.getWindow().clearTimeout(g));1E4>m?(f(1,0),k=f(0.5,1E4-m),p=f(0.2,2E4-m)):1E4<=m&&2E4>m?(f(0.5,0),p=f(0.2,2E4-m)):f(0.2,0)};this.getEdits=
-function(){return h.getEdits()};this.clearEdits=function(){h.clearEdits();d.setEdits([]);b.hasAttributeNS("urn:webodf:names:editinfo","editinfo:memberid")&&b.removeAttributeNS("urn:webodf:names:editinfo","editinfo:memberid")};this.getEditInfo=function(){return h};this.show=function(){b.style.display="block"};this.hide=function(){a.hideHandle();b.style.display="none"};this.showHandle=function(){d.show()};this.hideHandle=function(){d.hide()};this.destroy=function(a){c.removeChild(b);d.destroy(function(b){b?
-a(b):h.destroy(a)})};(function(){var e=h.getOdtDocument().getDOM();b=e.createElementNS(e.documentElement.namespaceURI,"div");b.setAttribute("class","editInfoMarker");b.onmouseover=function(){a.showHandle()};b.onmouseout=function(){a.hideHandle()};c=h.getNode();c.appendChild(b);d=new gui.EditInfoHandle(c);m||a.hide()})()};
+gui.KeyboardHandler=function(){function e(e,f){f||(f=h.None);return e+":"+f}var h=gui.KeyboardHandler.Modifier,f=null,n={};this.setDefault=function(e){f=e};this.bind=function(f,h,c){f=e(f,h);runtime.assert(!1===n.hasOwnProperty(f),"tried to overwrite the callback handler of key combo: "+f);n[f]=c};this.unbind=function(f,h){var c=e(f,h);delete n[c]};this.reset=function(){f=null;n={}};this.handleEvent=function(m){var p=m.keyCode,c=h.None;m.metaKey&&(c|=h.Meta);m.ctrlKey&&(c|=h.Ctrl);m.altKey&&(c|=h.Alt);
+m.shiftKey&&(c|=h.Shift);p=e(p,c);p=n[p];c=!1;p?c=p():null!==f&&(c=f(m));c&&(m.preventDefault?m.preventDefault():m.returnValue=!1)}};gui.KeyboardHandler.Modifier={None:0,Meta:1,Ctrl:2,Alt:4,CtrlAlt:6,Shift:8,MetaShift:9,CtrlShift:10,AltShift:12};gui.KeyboardHandler.KeyCode={Backspace:8,Tab:9,Clear:12,Enter:13,End:35,Home:36,Left:37,Up:38,Right:39,Down:40,Delete:46,A:65,B:66,C:67,D:68,E:69,F:70,G:71,H:72,I:73,J:74,K:75,L:76,M:77,N:78,O:79,P:80,Q:81,R:82,S:83,T:84,U:85,V:86,W:87,X:88,Y:89,Z:90};(function(){return gui.KeyboardHandler})();
+// Input 73
+runtime.loadClass("odf.Namespaces");runtime.loadClass("odf.ObjectNameGenerator");
+gui.ImageManager=function(e,h,f){var n={"image/gif":".gif","image/jpeg":".jpg","image/png":".png"},m=odf.Namespaces.textns,p=e.getOdtDocument(),c=p.getFormatting(),b={};this.insertImage=function(a,d,k,g){var q;runtime.assert(0<k&&0<g,"Both width and height of the image should be greater than 0px.");q=p.getParagraphElement(p.getCursor(h).getNode()).getAttributeNS(m,"style-name");b.hasOwnProperty(q)||(b[q]=c.getContentSize(q,"paragraph"));q=b[q];k*=0.0264583333333334;g*=0.0264583333333334;var l=1,r=
+1;k>q.width&&(l=q.width/k);g>q.height&&(r=q.height/g);l=Math.min(l,r);q=k*l;k=g*l;r=p.getOdfCanvas().odfContainer().rootElement.styles;g=a.toLowerCase();var l=n.hasOwnProperty(g)?n[g]:null,t;g=[];runtime.assert(null!==l,"Image type is not supported: "+a);l="Pictures/"+f.generateImageName()+l;t=new ops.OpSetBlob;t.init({memberid:h,filename:l,mimetype:a,content:d});g.push(t);c.getStyleElement("Graphics","graphic",[r])||(a=new ops.OpAddStyle,a.init({memberid:h,styleName:"Graphics",styleFamily:"graphic",
+isAutomaticStyle:!1,setProperties:{"style:graphic-properties":{"text:anchor-type":"paragraph","svg:x":"0cm","svg:y":"0cm","style:wrap":"dynamic","style:number-wrapped-paragraphs":"no-limit","style:wrap-contour":"false","style:vertical-pos":"top","style:vertical-rel":"paragraph","style:horizontal-pos":"center","style:horizontal-rel":"paragraph"}}}),g.push(a));a=f.generateStyleName();d=new ops.OpAddStyle;d.init({memberid:h,styleName:a,styleFamily:"graphic",isAutomaticStyle:!0,setProperties:{"style:parent-style-name":"Graphics",
+"style:graphic-properties":{"style:vertical-pos":"top","style:vertical-rel":"baseline","style:horizontal-pos":"center","style:horizontal-rel":"paragraph","fo:background-color":"transparent","style:background-transparency":"100%","style:shadow":"none","style:mirror":"none","fo:clip":"rect(0cm, 0cm, 0cm, 0cm)","draw:luminance":"0%","draw:contrast":"0%","draw:red":"0%","draw:green":"0%","draw:blue":"0%","draw:gamma":"100%","draw:color-inversion":"false","draw:image-opacity":"100%","draw:color-mode":"standard"}}});
+g.push(d);t=new ops.OpInsertImage;t.init({memberid:h,position:p.getCursorPosition(h),filename:l,frameWidth:q+"cm",frameHeight:k+"cm",frameStyleName:a,frameName:f.generateFrameName()});g.push(t);e.enqueue(g)}};
+// Input 74
+runtime.loadClass("odf.Namespaces");
+gui.ImageSelector=function(e){function h(){var c=e.getSizer(),b,a;b=m.createElement("div");b.id="imageSelector";b.style.borderWidth="1px";c.appendChild(b);n.forEach(function(c){a=m.createElement("div");a.className=c;b.appendChild(a)});return b}var f=odf.Namespaces.svgns,n="topLeft topRight bottomRight bottomLeft topMiddle rightMiddle bottomMiddle leftMiddle".split(" "),m=e.getElement().ownerDocument,p=!1;this.select=function(c){var b,a,d=m.getElementById("imageSelector");d||(d=h());p=!0;b=d.parentNode;
+a=c.getBoundingClientRect();var k=b.getBoundingClientRect(),g=e.getZoomLevel();b=(a.left-k.left)/g-1;a=(a.top-k.top)/g-1;d.style.display="block";d.style.left=b+"px";d.style.top=a+"px";d.style.width=c.getAttributeNS(f,"width");d.style.height=c.getAttributeNS(f,"height")};this.clearSelection=function(){var c;p&&(c=m.getElementById("imageSelector"))&&(c.style.display="none");p=!1};this.isSelectorElement=function(c){var b=m.getElementById("imageSelector");return b?c===b||c.parentNode===b:!1}};
 // Input 75
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -2165,6 +2241,9 @@ a(b):h.destroy(a)})};(function(){var e=h.getOdtDocument().getDOM();b=e.createEle
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2186,19 +2265,92 @@ a(b):h.destroy(a)})};(function(){var e=h.getOdtDocument().getDOM();b=e.createEle
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("gui.Caret");runtime.loadClass("ops.TrivialMemberModel");runtime.loadClass("ops.EditInfo");runtime.loadClass("gui.EditInfoMarker");gui.SessionViewOptions=function(){this.caretBlinksOnRangeSelect=this.caretAvatarsInitiallyVisible=this.editInfoMarkersInitiallyVisible=!0};
-gui.SessionView=function(){return function(h,m,f){function a(a,b,c){function d(b,c,e){c=b+'[editinfo|memberid^="'+a+'"]'+e+c;a:{var g=s.firstChild;for(b=b+'[editinfo|memberid^="'+a+'"]'+e;g;){if(g.nodeType===Node.TEXT_NODE&&0===g.data.indexOf(b)){b=g;break a}g=g.nextSibling}b=null}b?b.data=c:s.appendChild(document.createTextNode(c))}d("div.editInfoMarker","{ background-color: "+c+"; }","");d("span.editInfoColor","{ background-color: "+c+"; }","");d("span.editInfoAuthor",'{ content: "'+b+'"; }',":before");
-d("dc|creator",'{ content: "'+b+'"; display: none;}',":before");d("dc|creator","{ background-color: "+c+"; }","")}function c(a){var b,c;for(c in g)g.hasOwnProperty(c)&&(b=g[c],a?b.show():b.hide())}function d(a){f.getCarets().forEach(function(b){a?b.showHandle():b.hideHandle()})}function b(b,c){var d=f.getCaret(b);c?(d&&(d.setAvatarImageUrl(c.imageurl),d.setColor(c.color)),a(b,c.fullname,c.color)):runtime.log('MemberModel sent undefined data for member "'+b+'".')}function k(a){var c=a.getMemberId(),
-d=m.getMemberModel();f.registerCursor(a,u,q);b(c,null);d.getMemberDetailsAndUpdates(c,b);runtime.log("+++ View here +++ eagerly created an Caret for '"+c+"'! +++")}function p(a){var c=!1,d;for(d in g)if(g.hasOwnProperty(d)&&g[d].getEditInfo().getEdits().hasOwnProperty(a)){c=!0;break}c||m.getMemberModel().unsubscribeMemberDetailsUpdates(a,b)}function e(a){var b=a.paragraphElement,c=a.memberId;a=a.timeStamp;var d,e="",f=b.getElementsByTagNameNS(n,"editinfo")[0];f?(e=f.getAttributeNS(n,"id"),d=g[e]):
-(e=Math.random().toString(),d=new ops.EditInfo(b,m.getOdtDocument()),d=new gui.EditInfoMarker(d,l),f=b.getElementsByTagNameNS(n,"editinfo")[0],f.setAttributeNS(n,"id",e),g[e]=d);d.addEdit(c,new Date(a))}var s,n="urn:webodf:names:editinfo",g={},l=void 0!==h.editInfoMarkersInitiallyVisible?Boolean(h.editInfoMarkersInitiallyVisible):!0,u=void 0!==h.caretAvatarsInitiallyVisible?Boolean(h.caretAvatarsInitiallyVisible):!0,q=void 0!==h.caretBlinksOnRangeSelect?Boolean(h.caretBlinksOnRangeSelect):!0;this.showEditInfoMarkers=
-function(){l||(l=!0,c(l))};this.hideEditInfoMarkers=function(){l&&(l=!1,c(l))};this.showCaretAvatars=function(){u||(u=!0,d(u))};this.hideCaretAvatars=function(){u&&(u=!1,d(u))};this.getSession=function(){return m};this.getCaret=function(a){return f.getCaret(a)};this.destroy=function(a){var c=m.getOdtDocument(),d=m.getMemberModel(),h=Object.keys(g).map(function(a){return g[a]});c.unsubscribe(ops.OdtDocument.signalCursorAdded,k);c.unsubscribe(ops.OdtDocument.signalCursorRemoved,p);c.unsubscribe(ops.OdtDocument.signalParagraphChanged,
-e);f.getCarets().forEach(function(a){d.unsubscribeMemberDetailsUpdates(a.getCursor().getMemberId(),b)});s.parentNode.removeChild(s);(function v(b,c){c?a(c):b<h.length?h[b].destroy(function(a){v(b+1,a)}):a()})(0,void 0)};(function(){var a=m.getOdtDocument(),b=document.getElementsByTagName("head")[0];a.subscribe(ops.OdtDocument.signalCursorAdded,k);a.subscribe(ops.OdtDocument.signalCursorRemoved,p);a.subscribe(ops.OdtDocument.signalParagraphChanged,e);s=document.createElementNS(b.namespaceURI,"style");
-s.type="text/css";s.media="screen, print, handheld, projection";s.appendChild(document.createTextNode("@namespace editinfo url(urn:webodf:names:editinfo);"));s.appendChild(document.createTextNode("@namespace dc url(http://purl.org/dc/elements/1.1/);"));b.appendChild(s)})()}}();
+gui.TextManipulator=function(e,h,f){function n(c){var b=new ops.OpRemoveText;b.init({memberid:h,position:c.position,length:c.length});return b}function m(c){0>c.length&&(c.position+=c.length,c.length=-c.length);return c}var p=e.getOdtDocument();this.enqueueParagraphSplittingOps=function(){var c=m(p.getCursorSelection(h)),b,a=[];0<c.length&&(b=n(c),a.push(b));b=new ops.OpSplitParagraph;b.init({memberid:h,position:c.position});a.push(b);e.enqueue(a);return!0};this.removeTextByBackspaceKey=function(){var c=
+m(p.getCursorSelection(h)),b=null;0===c.length?0<c.position&&p.getPositionInTextNode(c.position-1)&&(b=new ops.OpRemoveText,b.init({memberid:h,position:c.position-1,length:1}),e.enqueue([b])):(b=n(c),e.enqueue([b]));return null!==b};this.removeTextByDeleteKey=function(){var c=m(p.getCursorSelection(h)),b=null;0===c.length?p.getPositionInTextNode(c.position+1)&&(b=new ops.OpRemoveText,b.init({memberid:h,position:c.position,length:1}),e.enqueue([b])):(b=n(c),e.enqueue([b]));return null!==b};this.removeCurrentSelection=
+function(){var c=m(p.getCursorSelection(h));0!==c.length&&(c=n(c),e.enqueue([c]));return!0};this.insertText=function(c){var b=m(p.getCursorSelection(h)),a,d=[];0<b.length&&(a=n(b),d.push(a));a=new ops.OpInsertText;a.init({memberid:h,position:b.position,text:c});d.push(a);f&&(c=f(b.position,c.length))&&d.push(c);e.enqueue(d)}};(function(){return gui.TextManipulator})();
 // Input 76
 /*
 
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("core.EventNotifier");runtime.loadClass("core.PositionFilter");runtime.loadClass("ops.OpAddAnnotation");runtime.loadClass("ops.OpRemoveAnnotation");runtime.loadClass("gui.SelectionMover");
+gui.AnnotationManager=function(e,h){function f(){var b=c.getCursor(h),b=b&&b.getNode(),e;if(e=b){a:{for(e=c.getRootNode();b&&b!==e;){if(b.namespaceURI===k&&"annotation"===b.localName){b=!0;break a}b=b.parentNode}b=!1}e=!b}b=e;b!==a&&(a=b,d.emit(gui.AnnotationManager.annotatableChanged,a))}function n(a){a.getMemberId()===h&&f()}function m(a){a===h&&f()}function p(a){a.getMemberId()===h&&f()}var c=e.getOdtDocument(),b=c.getPositionFilter(),a=!1,d=new core.EventNotifier([gui.AnnotationManager.annotatableChanged]),
+k=odf.Namespaces.officens,g=core.PositionFilter.FilterResult.FILTER_ACCEPT;this.isAnnotatable=function(){return a};this.addAnnotation=function(){var b=new ops.OpAddAnnotation,d=c.getCursorSelection(h),f=d.length,d=d.position;a&&(d=0<=f?d:d+f,f=Math.abs(f),b.init({memberid:h,position:d,length:f,name:h+Date.now()}),e.enqueue([b]))};this.removeAnnotation=function(a){var d,f;d=0;f=gui.SelectionMover.createPositionIterator(c.getRootNode());for(var k=new core.LoopWatchDog(1E3),m=!1;f.nextPosition();)if(k.check(),
+m=Boolean(a.compareDocumentPosition(f.container())&Node.DOCUMENT_POSITION_CONTAINED_BY),b.acceptPosition(f)===g){if(m)break;d+=1}f=0;k=gui.SelectionMover.createPositionIterator(c.getRootNode());m=!1;k.setUnfilteredPosition(a,0);do{m=Boolean(a.compareDocumentPosition(k.container())&Node.DOCUMENT_POSITION_CONTAINED_BY);if(!m&&a!==k.container())break;b.acceptPosition(k)===g&&(f+=1)}while(k.nextPosition());a=new ops.OpRemoveAnnotation;a.init({memberid:h,position:d,length:f});f=new ops.OpMoveCursor;f.init({memberid:h,
+position:d-1,length:0});e.enqueue([a,f])};this.subscribe=function(a,b){d.subscribe(a,b)};this.unsubscribe=function(a,b){d.unsubscribe(a,b)};this.destroy=function(a){c.unsubscribe(ops.OdtDocument.signalCursorAdded,n);c.unsubscribe(ops.OdtDocument.signalCursorRemoved,m);c.unsubscribe(ops.OdtDocument.signalCursorMoved,p);a()};c.subscribe(ops.OdtDocument.signalCursorAdded,n);c.subscribe(ops.OdtDocument.signalCursorRemoved,m);c.subscribe(ops.OdtDocument.signalCursorMoved,p);f()};
+gui.AnnotationManager.annotatableChanged="annotatable/changed";(function(){return gui.AnnotationManager})();
+// Input 77
+gui.EventManager=function(e){function h(a){var b=a.scrollX,c=a.scrollY;this.restore=function(){a.scrollX===b&&a.scrollY===c||a.scrollTo(b,c)}}function f(a){var b=a.scrollTop,c=a.scrollLeft;this.restore=function(){if(a.scrollTop!==b||a.scrollLeft!==c)a.scrollTop=b,a.scrollLeft=c}}function n(){return e.getDOM().activeElement===m}var m=e.getOdfCanvas().getElement(),p=runtime.getWindow(),c={beforecut:!0,beforepaste:!0},b={mousedown:!0,mouseup:!0};this.subscribe=function(a,d){var e=m;b[a]&&p&&(e=p);var f=
+"on"+a,h=!1;e.attachEvent&&(h=e.attachEvent(f,d));!h&&e.addEventListener&&(e.addEventListener(a,d,!1),h=!0);h&&!c[a]||!e.hasOwnProperty(f)||(e[f]=d)};this.unsubscribe=function(a,c){var e=m;b[a]&&p&&(e=p);var f="on"+a;e.detachEvent&&e.detachEvent(f,c);e.removeEventListener&&e.removeEventListener(a,c,!1);e[f]===c&&(e[f]=null)};this.hasFocus=n;this.focus=function(){var a;if(!n()){for(a=m;a&&!a.scrollTop&&!a.scrollLeft;)a=a.parentNode;a=a?new f(a):p?new h(p):null;m.focus();a&&a.restore()}}};
+// Input 78
+runtime.loadClass("core.DomUtils");runtime.loadClass("core.Async");runtime.loadClass("core.ScheduledTask");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.ObjectNameGenerator");runtime.loadClass("ops.OdtCursor");runtime.loadClass("ops.OpAddCursor");runtime.loadClass("ops.OpRemoveCursor");runtime.loadClass("gui.Clipboard");runtime.loadClass("gui.DirectTextStyler");runtime.loadClass("gui.DirectParagraphStyler");runtime.loadClass("gui.KeyboardHandler");runtime.loadClass("gui.ImageManager");
+runtime.loadClass("gui.ImageSelector");runtime.loadClass("gui.TextManipulator");runtime.loadClass("gui.AnnotationManager");runtime.loadClass("gui.EventManager");
+gui.SessionController=function(){var e=core.PositionFilter.FilterResult.FILTER_ACCEPT;gui.SessionController=function(h,f,n,m){function p(a){a.preventDefault?a.preventDefault():a.returnValue=!1}function c(a,b,c){var d=new ops.OpMoveCursor;d.init({memberid:f,position:a,length:b||0,selectionType:c});return d}function b(a){var b=F.getOdfCanvas().getElement(),c=F.getRootNode(),d=0;b.compareDocumentPosition(a)&Node.DOCUMENT_POSITION_PRECEDING||(a=gui.SelectionMover.createPositionIterator(c),a.moveToEnd(),
+c=a.container(),d=a.unfilteredDomOffset());return{node:c,offset:d}}function a(a){a=F.getDistanceFromCursor(f,a,0);var b=null!==a?a+1:null,d;if(b||a)d=F.getCursorPosition(f),a=c(d+a,b-a,ops.OdtCursor.RegionSelection),h.enqueue([a]);X.focus()}function d(a,d){var e,g,k,l;g=F.getOdfCanvas().getElement();e=d.detail;if(a){if(!a.anchorNode&&!a.focusNode){k=d.clientX;l=d.clientY;var m=F.getDOM();m.caretRangeFromPoint?(k=m.caretRangeFromPoint(k,l),k={container:k.startContainer,offset:k.startOffset}):m.caretPositionFromPoint?
+(k=m.caretPositionFromPoint(k,l),k={container:k.offsetNode,offset:k.offset}):k=null;if(!k)return;a.anchorNode=k.container;a.anchorOffset=k.offset;a.focusNode=a.anchorNode;a.focusOffset=a.anchorOffset}runtime.assert(null!==a.anchorNode&&null!==a.focusNode,"anchorNode or focusNode is null");k=Y.containsNode(g,a.anchorNode);g=Y.containsNode(g,a.focusNode);if(k||g){k||(k=b(a.anchorNode),a.anchorNode=k.node,a.anchorOffset=k.offset);g||(k=b(a.focusNode),a.focusNode=k.node,a.focusOffset=k.offset);if(2===
+e){var m=/[A-Za-z0-9]/,n=gui.SelectionMover.createPositionIterator(F.getRootNode()),p=0<Y.comparePoints(a.anchorNode,a.anchorOffset,a.focusNode,a.focusOffset),t;p?(k=a.anchorNode,l=a.anchorOffset,e=a.focusNode,g=a.focusOffset):(k=a.focusNode,l=a.focusOffset,e=a.anchorNode,g=a.anchorOffset);for(n.setUnfilteredPosition(k,l);n.previousPosition();){t=n.getCurrentNode();if(t.nodeType===Node.TEXT_NODE){if(t=t.data[n.unfilteredDomOffset()],!m.test(t))break}else if(!ba.isTextSpan(t))break;k=n.container();
+l=n.unfilteredDomOffset()}n.setUnfilteredPosition(e,g);do if(t=n.getCurrentNode(),t.nodeType===Node.TEXT_NODE){if(t=t.data[n.unfilteredDomOffset()],!m.test(t))break}else if(!ba.isTextSpan(t))break;while(n.nextPosition());e=n.container();g=n.unfilteredDomOffset();p?(a.anchorNode=k,a.anchorOffset=l,a.focusNode=e,a.focusOffset=g):(a.focusNode=k,a.focusOffset=l,a.anchorNode=e,a.anchorOffset=g)}else 3===e&&(e=F.getParagraphElement(a.anchorNode),g=F.getParagraphElement(a.focusNode),e&&(a.anchorNode=e,a.anchorOffset=
+0),g&&(a.focusNode=g,a.focusOffset=g.childNodes.length));e=F.getDistanceFromCursor(f,a.anchorNode,a.anchorOffset);if((g=a.focusNode===a.anchorNode&&a.focusOffset===a.anchorOffset?e:F.getDistanceFromCursor(f,a.focusNode,a.focusOffset))||e)k=F.getCursorPosition(f),e=c(k+e,g-e,ops.OdtCursor.RangeSelection),h.enqueue([e]);X.focus()}}}function k(a){var b=F.getCursorSelection(f),d=F.getCursor(f).getStepCounter();0!==a&&(a=0<a?d.convertForwardStepsBetweenFilters(a,pa,ma):-d.convertBackwardStepsBetweenFilters(-a,
+pa,ma),a=b.length+a,h.enqueue([c(b.position,a)]))}function g(a){var b=F.getCursorPosition(f),d=F.getCursor(f).getStepCounter();0!==a&&(a=0<a?d.convertForwardStepsBetweenFilters(a,pa,ma):-d.convertBackwardStepsBetweenFilters(-a,pa,ma),h.enqueue([c(b+a,0)]))}function q(){g(-1);return!0}function l(){g(1);return!0}function r(){k(-1);return!0}function t(){k(1);return!0}function w(a,b){var c=F.getParagraphElement(F.getCursor(f).getNode());runtime.assert(Boolean(c),"SessionController: Cursor outside paragraph");
+c=F.getCursor(f).getStepCounter().countLinesSteps(a,pa);b?k(c):g(c)}function v(){w(-1,!1);return!0}function y(){w(1,!1);return!0}function x(){w(-1,!0);return!0}function u(){w(1,!0);return!0}function s(a,b){var c=F.getCursor(f).getStepCounter().countStepsToLineBoundary(a,pa);b?k(c):g(c)}function C(){s(-1,!1);return!0}function B(){s(1,!1);return!0}function A(){s(-1,!0);return!0}function I(){s(1,!0);return!0}function z(){var a=F.getParagraphElement(F.getCursor(f).getNode()),b,c;runtime.assert(Boolean(a),
+"SessionController: Cursor outside paragraph");c=F.getDistanceFromCursor(f,a,0);b=gui.SelectionMover.createPositionIterator(F.getRootNode());for(b.setUnfilteredPosition(a,0);0===c&&b.previousPosition();)a=b.getCurrentNode(),ba.isParagraph(a)&&(c=F.getDistanceFromCursor(f,a,0));k(c);return!0}function N(){var a=F.getParagraphElement(F.getCursor(f).getNode()),b,c;runtime.assert(Boolean(a),"SessionController: Cursor outside paragraph");b=gui.SelectionMover.createPositionIterator(F.getRootNode());b.moveToEndOfNode(a);
+for(c=F.getDistanceFromCursor(f,b.container(),b.unfilteredDomOffset());0===c&&b.nextPosition();)a=b.getCurrentNode(),ba.isParagraph(a)&&(b.moveToEndOfNode(a),c=F.getDistanceFromCursor(f,b.container(),b.unfilteredDomOffset()));k(c);return!0}function G(a,b){var c=gui.SelectionMover.createPositionIterator(F.getRootNode());0<a&&c.moveToEnd();c=F.getDistanceFromCursor(f,c.container(),c.unfilteredDomOffset());b?k(c):g(c)}function R(){G(-1,!1);return!0}function Z(){G(1,!1);return!0}function ka(){G(-1,!0);
+return!0}function T(){G(1,!0);return!0}function ra(){var a=gui.SelectionMover.createPositionIterator(F.getRootNode()),b;b=-F.getDistanceFromCursor(f,a.container(),a.unfilteredDomOffset());a.moveToEnd();b+=F.getDistanceFromCursor(f,a.container(),a.unfilteredDomOffset());h.enqueue([c(0,b)]);return!0}function $(){var a=F.getCursor(f),b=fa.getSelection(),c;a?(va.clearSelection(),a.getSelectionType()===ops.OdtCursor.RegionSelection&&(c=ba.getImageElements(a.getSelectedRange())[0])&&va.select(c.parentNode),
+X.hasFocus()&&(c=a.getSelectedRange(),b.extend?a.hasForwardSelection()?(b.collapse(c.startContainer,c.startOffset),b.extend(c.endContainer,c.endOffset)):(b.collapse(c.endContainer,c.endOffset),b.extend(c.startContainer,c.startOffset)):(b.removeAllRanges(),b.addRange(c.cloneRange())))):va.clearSelection()}function ha(){runtime.setTimeout($,0)}function U(a){var b=F.getCursor(f);b.getSelectedRange().collapsed||(la.setDataFromRange(a,b.getSelectedRange())?qa.removeCurrentSelection():runtime.log("Cut operation failed"))}
+function O(){return!1!==F.getCursor(f).getSelectedRange().collapsed}function W(a){var b=F.getCursor(f);b.getSelectedRange().collapsed||la.setDataFromRange(a,b.getSelectedRange())||runtime.log("Cut operation failed")}function E(a){var b;fa.clipboardData&&fa.clipboardData.getData?b=fa.clipboardData.getData("Text"):a.clipboardData&&a.clipboardData.getData&&(b=a.clipboardData.getData("text/plain"));b&&(qa.insertText(b),a.preventDefault?a.preventDefault():a.returnValue=!1)}function H(){return!1}function M(a){if(ca)ca.onOperationExecuted(a)}
+function S(a){F.emit(ops.OdtDocument.signalUndoStackChanged,a)}function P(){return ca?(ca.moveBackward(1),$(),!0):!1}function aa(){return ca?(ca.moveForward(1),$(),!0):!1}function na(a){if(ya=(a=a.target||a.srcElement)&&Y.containsNode(F.getOdfCanvas().getElement(),a))ta=!1,xa=F.createRootFilter(a)}function da(a){var b=a.getSelectedRange();return a.hasForwardSelection()?{anchorNode:b.startContainer,anchorOffset:b.startOffset,focusNode:b.endContainer,focusOffset:b.endOffset}:{anchorNode:b.endContainer,
+anchorOffset:b.endOffset,focusNode:b.startContainer,focusOffset:b.startOffset}}function V(b){var c=b.target||b.srcElement,e={detail:b.detail,clientX:b.clientX,clientY:b.clientY,target:c};ua.processRequests();ba.isImage(c)&&ba.isCharacterFrame(c.parentNode)?a(c.parentNode):ya&&!va.isSelectorElement(c)&&(ta?d(da(n),b):runtime.setTimeout(function(){var a;a=(a=fa.getSelection())?{anchorNode:a.anchorNode,anchorOffset:a.anchorOffset,focusNode:a.focusNode,focusOffset:a.focusOffset}:null;d(a,e)},0));ta=ya=
+!1}function Q(a){V(a)}function J(a){var b=a.target||a.srcElement,c=null;"annotationRemoveButton"===b.className?(c=Y.getElementsByTagNameNS(b.parentNode,odf.Namespaces.officens,"annotation")[0],ga.removeAnnotation(c)):V(a)}function ea(){var a=fa.getSelection(),b;ya&&0<a.rangeCount&&(ta=!0,va.clearSelection(),wa.setUnfilteredPosition(a.focusNode,a.focusOffset),xa.acceptPosition(wa)===e&&(b=a.getRangeAt(0).cloneRange(),a=a.anchorNode===b.startContainer&&a.anchorOffset===b.startOffset,n.setSelectedRange(b,
+a),F.emit(ops.OdtDocument.signalCursorMoved,n)))}function oa(a){return function(){a();return!0}}function D(a){return function(b){return F.getCursor(f).getSelectionType()===ops.OdtCursor.RangeSelection?a(b):!0}}var fa=runtime.getWindow(),F=h.getOdtDocument(),ia=new core.Async,Y=new core.DomUtils,ba=new odf.OdfUtils,la=new gui.Clipboard,L=new gui.KeyboardHandler,sa=new gui.KeyboardHandler,pa=new core.PositionFilterChain,ma=F.getPositionFilter(),ya=!1,za=new odf.ObjectNameGenerator(F.getOdfCanvas().odfContainer(),
+f),ta=!1,xa=null,ca=null,X=new gui.EventManager(F),ga=new gui.AnnotationManager(h,f),K=m&&m.directStylingEnabled?new gui.DirectTextStyler(h,f):null,ja=m&&m.directStylingEnabled?new gui.DirectParagraphStyler(h,f,za):null,qa=new gui.TextManipulator(h,f,K&&K.createCursorStyleOp),Aa=new gui.ImageManager(h,f,za),va=new gui.ImageSelector(F.getOdfCanvas()),wa=gui.SelectionMover.createPositionIterator(F.getRootNode()),ua;runtime.assert(null!==fa,"Expected to be run in an environment which has a global window, like a browser.");
+pa.addFilter("BaseFilter",ma);pa.addFilter("RootFilter",F.createRootFilter(f));this.startEditing=function(){var a;F.getOdfCanvas().getElement().classList.add("virtualSelections");X.subscribe("keydown",L.handleEvent);X.subscribe("keypress",sa.handleEvent);X.subscribe("keyup",p);X.subscribe("beforecut",O);X.subscribe("cut",U);X.subscribe("copy",W);X.subscribe("beforepaste",H);X.subscribe("paste",E);X.subscribe("mousedown",na);X.subscribe("mousemove",ua.trigger);X.subscribe("mouseup",J);X.subscribe("contextmenu",
+Q);X.subscribe("focus",ha);F.subscribe(ops.OdtDocument.signalOperationExecuted,$);F.subscribe(ops.OdtDocument.signalOperationExecuted,M);a=new ops.OpAddCursor;a.init({memberid:f});h.enqueue([a]);ca&&ca.saveInitialState()};this.endEditing=function(){var a;a=new ops.OpRemoveCursor;a.init({memberid:f});h.enqueue([a]);ca&&ca.resetInitialState();F.unsubscribe(ops.OdtDocument.signalOperationExecuted,M);F.unsubscribe(ops.OdtDocument.signalOperationExecuted,$);X.unsubscribe("keydown",L.handleEvent);X.unsubscribe("keypress",
+sa.handleEvent);X.unsubscribe("keyup",p);X.unsubscribe("cut",U);X.unsubscribe("beforecut",O);X.unsubscribe("copy",W);X.unsubscribe("paste",E);X.unsubscribe("beforepaste",H);X.unsubscribe("mousemove",ua.trigger);X.unsubscribe("mousedown",na);X.unsubscribe("mouseup",J);X.unsubscribe("contextmenu",Q);X.unsubscribe("focus",ha);F.getOdfCanvas().getElement().classList.remove("virtualSelections")};this.getInputMemberId=function(){return f};this.getSession=function(){return h};this.setUndoManager=function(a){ca&&
+ca.unsubscribe(gui.UndoManager.signalUndoStackChanged,S);if(ca=a)ca.setOdtDocument(F),ca.setPlaybackFunction(function(a){a.execute(F)}),ca.subscribe(gui.UndoManager.signalUndoStackChanged,S)};this.getUndoManager=function(){return ca};this.getAnnotationManager=function(){return ga};this.getDirectTextStyler=function(){return K};this.getDirectParagraphStyler=function(){return ja};this.getImageManager=function(){return Aa};this.getTextManipulator=function(){return qa};this.getEventManager=function(){return X};
+this.getKeyboardHandlers=function(){return{keydown:L,keypress:sa}};this.destroy=function(a){var b=[ua.destroy];K&&b.push(K.destroy);ja&&b.push(ja.destroy);ia.destroyAll(b,a)};(function(){var a=-1!==fa.navigator.appVersion.toLowerCase().indexOf("mac"),b=gui.KeyboardHandler.Modifier,c=gui.KeyboardHandler.KeyCode;ua=new core.ScheduledTask(ea,0);L.bind(c.Tab,b.None,D(function(){qa.insertText("\t");return!0}));L.bind(c.Left,b.None,D(q));L.bind(c.Right,b.None,D(l));L.bind(c.Up,b.None,D(v));L.bind(c.Down,
+b.None,D(y));L.bind(c.Backspace,b.None,oa(qa.removeTextByBackspaceKey));L.bind(c.Delete,b.None,qa.removeTextByDeleteKey);L.bind(c.Left,b.Shift,D(r));L.bind(c.Right,b.Shift,D(t));L.bind(c.Up,b.Shift,D(x));L.bind(c.Down,b.Shift,D(u));L.bind(c.Home,b.None,D(C));L.bind(c.End,b.None,D(B));L.bind(c.Home,b.Ctrl,D(R));L.bind(c.End,b.Ctrl,D(Z));L.bind(c.Home,b.Shift,D(A));L.bind(c.End,b.Shift,D(I));L.bind(c.Up,b.CtrlShift,D(z));L.bind(c.Down,b.CtrlShift,D(N));L.bind(c.Home,b.CtrlShift,D(ka));L.bind(c.End,
+b.CtrlShift,D(T));a?(L.bind(c.Clear,b.None,qa.removeCurrentSelection),L.bind(c.Left,b.Meta,D(C)),L.bind(c.Right,b.Meta,D(B)),L.bind(c.Home,b.Meta,D(R)),L.bind(c.End,b.Meta,D(Z)),L.bind(c.Left,b.MetaShift,D(A)),L.bind(c.Right,b.MetaShift,D(I)),L.bind(c.Up,b.AltShift,D(z)),L.bind(c.Down,b.AltShift,D(N)),L.bind(c.Up,b.MetaShift,D(ka)),L.bind(c.Down,b.MetaShift,D(T)),L.bind(c.A,b.Meta,D(ra)),K&&(L.bind(c.B,b.Meta,D(K.toggleBold)),L.bind(c.I,b.Meta,D(K.toggleItalic)),L.bind(c.U,b.Meta,D(K.toggleUnderline))),
+ja&&(L.bind(c.L,b.MetaShift,D(ja.alignParagraphLeft)),L.bind(c.E,b.MetaShift,D(ja.alignParagraphCenter)),L.bind(c.R,b.MetaShift,D(ja.alignParagraphRight)),L.bind(c.J,b.MetaShift,D(ja.alignParagraphJustified))),ga&&L.bind(c.C,b.MetaShift,ga.addAnnotation),L.bind(c.Z,b.Meta,P),L.bind(c.Z,b.MetaShift,aa)):(L.bind(c.A,b.Ctrl,D(ra)),K&&(L.bind(c.B,b.Ctrl,D(K.toggleBold)),L.bind(c.I,b.Ctrl,D(K.toggleItalic)),L.bind(c.U,b.Ctrl,D(K.toggleUnderline))),ja&&(L.bind(c.L,b.CtrlShift,D(ja.alignParagraphLeft)),
+L.bind(c.E,b.CtrlShift,D(ja.alignParagraphCenter)),L.bind(c.R,b.CtrlShift,D(ja.alignParagraphRight)),L.bind(c.J,b.CtrlShift,D(ja.alignParagraphJustified))),ga&&L.bind(c.C,b.CtrlAlt,ga.addAnnotation),L.bind(c.Z,b.Ctrl,P),L.bind(c.Z,b.CtrlShift,aa));sa.setDefault(D(function(a){var b;b=null===a.which||void 0===a.which?String.fromCharCode(a.keyCode):0!==a.which&&0!==a.charCode?String.fromCharCode(a.which):null;return!b||a.altKey||a.ctrlKey||a.metaKey?!1:(qa.insertText(b),!0)}));sa.bind(c.Enter,b.None,
+D(qa.enqueueParagraphSplittingOps))})()};return gui.SessionController}();
+// Input 79
+/*
+
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
@@ -2209,62 +2361,8 @@ s.type="text/css";s.media="screen, print, handheld, projection";s.appendChild(do
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
- As additional permission under GNU AGPL version 3 section 7, you
- may distribute non-source (e.g., minimized or compacted) forms of
- that code without the copy of the GNU GPL normally required by
- section 4, provided you include this license notice and a URL
- through which recipients can access the Corresponding Source.
-
- As a special exception to the AGPL, any HTML file which merely makes function
- calls to this code, and for that purpose includes it by reference shall be
- deemed a separate work for copyright law purposes. In addition, the copyright
- holders of this code give you permission to combine this code with free
- software libraries that are released under the GNU LGPL. You may copy and
- distribute such a system following the terms of the GNU AGPL for this code
- and the LGPL for the libraries. If you modify this code, you may extend this
- exception to your version of the code, but you are not obligated to do so.
- If you do not wish to do so, delete this exception statement from your
- version.
-
- This license applies to this entire compilation.
- @licend
- @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
-*/
-runtime.loadClass("gui.Caret");
-gui.CaretManager=function(h){function m(a){return n.hasOwnProperty(a)?n[a]:null}function f(){return Object.keys(n).map(function(a){return n[a]})}function a(){return h.getSession().getOdtDocument().getOdfCanvas().getElement()}function c(b){b===h.getInputMemberId()&&a().removeAttribute("tabindex");delete n[b]}function d(a){a=a.getMemberId();a===h.getInputMemberId()&&(a=m(a))&&a.refreshCursorBlinking()}function b(a){a.memberId===h.getInputMemberId()&&(a=m(a.memberId))&&a.ensureVisible()}function k(){var a=
-m(h.getInputMemberId());a&&a.setFocus()}function p(){var a=m(h.getInputMemberId());a&&a.removeFocus()}function e(){var a=m(h.getInputMemberId());a&&a.show()}function s(){var a=m(h.getInputMemberId());a&&a.hide()}var n={},g=runtime.getWindow();this.registerCursor=function(b,c,d){var e=b.getMemberId(),g=a();c=new gui.Caret(b,c,d);n[e]=c;e===h.getInputMemberId()&&(runtime.log("Starting to track input on new cursor of "+e),b.handleUpdate=c.ensureVisible,g.setAttribute("tabindex",0),g.focus());return c};
-this.getCaret=m;this.getCarets=f;this.destroy=function(l){var m=h.getSession().getOdtDocument(),q=a(),n=f();m.unsubscribe(ops.OdtDocument.signalParagraphChanged,b);m.unsubscribe(ops.OdtDocument.signalCursorMoved,d);m.unsubscribe(ops.OdtDocument.signalCursorRemoved,c);q.removeEventListener("focus",k,!1);q.removeEventListener("blur",p,!1);g.removeEventListener("focus",e,!1);g.removeEventListener("blur",s,!1);(function y(a,b){b?l(b):a<n.length?n[a].destroy(function(b){y(a+1,b)}):l()})(0,void 0)};(function(){var f=
-h.getSession().getOdtDocument(),m=a();f.subscribe(ops.OdtDocument.signalParagraphChanged,b);f.subscribe(ops.OdtDocument.signalCursorMoved,d);f.subscribe(ops.OdtDocument.signalCursorRemoved,c);m.addEventListener("focus",k,!1);m.addEventListener("blur",p,!1);g.addEventListener("focus",e,!1);g.addEventListener("blur",s,!1)})()};
-// Input 77
-runtime.loadClass("xmldom.XPath");runtime.loadClass("odf.Namespaces");
-gui.PresenterUI=function(){var h=new xmldom.XPath,m=runtime.getWindow();return function(f){var a=this;a.setInitialSlideMode=function(){a.startSlideMode("single")};a.keyDownHandler=function(c){if(!c.target.isContentEditable&&"input"!==c.target.nodeName)switch(c.keyCode){case 84:a.toggleToolbar();break;case 37:case 8:a.prevSlide();break;case 39:case 32:a.nextSlide();break;case 36:a.firstSlide();break;case 35:a.lastSlide()}};a.root=function(){return a.odf_canvas.odfContainer().rootElement};a.firstSlide=
-function(){a.slideChange(function(a,d){return 0})};a.lastSlide=function(){a.slideChange(function(a,d){return d-1})};a.nextSlide=function(){a.slideChange(function(a,d){return a+1<d?a+1:-1})};a.prevSlide=function(){a.slideChange(function(a,d){return 1>a?-1:a-1})};a.slideChange=function(c){var d=a.getPages(a.odf_canvas.odfContainer().rootElement),b=-1,f=0;d.forEach(function(a){a=a[1];a.hasAttribute("slide_current")&&(b=f,a.removeAttribute("slide_current"));f+=1});c=c(b,d.length);-1===c&&(c=b);d[c][1].setAttribute("slide_current",
-"1");document.getElementById("pagelist").selectedIndex=c;"cont"===a.slide_mode&&m.scrollBy(0,d[c][1].getBoundingClientRect().top-30)};a.selectSlide=function(c){a.slideChange(function(a,b){return c>=b||0>c?-1:c})};a.scrollIntoContView=function(c){var d=a.getPages(a.odf_canvas.odfContainer().rootElement);0!==d.length&&m.scrollBy(0,d[c][1].getBoundingClientRect().top-30)};a.getPages=function(a){a=a.getElementsByTagNameNS(odf.Namespaces.drawns,"page");var d=[],b;for(b=0;b<a.length;b+=1)d.push([a[b].getAttribute("draw:name"),
-a[b]]);return d};a.fillPageList=function(c,d){for(var b=a.getPages(c),f,m,e;d.firstChild;)d.removeChild(d.firstChild);for(f=0;f<b.length;f+=1)m=document.createElement("option"),e=h.getODFElementsWithXPath(b[f][1],'./draw:frame[@presentation:class="title"]//draw:text-box/text:p',xmldom.XPath),e=0<e.length?e[0].textContent:b[f][0],m.textContent=f+1+": "+e,d.appendChild(m)};a.startSlideMode=function(c){var d=document.getElementById("pagelist"),b=a.odf_canvas.slidevisibilitycss().sheet;for(a.slide_mode=
-c;0<b.cssRules.length;)b.deleteRule(0);a.selectSlide(0);"single"===a.slide_mode?(b.insertRule("draw|page { position:fixed; left:0px;top:30px; z-index:1; }",0),b.insertRule("draw|page[slide_current]  { z-index:2;}",1),b.insertRule("draw|page  { -webkit-transform: scale(1);}",2),a.fitToWindow(),m.addEventListener("resize",a.fitToWindow,!1)):"cont"===a.slide_mode&&m.removeEventListener("resize",a.fitToWindow,!1);a.fillPageList(a.odf_canvas.odfContainer().rootElement,d)};a.toggleToolbar=function(){var c,
-d,b;c=a.odf_canvas.slidevisibilitycss().sheet;d=-1;for(b=0;b<c.cssRules.length;b+=1)if(".toolbar"===c.cssRules[b].cssText.substring(0,8)){d=b;break}-1<d?c.deleteRule(d):c.insertRule(".toolbar { position:fixed; left:0px;top:-200px; z-index:0; }",0)};a.fitToWindow=function(){var c=a.getPages(a.root()),d=(m.innerHeight-40)/c[0][1].clientHeight,c=(m.innerWidth-10)/c[0][1].clientWidth,d=d<c?d:c,c=a.odf_canvas.slidevisibilitycss().sheet;c.deleteRule(2);c.insertRule("draw|page { \n-moz-transform: scale("+
-d+"); \n-moz-transform-origin: 0% 0%; -webkit-transform-origin: 0% 0%; -webkit-transform: scale("+d+"); -o-transform-origin: 0% 0%; -o-transform: scale("+d+"); -ms-transform-origin: 0% 0%; -ms-transform: scale("+d+"); }",2)};a.load=function(c){a.odf_canvas.load(c)};a.odf_element=f;a.odf_canvas=new odf.OdfCanvas(a.odf_element);a.odf_canvas.addListener("statereadychange",a.setInitialSlideMode);a.slide_mode="undefined";document.addEventListener("keydown",a.keyDownHandler,!1)}}();
-// Input 78
-runtime.loadClass("core.PositionIterator");runtime.loadClass("core.Cursor");
-gui.XMLEdit=function(h,m){function f(a,b,c){a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent?a.attachEvent("on"+b,c):a["on"+b]=c}function a(a){a.preventDefault?a.preventDefault():a.returnValue=!1}function c(){var a=h.ownerDocument.defaultView.getSelection();!a||(0>=a.rangeCount||!u)||(a=a.getRangeAt(0),u.setPoint(a.startContainer,a.startOffset))}function d(){var a=h.ownerDocument.defaultView.getSelection(),b,c;a.removeAllRanges();u&&u.node()&&(b=u.node(),c=b.ownerDocument.createRange(),
-c.setStart(b,u.position()),c.collapse(!0),a.addRange(c))}function b(b){var e=b.charCode||b.keyCode;if(u=null,u&&37===e)c(),u.stepBackward(),d();else if(16<=e&&20>=e||33<=e&&40>=e)return;a(b)}function k(b){a(b)}function p(a){for(var b=a.firstChild;b&&b!==a;)b.nodeType===Node.ELEMENT_NODE&&p(b),b=b.nextSibling||b.parentNode;var c,d,e,b=a.attributes;c="";for(e=b.length-1;0<=e;e-=1)d=b.item(e),c=c+" "+d.nodeName+'="'+d.nodeValue+'"';a.setAttribute("customns_name",a.nodeName);a.setAttribute("customns_atts",
-c);b=a.firstChild;for(d=/^\s*$/;b&&b!==a;)c=b,b=b.nextSibling||b.parentNode,c.nodeType===Node.TEXT_NODE&&d.test(c.nodeValue)&&c.parentNode.removeChild(c)}function e(a,b){for(var c=a.firstChild,d,f,g;c&&c!==a;){if(c.nodeType===Node.ELEMENT_NODE)for(e(c,b),d=c.attributes,g=d.length-1;0<=g;g-=1)f=d.item(g),"http://www.w3.org/2000/xmlns/"!==f.namespaceURI||b[f.nodeValue]||(b[f.nodeValue]=f.localName);c=c.nextSibling||c.parentNode}}function s(){var a=h.ownerDocument.createElement("style"),b;b={};e(h,b);
-var c={},d,f,g=0;for(d in b)if(b.hasOwnProperty(d)&&d){f=b[d];if(!f||c.hasOwnProperty(f)||"xmlns"===f){do f="ns"+g,g+=1;while(c.hasOwnProperty(f));b[d]=f}c[f]=!0}a.type="text/css";b="@namespace customns url(customns);\n"+n;a.appendChild(h.ownerDocument.createTextNode(b));m=m.parentNode.replaceChild(a,m)}var n,g,l,u=null;h.id||(h.id="xml"+String(Math.random()).substring(2));g="#"+h.id+" ";n=g+"*,"+g+":visited, "+g+":link {display:block; margin: 0px; margin-left: 10px; font-size: medium; color: black; background: white; font-variant: normal; font-weight: normal; font-style: normal; font-family: sans-serif; text-decoration: none; white-space: pre-wrap; height: auto; width: auto}\n"+
-g+":before {color: blue; content: '<' attr(customns_name) attr(customns_atts) '>';}\n"+g+":after {color: blue; content: '</' attr(customns_name) '>';}\n"+g+"{overflow: auto;}\n";(function(c){f(c,"click",k);f(c,"keydown",b);f(c,"drop",a);f(c,"dragend",a);f(c,"beforepaste",a);f(c,"paste",a)})(h);this.updateCSS=s;this.setXML=function(a){a=a.documentElement||a;l=a=h.ownerDocument.importNode(a,!0);for(p(a);h.lastChild;)h.removeChild(h.lastChild);h.appendChild(a);s();u=new core.PositionIterator(a)};this.getXML=
-function(){return l}};
-// Input 79
-/*
-
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
-
- @licstart
- The JavaScript code in this page is free software: you can redistribute it
- and/or modify it under the terms of the GNU Affero General Public License
- (GNU AGPL) as published by the Free Software Foundation, either version 3 of
- the License, or (at your option) any later version.  The code is distributed
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2286,14 +2384,13 @@ function(){return l}};
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-gui.UndoManager=function(){};gui.UndoManager.prototype.subscribe=function(h,m){};gui.UndoManager.prototype.unsubscribe=function(h,m){};gui.UndoManager.prototype.setOdtDocument=function(h){};gui.UndoManager.prototype.saveInitialState=function(){};gui.UndoManager.prototype.resetInitialState=function(){};gui.UndoManager.prototype.setPlaybackFunction=function(h){};gui.UndoManager.prototype.hasUndoStates=function(){};gui.UndoManager.prototype.hasRedoStates=function(){};
-gui.UndoManager.prototype.moveForward=function(h){};gui.UndoManager.prototype.moveBackward=function(h){};gui.UndoManager.prototype.onOperationExecuted=function(h){};gui.UndoManager.signalUndoStackChanged="undoStackChanged";gui.UndoManager.signalUndoStateCreated="undoStateCreated";gui.UndoManager.signalUndoStateModified="undoStateModified";(function(){return gui.UndoManager})();
+ops.MemberModel=function(){};ops.MemberModel.prototype.getMemberDetailsAndUpdates=function(e,h){};ops.MemberModel.prototype.unsubscribeMemberDetailsUpdates=function(e,h){};ops.MemberModel.prototype.close=function(e){};
 // Input 80
 /*
 
- Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -2302,6 +2399,9 @@ gui.UndoManager.prototype.moveForward=function(h){};gui.UndoManager.prototype.mo
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2323,10 +2423,9 @@ gui.UndoManager.prototype.moveForward=function(h){};gui.UndoManager.prototype.mo
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-gui.UndoStateRules=function(){function h(f){return f.spec().optype}function m(f){switch(h(f)){case "MoveCursor":case "AddCursor":case "RemoveCursor":return!1;default:return!0}}this.getOpType=h;this.isEditOperation=m;this.isPartOfOperationSet=function(f,a){if(m(f)){if(0===a.length)return!0;var c;if(c=m(a[a.length-1]))a:{c=a.filter(m);var d=h(f),b;b:switch(d){case "RemoveText":case "InsertText":b=!0;break b;default:b=!1}if(b&&d===h(c[0])){if(1===c.length){c=!0;break a}d=c[c.length-2].spec().position;
-c=c[c.length-1].spec().position;b=f.spec().position;if(c===b-(c-d)){c=!0;break a}}c=!1}return c}return!0}};
+ops.TrivialMemberModel=function(){this.getMemberDetailsAndUpdates=function(e,h){h(e,{memberid:e,fullname:runtime.tr("Unknown Author"),color:"black",imageurl:"avatar-joe.png"})};this.unsubscribeMemberDetailsUpdates=function(e,h){};this.close=function(e){e()}};
 // Input 81
 /*
 
@@ -2340,6 +2439,9 @@ c=c[c.length-1].spec().position;b=f.spec().position;if(c===b-(c-d)){c=!0;break a
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -2360,19 +2462,13 @@ c=c[c.length-1].spec().position;b=f.spec().position;if(c===b-(c-d)){c=!0;break a
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.DomUtils");runtime.loadClass("gui.UndoManager");runtime.loadClass("gui.UndoStateRules");
-gui.TrivialUndoManager=function(h){function m(){q.emit(gui.UndoManager.signalUndoStackChanged,{undoAvailable:b.hasUndoStates(),redoAvailable:b.hasRedoStates()})}function f(){g!==e&&g!==l[l.length-1]&&l.push(g)}function a(a){var b=a.previousSibling||a.nextSibling;a.parentNode.removeChild(a);k.normalizeTextNodes(b)}function c(a){return Object.keys(a).map(function(b){return a[b]})}function d(a){function b(a){var c=a.spec();if(f[c.memberid])switch(c.optype){case "AddCursor":d[c.memberid]||(d[c.memberid]=
-a,delete f[c.memberid],g-=1);break;case "MoveCursor":e[c.memberid]||(e[c.memberid]=a)}}var d={},e={},f={},g,k=a.pop();n.getCursors().forEach(function(a){f[a.getMemberId()]=!0});for(g=Object.keys(f).length;k&&0<g;)k.reverse(),k.forEach(b),k=a.pop();return c(d).concat(c(e))}var b=this,k=new core.DomUtils,p,e=[],s,n,g=[],l=[],u=[],q=new core.EventNotifier([gui.UndoManager.signalUndoStackChanged,gui.UndoManager.signalUndoStateCreated,gui.UndoManager.signalUndoStateModified,gui.TrivialUndoManager.signalDocumentRootReplaced]),
-x=h||new gui.UndoStateRules;this.subscribe=function(a,b){q.subscribe(a,b)};this.unsubscribe=function(a,b){q.unsubscribe(a,b)};this.hasUndoStates=function(){return 0<l.length};this.hasRedoStates=function(){return 0<u.length};this.setOdtDocument=function(a){n=a};this.resetInitialState=function(){l.length=0;u.length=0;e.length=0;g.length=0;p=null;m()};this.saveInitialState=function(){var b=n.getOdfCanvas().odfContainer(),c=n.getOdfCanvas().getAnnotationManager();c&&c.forgetAnnotations();p=b.rootElement.cloneNode(!0);
-n.getOdfCanvas().refreshAnnotations();b=p;k.getElementsByTagNameNS(b,"urn:webodf:names:cursor","cursor").forEach(a);k.getElementsByTagNameNS(b,"urn:webodf:names:cursor","anchor").forEach(a);f();l.unshift(e);g=e=d(l);l.length=0;u.length=0;m()};this.setPlaybackFunction=function(a){s=a};this.onOperationExecuted=function(a){u.length=0;x.isEditOperation(a)&&g===e||!x.isPartOfOperationSet(a,g)?(f(),g=[a],l.push(g),q.emit(gui.UndoManager.signalUndoStateCreated,{operations:g}),m()):(g.push(a),q.emit(gui.UndoManager.signalUndoStateModified,
-{operations:g}))};this.moveForward=function(a){for(var b=0,c;a&&u.length;)c=u.pop(),l.push(c),c.forEach(s),a-=1,b+=1;b&&(g=l[l.length-1],m());return b};this.moveBackward=function(a){for(var b=n.getOdfCanvas(),c=b.odfContainer(),d=0;a&&l.length;)u.push(l.pop()),a-=1,d+=1;d&&(c.setRootElement(p.cloneNode(!0)),b.setOdfContainer(c,!0),q.emit(gui.TrivialUndoManager.signalDocumentRootReplaced,{}),n.getCursors().forEach(function(a){n.removeCursor(a.getMemberId())}),e.forEach(s),l.forEach(function(a){a.forEach(s)}),
-b.refreshCSS(),g=l[l.length-1]||e,m());return d}};gui.TrivialUndoManager.signalDocumentRootReplaced="documentRootReplaced";(function(){return gui.TrivialUndoManager})();
+ops.OperationRouter=function(){};ops.OperationRouter.prototype.setOperationFactory=function(e){};ops.OperationRouter.prototype.setPlaybackFunction=function(e){};ops.OperationRouter.prototype.push=function(e){};ops.OperationRouter.prototype.close=function(e){};
 // Input 82
 /*
 
- Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+ Copyright (C) 2012 KO GmbH <copyright@kogmbh.com>
 
  @licstart
  The JavaScript code in this page is free software: you can redistribute it
@@ -2381,6 +2477,9 @@ b.refreshCSS(),g=l[l.length-1]||e,m());return d}};gui.TrivialUndoManager.signalD
  the License, or (at your option) any later version.  The code is distributed
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
 
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
@@ -2402,27 +2501,13 @@ b.refreshCSS(),g=l[l.length-1]||e,m());return d}};gui.TrivialUndoManager.signalD
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
 */
-runtime.loadClass("core.EventNotifier");runtime.loadClass("core.DomUtils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.Namespaces");runtime.loadClass("gui.SelectionMover");runtime.loadClass("gui.StyleHelper");runtime.loadClass("core.PositionFilterChain");
-ops.OdtDocument=function(h){function m(){var a=h.odfContainer().getContentElement(),b=a&&a.localName;runtime.assert("text"===b,"Unsupported content element type '"+b+"'for OdtDocument");return a}function f(a){function b(a){for(;!(a.namespaceURI===odf.Namespaces.officens&&"text"===a.localName||a.namespaceURI===odf.Namespaces.officens&&"annotation"===a.localName);)a=a.parentNode;return a}this.acceptPosition=function(c){c=c.container();var d=s[a].getNode();return b(c)===b(d)?g:l}}function a(a){var b=
-gui.SelectionMover.createPositionIterator(m());for(a+=1;0<a&&b.nextPosition();)u.acceptPosition(b)===g&&(a-=1);return b}function c(a){return p.getParagraphElement(a)}function d(a,b){return h.getFormatting().getStyleElement(a,b)}function b(a){return d(a,"paragraph")}var k=this,p,e,s={},n=new core.EventNotifier([ops.OdtDocument.signalCursorAdded,ops.OdtDocument.signalCursorRemoved,ops.OdtDocument.signalCursorMoved,ops.OdtDocument.signalParagraphChanged,ops.OdtDocument.signalParagraphStyleModified,ops.OdtDocument.signalCommonStyleCreated,
-ops.OdtDocument.signalCommonStyleDeleted,ops.OdtDocument.signalTableAdded,ops.OdtDocument.signalOperationExecuted,ops.OdtDocument.signalUndoStackChanged]),g=core.PositionFilter.FilterResult.FILTER_ACCEPT,l=core.PositionFilter.FilterResult.FILTER_REJECT,u;this.getIteratorAtPosition=a;this.getStyleElement=d;this.upgradeWhitespacesAtPosition=function(b){b=a(b);var c,d,e;b.previousPosition();b.previousPosition();for(e=-1;1>=e;e+=1){c=b.container();d=b.unfilteredDomOffset();if(c.nodeType===Node.TEXT_NODE&&
-" "===c.data[d]&&p.isSignificantWhitespace(c,d)){runtime.assert(" "===c.data[d],"upgradeWhitespaceToElement: textNode.data[offset] should be a literal space");var f=c.ownerDocument.createElementNS(odf.Namespaces.textns,"text:s");f.appendChild(c.ownerDocument.createTextNode(" "));c.deleteData(d,1);0<d&&(c=c.splitText(d));c.parentNode.insertBefore(f,c);c=f;b.moveToEndOfNode(c)}b.nextPosition()}};this.downgradeWhitespacesAtPosition=function(b){var c=a(b),d;b=c.container();for(c=c.unfilteredDomOffset();!p.isCharacterElement(b)&&
-b.childNodes[c];)b=b.childNodes[c],c=0;b.nodeType===Node.TEXT_NODE&&(b=b.parentNode);p.isDowngradableSpaceElement(b)&&(c=b.firstChild,d=b.lastChild,e.mergeIntoParent(b),d!==c&&e.normalizeTextNodes(d),e.normalizeTextNodes(c))};this.getParagraphStyleElement=b;this.getParagraphElement=c;this.getParagraphStyleAttributes=function(a){return(a=b(a))?h.getFormatting().getInheritedStyleAttributes(a):null};this.getPositionInTextNode=function(a,b){var c=gui.SelectionMover.createPositionIterator(m()),d=null,
-e,f=0,h=null,h=a;runtime.assert(0<=a,"position must be >= 0");u.acceptPosition(c)===g?(e=c.container(),e.nodeType===Node.TEXT_NODE&&(d=e,f=0)):a+=1;for(;0<a||null===d;){if(!c.nextPosition())return null;if(u.acceptPosition(c)===g)if(a-=1,e=c.container(),e.nodeType===Node.TEXT_NODE)e!==d?(d=e,f=c.unfilteredDomOffset()):f+=1;else if(null!==d){if(0===a){f=d.length;break}d=null}else if(0===a){d=m().ownerDocument.createTextNode("");e.insertBefore(d,c.rightNode());f=0;break}}if(null===d)return null;if(b&&
-s[b]&&k.getCursorPosition(b)===h){for(h=s[b].getNode();0===f&&h.nextSibling&&"cursor"===h.nextSibling.localName;)h.parentNode.insertBefore(h,h.nextSibling.nextSibling);0<d.length&&(d=m().ownerDocument.createTextNode(""),f=0,h.parentNode.insertBefore(d,h.nextSibling));for(;0===f&&(d.previousSibling&&"cursor"===d.previousSibling.localName)&&(e=d.previousSibling,0<d.length&&(d=m().ownerDocument.createTextNode("")),e.parentNode.insertBefore(d,e),h!==e););}for(;d.previousSibling&&d.previousSibling.nodeType===
-Node.TEXT_NODE;)d.previousSibling.appendData(d.data),f=d.previousSibling.length,d=d.previousSibling,d.parentNode.removeChild(d.nextSibling);return{textNode:d,offset:f}};this.fixCursorPositions=function(a){var b,c,d,e=new core.PositionFilterChain;e.addFilter("BaseFilter",k.getPositionFilter());for(b in s)s.hasOwnProperty(b)&&(e.addFilter("RootFilter",k.createRootFilter(b)),c=s[b],d=c.getStepCounter(),d.isPositionWalkable(e)?0===k.getCursorSelection(b).length&&c.move(0):(d=d.countStepsToValidPosition(e),
-c.move(d),b===a&&k.emit(ops.OdtDocument.signalCursorMoved,c)),e.removeFilter("RootFilter"))};this.getWalkableParagraphLength=function(b){var d=a(0),e=0;d.setUnfilteredPosition(b,0);do{if(c(d.container())!==b)break;u.acceptPosition(d)===g&&(e+=1)}while(d.nextPosition());return e};this.getDistanceFromCursor=function(a,b,c){a=s[a];var d=0;runtime.assert(null!==b&&void 0!==b,"OdtDocument.getDistanceFromCursor called without node");a&&(a=a.getStepCounter().countStepsToPosition,d=a(b,c,u));return d};this.getCursorPosition=
-function(a){return-k.getDistanceFromCursor(a,m(),0)};this.getCursorSelection=function(a){var b;a=s[a];var c=0;b=0;a&&(b=a.getStepCounter().countStepsToPosition,c=-b(m(),0,u),b=b(a.getAnchorNode(),0,u));return{position:c+b,length:-b}};this.getPositionFilter=function(){return u};this.getOdfCanvas=function(){return h};this.getRootNode=m;this.getDOM=function(){return m().ownerDocument};this.getCursor=function(a){return s[a]};this.getCursors=function(){var a=[],b;for(b in s)s.hasOwnProperty(b)&&a.push(s[b]);
-return a};this.addCursor=function(a){runtime.assert(Boolean(a),"OdtDocument::addCursor without cursor");var b=a.getStepCounter().countForwardSteps(1,u),c=a.getMemberId();runtime.assert(Boolean(c),"OdtDocument::addCursor has cursor without memberid");runtime.assert(!s[c],"OdtDocument::addCursor is adding a duplicate cursor with memberid "+c);a.move(b);s[c]=a};this.removeCursor=function(a){var b=s[a];return b?(b.removeFromOdtDocument(),delete s[a],k.emit(ops.OdtDocument.signalCursorRemoved,a),!0):!1};
-this.getMetaData=function(a){for(var b=h.odfContainer().rootElement.firstChild;b&&"meta"!==b.localName;)b=b.nextSibling;for(b=b&&b.firstChild;b&&b.localName!==a;)b=b.nextSibling;for(b=b&&b.firstChild;b&&b.nodeType!==Node.TEXT_NODE;)b=b.nextSibling;return b?b.data:null};this.getFormatting=function(){return h.getFormatting()};this.getTextElements=function(a,b){return p.getTextElements(a,b)};this.getParagraphElements=function(a){return p.getParagraphElements(a)};this.emit=function(a,b){n.emit(a,b)};
-this.subscribe=function(a,b){n.subscribe(a,b)};this.unsubscribe=function(a,b){n.unsubscribe(a,b)};this.createRootFilter=function(a){return new f(a)};this.close=function(a){a()};this.destroy=function(a){a()};u=new function(){function a(b,c,d){var e,f;if(c&&(e=p.lookLeftForCharacter(c),1===e||2===e&&(p.scanRightForAnyCharacter(d)||p.scanRightForAnyCharacter(p.nextNode(b)))))return g;e=null===c&&p.isParagraph(b);f=p.lookRightForCharacter(d);if(e)return f?g:p.scanRightForAnyCharacter(d)?l:g;if(!f)return l;
-c=c||p.previousNode(b);return p.scanLeftForAnyCharacter(c)?l:g}this.acceptPosition=function(b){var c=b.container(),d=c.nodeType,e,f,h;if(d!==Node.ELEMENT_NODE&&d!==Node.TEXT_NODE)return l;if(d===Node.TEXT_NODE){if(!p.isGroupingElement(c.parentNode)||p.isWithinTrackedChanges(c.parentNode,m()))return l;d=b.unfilteredDomOffset();e=c.data;runtime.assert(d!==e.length,"Unexpected offset.");if(0<d){b=e.substr(d-1,1);if(!p.isODFWhitespace(b))return g;if(1<d)if(b=e.substr(d-2,1),!p.isODFWhitespace(b))f=g;
-else{if(!p.isODFWhitespace(e.substr(0,d)))return l}else h=p.previousNode(c),p.scanLeftForNonWhitespace(h)&&(f=g);if(f===g)return p.isTrailingWhitespace(c,d)?l:g;f=e.substr(d,1);return p.isODFWhitespace(f)?l:p.scanLeftForAnyCharacter(p.previousNode(c))?l:g}h=b.leftNode();f=c;c=c.parentNode;f=a(c,h,f)}else!p.isGroupingElement(c)||p.isWithinTrackedChanges(c,m())?f=l:(h=b.leftNode(),f=b.rightNode(),f=a(c,h,f));return f}};p=new odf.OdfUtils;e=new core.DomUtils};ops.OdtDocument.signalCursorAdded="cursor/added";
-ops.OdtDocument.signalCursorRemoved="cursor/removed";ops.OdtDocument.signalCursorMoved="cursor/moved";ops.OdtDocument.signalParagraphChanged="paragraph/changed";ops.OdtDocument.signalTableAdded="table/added";ops.OdtDocument.signalCommonStyleCreated="style/created";ops.OdtDocument.signalCommonStyleDeleted="style/deleted";ops.OdtDocument.signalParagraphStyleModified="paragraphstyle/modified";ops.OdtDocument.signalOperationExecuted="operation/executed";ops.OdtDocument.signalUndoStackChanged="undo/changed";
-(function(){return ops.OdtDocument})();
+ops.TrivialOperationRouter=function(){var e,h;this.setOperationFactory=function(f){e=f};this.setPlaybackFunction=function(e){h=e};this.push=function(f){f.forEach(function(f){f=f.spec();f.timestamp=(new Date).getTime();f=e.create(f);h(f)})};this.close=function(e){e()}};
 // Input 83
+gui.EditInfoHandle=function(e){var h=[],f,n=e.ownerDocument,m=n.documentElement.namespaceURI;this.setEdits=function(e){h=e;var c,b,a,d;f.innerHTML="";for(e=0;e<h.length;e+=1)c=n.createElementNS(m,"div"),c.className="editInfo",b=n.createElementNS(m,"span"),b.className="editInfoColor",b.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",h[e].memberid),a=n.createElementNS(m,"span"),a.className="editInfoAuthor",a.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",h[e].memberid),
+d=n.createElementNS(m,"span"),d.className="editInfoTime",d.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",h[e].memberid),d.innerHTML=h[e].time,c.appendChild(b),c.appendChild(a),c.appendChild(d),f.appendChild(c)};this.show=function(){f.style.display="block"};this.hide=function(){f.style.display="none"};this.destroy=function(h){e.removeChild(f);h()};f=n.createElementNS(m,"div");f.setAttribute("class","editInfoHandle");f.style.display="none";e.appendChild(f)};
+// Input 84
 /*
 
  Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
@@ -2435,6 +2520,9 @@ ops.OdtDocument.signalCursorRemoved="cursor/removed";ops.OdtDocument.signalCurso
  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
 
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
  As additional permission under GNU AGPL version 3 section 7, you
  may distribute non-source (e.g., minimized or compacted) forms of
  that code without the copy of the GNU GPL normally required by
@@ -2455,10 +2543,377 @@ ops.OdtDocument.signalCursorRemoved="cursor/removed";ops.OdtDocument.signalCurso
  This license applies to this entire compilation.
  @licend
  @source: http://www.webodf.org/
- @source: http://gitorious.org/webodf/webodf/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("ops.EditInfo");runtime.loadClass("gui.EditInfoHandle");
+gui.EditInfoMarker=function(e,h){function f(a,b){return runtime.setTimeout(function(){c.style.opacity=a},b)}var n=this,m,p,c,b,a;this.addEdit=function(d,h){var g=Date.now()-h;e.addEdit(d,h);p.setEdits(e.getSortedEdits());c.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",d);b&&runtime.clearTimeout(b);a&&runtime.clearTimeout(a);1E4>g?(f(1,0),b=f(0.5,1E4-g),a=f(0.2,2E4-g)):1E4<=g&&2E4>g?(f(0.5,0),a=f(0.2,2E4-g)):f(0.2,0)};this.getEdits=function(){return e.getEdits()};this.clearEdits=function(){e.clearEdits();
+p.setEdits([]);c.hasAttributeNS("urn:webodf:names:editinfo","editinfo:memberid")&&c.removeAttributeNS("urn:webodf:names:editinfo","editinfo:memberid")};this.getEditInfo=function(){return e};this.show=function(){c.style.display="block"};this.hide=function(){n.hideHandle();c.style.display="none"};this.showHandle=function(){p.show()};this.hideHandle=function(){p.hide()};this.destroy=function(a){m.removeChild(c);p.destroy(function(b){b?a(b):e.destroy(a)})};(function(){var a=e.getOdtDocument().getDOM();
+c=a.createElementNS(a.documentElement.namespaceURI,"div");c.setAttribute("class","editInfoMarker");c.onmouseover=function(){n.showHandle()};c.onmouseout=function(){n.hideHandle()};m=e.getNode();m.appendChild(c);p=new gui.EditInfoHandle(m);h||n.hide()})()};
+// Input 85
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("gui.Caret");runtime.loadClass("ops.TrivialMemberModel");runtime.loadClass("ops.EditInfo");runtime.loadClass("gui.EditInfoMarker");gui.SessionViewOptions=function(){this.caretBlinksOnRangeSelect=this.caretAvatarsInitiallyVisible=this.editInfoMarkersInitiallyVisible=!0};
+gui.SessionView=function(){return function(e,h,f,n,m){function p(a,b,c){function d(b,c,e){c=b+'[editinfo|memberid="'+a+'"]'+e+c;a:{var f=t.firstChild;for(b=b+'[editinfo|memberid="'+a+'"]'+e+"{";f;){if(f.nodeType===Node.TEXT_NODE&&0===f.data.indexOf(b)){b=f;break a}f=f.nextSibling}b=null}b?b.data=c:t.appendChild(document.createTextNode(c))}d("div.editInfoMarker","{ background-color: "+c+"; }","");d("span.editInfoColor","{ background-color: "+c+"; }","");d("span.editInfoAuthor",'{ content: "'+b+'"; }',
+":before");d("dc|creator",'{ content: "'+b+'"; display: none;}',":before");d("dc|creator","{ background-color: "+c+"; }","");d("div.selectionOverlay","{ background-color: "+c+";}","")}function c(a){var b,c;for(c in v)v.hasOwnProperty(c)&&(b=v[c],a?b.show():b.hide())}function b(a){n.getCarets().forEach(function(b){a?b.showHandle():b.hideHandle()})}function a(a,b){var c=n.getCaret(a);b?(c&&(c.setAvatarImageUrl(b.imageurl),c.setColor(b.color)),p(a,b.fullname,b.color),h===a&&p("",b.fullname,b.color)):
+runtime.log('MemberModel sent undefined data for member "'+a+'".')}function d(b){var c=b.getMemberId(),d=f.getMemberModel();n.registerCursor(b,x,u);m.registerCursor(b,!0);a(c,null);d.getMemberDetailsAndUpdates(c,a);runtime.log("+++ View here +++ eagerly created an Caret for '"+c+"'! +++")}function k(a){a=a.getMemberId();var b=m.getSelectionView(h),c=m.getSelectionView(gui.ShadowCursor.ShadowCursorMemberId),d=n.getCaret(h);a===h?(c.hide(),b.show(),d&&d.show()):a===gui.ShadowCursor.ShadowCursorMemberId&&
+(c.show(),b.hide(),d&&d.hide())}function g(b){var c=!1,d;for(d in v)if(v.hasOwnProperty(d)&&v[d].getEditInfo().getEdits().hasOwnProperty(b)){c=!0;break}m.removeSelectionView(b);c||f.getMemberModel().unsubscribeMemberDetailsUpdates(b,a)}function q(a){var b=a.paragraphElement,c=a.memberId;a=a.timeStamp;var d,e="",g=b.getElementsByTagNameNS(w,"editinfo")[0];g?(e=g.getAttributeNS(w,"id"),d=v[e]):(e=Math.random().toString(),d=new ops.EditInfo(b,f.getOdtDocument()),d=new gui.EditInfoMarker(d,y),g=b.getElementsByTagNameNS(w,
+"editinfo")[0],g.setAttributeNS(w,"id",e),v[e]=d);d.addEdit(c,new Date(a))}function l(){C=!0}function r(){s=runtime.getWindow().setInterval(function(){C&&(m.rerenderSelectionViews(),C=!1)},200)}var t,w="urn:webodf:names:editinfo",v={},y=void 0!==e.editInfoMarkersInitiallyVisible?Boolean(e.editInfoMarkersInitiallyVisible):!0,x=void 0!==e.caretAvatarsInitiallyVisible?Boolean(e.caretAvatarsInitiallyVisible):!0,u=void 0!==e.caretBlinksOnRangeSelect?Boolean(e.caretBlinksOnRangeSelect):!0,s,C=!1;this.showEditInfoMarkers=
+function(){y||(y=!0,c(y))};this.hideEditInfoMarkers=function(){y&&(y=!1,c(y))};this.showCaretAvatars=function(){x||(x=!0,b(x))};this.hideCaretAvatars=function(){x&&(x=!1,b(x))};this.getSession=function(){return f};this.getCaret=function(a){return n.getCaret(a)};this.destroy=function(b){var c=f.getOdtDocument(),e=f.getMemberModel(),h=Object.keys(v).map(function(a){return v[a]});c.unsubscribe(ops.OdtDocument.signalCursorAdded,d);c.unsubscribe(ops.OdtDocument.signalCursorRemoved,g);c.unsubscribe(ops.OdtDocument.signalParagraphChanged,
+q);c.unsubscribe(ops.OdtDocument.signalCursorMoved,k);c.unsubscribe(ops.OdtDocument.signalParagraphChanged,l);c.unsubscribe(ops.OdtDocument.signalTableAdded,l);c.unsubscribe(ops.OdtDocument.signalParagraphStyleModified,l);runtime.getWindow().clearInterval(s);n.getCarets().forEach(function(b){e.unsubscribeMemberDetailsUpdates(b.getCursor().getMemberId(),a)});t.parentNode.removeChild(t);(function G(a,c){c?b(c):a<h.length?h[a].destroy(function(b){G(a+1,b)}):b()})(0,void 0)};(function(){var a=f.getOdtDocument(),
+b=document.getElementsByTagName("head")[0];a.subscribe(ops.OdtDocument.signalCursorAdded,d);a.subscribe(ops.OdtDocument.signalCursorRemoved,g);a.subscribe(ops.OdtDocument.signalParagraphChanged,q);a.subscribe(ops.OdtDocument.signalCursorMoved,k);r();a.subscribe(ops.OdtDocument.signalParagraphChanged,l);a.subscribe(ops.OdtDocument.signalTableAdded,l);a.subscribe(ops.OdtDocument.signalParagraphStyleModified,l);t=document.createElementNS(b.namespaceURI,"style");t.type="text/css";t.media="screen, print, handheld, projection";
+t.appendChild(document.createTextNode("@namespace editinfo url(urn:webodf:names:editinfo);"));t.appendChild(document.createTextNode("@namespace dc url(http://purl.org/dc/elements/1.1/);"));b.appendChild(t)})()}}();
+// Input 86
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("gui.Caret");
+gui.CaretManager=function(e){function h(a){return q.hasOwnProperty(a)?q[a]:null}function f(){return Object.keys(q).map(function(a){return q[a]})}function n(a){a===e.getInputMemberId()&&e.getSession().getOdtDocument().getOdfCanvas().getElement().removeAttribute("tabindex");delete q[a]}function m(a){a=a.getMemberId();a===e.getInputMemberId()&&(a=h(a))&&a.refreshCursorBlinking()}function p(){var a=h(e.getInputMemberId());r=!1;a&&a.ensureVisible()}function c(){var a=h(e.getInputMemberId());a&&(a.handleUpdate(),
+r||(r=!0,runtime.setTimeout(p,50)))}function b(a){a.memberId===e.getInputMemberId()&&c()}function a(){var a=h(e.getInputMemberId());a&&a.setFocus()}function d(){var a=h(e.getInputMemberId());a&&a.removeFocus()}function k(){var a=h(e.getInputMemberId());a&&a.show()}function g(){var a=h(e.getInputMemberId());a&&a.hide()}var q={},l=runtime.getWindow(),r=!1;this.registerCursor=function(a,b,d){var f=a.getMemberId();b=new gui.Caret(a,b,d);q[f]=b;f===e.getInputMemberId()?(runtime.log("Starting to track input on new cursor of "+
+f),a.handleUpdate=c,e.getSession().getOdtDocument().getOdfCanvas().getElement().setAttribute("tabindex",-1),e.getEventManager().focus()):a.handleUpdate=b.handleUpdate;return b};this.getCaret=h;this.getCarets=f;this.destroy=function(c){var h=e.getSession().getOdtDocument(),p=e.getEventManager(),r=f();h.unsubscribe(ops.OdtDocument.signalParagraphChanged,b);h.unsubscribe(ops.OdtDocument.signalCursorMoved,m);h.unsubscribe(ops.OdtDocument.signalCursorRemoved,n);p.unsubscribe("focus",a);p.unsubscribe("blur",
+d);l.removeEventListener("focus",k,!1);l.removeEventListener("blur",g,!1);(function u(a,b){b?c(b):a<r.length?r[a].destroy(function(b){u(a+1,b)}):c()})(0,void 0);q={}};(function(){var c=e.getSession().getOdtDocument(),f=e.getEventManager();c.subscribe(ops.OdtDocument.signalParagraphChanged,b);c.subscribe(ops.OdtDocument.signalCursorMoved,m);c.subscribe(ops.OdtDocument.signalCursorRemoved,n);f.subscribe("focus",a);f.subscribe("blur",d);l.addEventListener("focus",k,!1);l.addEventListener("blur",g,!1)})()};
+// Input 87
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+gui.UndoManager=function(){};gui.UndoManager.prototype.subscribe=function(e,h){};gui.UndoManager.prototype.unsubscribe=function(e,h){};gui.UndoManager.prototype.setOdtDocument=function(e){};gui.UndoManager.prototype.saveInitialState=function(){};gui.UndoManager.prototype.resetInitialState=function(){};gui.UndoManager.prototype.setPlaybackFunction=function(e){};gui.UndoManager.prototype.hasUndoStates=function(){};gui.UndoManager.prototype.hasRedoStates=function(){};
+gui.UndoManager.prototype.moveForward=function(e){};gui.UndoManager.prototype.moveBackward=function(e){};gui.UndoManager.prototype.onOperationExecuted=function(e){};gui.UndoManager.signalUndoStackChanged="undoStackChanged";gui.UndoManager.signalUndoStateCreated="undoStateCreated";gui.UndoManager.signalUndoStateModified="undoStateModified";(function(){return gui.UndoManager})();
+// Input 88
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+gui.UndoStateRules=function(){function e(e){return e.spec().optype}function h(f){switch(e(f)){case "MoveCursor":case "AddCursor":case "RemoveCursor":return!1;default:return!0}}this.getOpType=e;this.isEditOperation=h;this.isPartOfOperationSet=function(f,n){if(h(f)){if(0===n.length)return!0;var m;if(m=h(n[n.length-1]))a:{m=n.filter(h);var p=e(f),c;b:switch(p){case "RemoveText":case "InsertText":c=!0;break b;default:c=!1}if(c&&p===e(m[0])){if(1===m.length){m=!0;break a}p=m[m.length-2].spec().position;
+m=m[m.length-1].spec().position;c=f.spec().position;if(m===c-(m-p)){m=!0;break a}}m=!1}return m}return!0}};
+// Input 89
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("core.DomUtils");runtime.loadClass("gui.UndoManager");runtime.loadClass("gui.UndoStateRules");
+gui.TrivialUndoManager=function(e){function h(){t.emit(gui.UndoManager.signalUndoStackChanged,{undoAvailable:c.hasUndoStates(),redoAvailable:c.hasRedoStates()})}function f(){q!==d&&q!==l[l.length-1]&&l.push(q)}function n(a){var c=a.previousSibling||a.nextSibling;a.parentNode.removeChild(a);b.normalizeTextNodes(c)}function m(a){return Object.keys(a).map(function(b){return a[b]})}function p(a){function b(a){var g=a.spec();if(e[g.memberid])switch(g.optype){case "AddCursor":c[g.memberid]||(c[g.memberid]=
+a,delete e[g.memberid],f-=1);break;case "MoveCursor":d[g.memberid]||(d[g.memberid]=a)}}var c={},d={},e={},f,h=a.pop();g.getCursors().forEach(function(a){e[a.getMemberId()]=!0});for(f=Object.keys(e).length;h&&0<f;)h.reverse(),h.forEach(b),h=a.pop();return m(c).concat(m(d))}var c=this,b=new core.DomUtils,a,d=[],k,g,q=[],l=[],r=[],t=new core.EventNotifier([gui.UndoManager.signalUndoStackChanged,gui.UndoManager.signalUndoStateCreated,gui.UndoManager.signalUndoStateModified,gui.TrivialUndoManager.signalDocumentRootReplaced]),
+w=e||new gui.UndoStateRules;this.subscribe=function(a,b){t.subscribe(a,b)};this.unsubscribe=function(a,b){t.unsubscribe(a,b)};this.hasUndoStates=function(){return 0<l.length};this.hasRedoStates=function(){return 0<r.length};this.setOdtDocument=function(a){g=a};this.resetInitialState=function(){l.length=0;r.length=0;d.length=0;q.length=0;a=null;h()};this.saveInitialState=function(){var c=g.getOdfCanvas().odfContainer(),e=g.getOdfCanvas().getAnnotationManager();e&&e.forgetAnnotations();a=c.rootElement.cloneNode(!0);
+g.getOdfCanvas().refreshAnnotations();c=a;b.getElementsByTagNameNS(c,"urn:webodf:names:cursor","cursor").forEach(n);b.getElementsByTagNameNS(c,"urn:webodf:names:cursor","anchor").forEach(n);f();l.unshift(d);q=d=p(l);l.length=0;r.length=0;h()};this.setPlaybackFunction=function(a){k=a};this.onOperationExecuted=function(a){r.length=0;w.isEditOperation(a)&&q===d||!w.isPartOfOperationSet(a,q)?(f(),q=[a],l.push(q),t.emit(gui.UndoManager.signalUndoStateCreated,{operations:q}),h()):(q.push(a),t.emit(gui.UndoManager.signalUndoStateModified,
+{operations:q}))};this.moveForward=function(a){for(var b=0,c;a&&r.length;)c=r.pop(),l.push(c),c.forEach(k),a-=1,b+=1;b&&(q=l[l.length-1],h());return b};this.moveBackward=function(b){for(var c=g.getOdfCanvas(),e=c.odfContainer(),f=0;b&&l.length;)r.push(l.pop()),b-=1,f+=1;f&&(e.setRootElement(a.cloneNode(!0)),c.setOdfContainer(e,!0),t.emit(gui.TrivialUndoManager.signalDocumentRootReplaced,{}),g.getCursors().forEach(function(a){g.removeCursor(a.getMemberId())}),d.forEach(k),l.forEach(function(a){a.forEach(k)}),
+c.refreshCSS(),q=l[l.length-1]||d,h());return f}};gui.TrivialUndoManager.signalDocumentRootReplaced="documentRootReplaced";(function(){return gui.TrivialUndoManager})();
+// Input 90
+runtime.loadClass("core.DomUtils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.OdfNodeFilter");runtime.loadClass("gui.SelectionMover");
+gui.SelectionView=function(e){function h(a){if(A&&a.nodeType===Node.ELEMENT_NODE)return a.getBoundingClientRect();C.selectNode(a);return C.getBoundingClientRect()}function f(a,b){a.style.left=b.left+"px";a.style.top=b.top+"px";a.style.width=b.width+"px";a.style.height=b.height+"px"}function n(a){s=a;w.style.display=v.style.display=y.style.display=!0===a?"block":"none"}function m(a){var b=h(r),c=l.getOdfCanvas().getZoomLevel(),d={};d.top=u.adaptRangeDifferenceToZoomLevel(a.top-b.top,c);d.left=u.adaptRangeDifferenceToZoomLevel(a.left-
+b.left,c);d.bottom=u.adaptRangeDifferenceToZoomLevel(a.bottom-b.top,c);d.right=u.adaptRangeDifferenceToZoomLevel(a.right-b.left,c);d.width=u.adaptRangeDifferenceToZoomLevel(a.width,c);d.height=u.adaptRangeDifferenceToZoomLevel(a.height,c);return d}function p(a){a=a.getBoundingClientRect();return Boolean(a&&0!==a.height)}function c(a){var b=x.getTextElements(a,!0,!1),c=a.cloneRange(),d=a.cloneRange();a=a.cloneRange();if(!b.length)return null;var e;a:{e=0;var f=b[e],g=c.startContainer===f?c.startOffset:
+0,h=g;c.setStart(f,g);for(c.setEnd(f,h);!p(c);){if(f.nodeType===Node.ELEMENT_NODE&&h<f.childNodes.length)h=f.childNodes.length;else if(f.nodeType===Node.TEXT_NODE&&h<f.length)h+=1;else if(b[e])f=b[e],e+=1,g=h=0;else{e=!1;break a}c.setStart(f,g);c.setEnd(f,h)}e=!0}if(!e)return null;a:{e=b.length-1;f=b[e];h=g=d.endContainer===f?d.endOffset:f.length||f.childNodes.length;d.setStart(f,g);for(d.setEnd(f,h);!p(d);){if(f.nodeType===Node.ELEMENT_NODE&&0<g)g=0;else if(f.nodeType===Node.TEXT_NODE&&0<g)g-=1;
+else if(b[e])f=b[e],e-=1,g=h=f.length||f.childNodes.length;else{b=!1;break a}d.setStart(f,g);d.setEnd(f,h)}b=!0}if(!b)return null;a.setStart(c.startContainer,c.startOffset);a.setEnd(d.endContainer,d.endOffset);return{firstRange:c,lastRange:d,fillerRange:a}}function b(a,b){var c={};c.top=Math.min(a.top,b.top);c.left=Math.min(a.left,b.left);c.right=Math.max(a.right,b.right);c.bottom=Math.max(a.bottom,b.bottom);c.width=c.right-c.left;c.height=c.bottom-c.top;return c}function a(a,c){c&&0<c.width&&0<c.height&&
+(a=a?b(a,c):c);return a}function d(b){function c(a){B.setUnfilteredPosition(a,0);return w.acceptNode(a)===I&&u.acceptPosition(B)===I?I:z}function d(a){var b=null;c(a)===I&&(b=h(a));return b}var e=b.commonAncestorContainer,f=b.startContainer,g=b.endContainer,k=b.startOffset,m=b.endOffset,n,p,q=null,r,s=t.createRange(),u,w=new odf.OdfNodeFilter,v;if(f===e||g===e)return s=b.cloneRange(),q=s.getBoundingClientRect(),s.detach(),q;for(b=f;b.parentNode!==e;)b=b.parentNode;for(p=g;p.parentNode!==e;)p=p.parentNode;
+u=l.createRootFilter(f);for(e=b.nextSibling;e&&e!==p;)r=d(e),q=a(q,r),e=e.nextSibling;if(x.isParagraph(b))q=a(q,h(b));else for(v=t.createTreeWalker(b,NodeFilter.SHOW_TEXT,c),e=v.currentNode=f;e&&e!==g;)s.setStart(e,k),s.setEnd(e,e.length),r=s.getBoundingClientRect(),q=a(q,r),n=e,k=0,e=v.nextNode();n||(n=f);if(x.isParagraph(p))q=a(q,h(b));else for(v=t.createTreeWalker(p,NodeFilter.SHOW_TEXT,c),e=v.currentNode=g;e&&e!==n;)if(s.setStart(e,0),s.setEnd(e,m),r=s.getBoundingClientRect(),q=a(q,r),e=v.previousNode())m=
+e.length;return q}function k(a,b){var c=a.getBoundingClientRect(),d={width:0};d.top=c.top;d.bottom=c.bottom;d.height=c.height;d.left=d.right=b?c.right:c.left;return d}function g(){if(e.getSelectionType()===ops.OdtCursor.RangeSelection){n(!0);var a=e.getSelectedRange(),g=c(a),h,l,p,t;a.collapsed||!g?n(!1):(n(!0),a=g.firstRange,h=g.lastRange,g=g.fillerRange,l=m(k(a,!1)),t=m(k(h,!0)),p=(p=d(g))?m(p):b(l,t),f(w,{left:l.left,top:l.top,width:Math.max(0,p.width-(l.left-p.left)),height:l.height}),t.top===
+l.top||t.bottom===l.bottom?v.style.display=y.style.display="none":(f(y,{left:p.left,top:t.top,width:Math.max(0,t.right-p.left),height:t.height}),f(v,{left:p.left,top:l.top+l.height,width:Math.max(0,parseFloat(w.style.left)+parseFloat(w.style.width)-parseFloat(y.style.left)),height:Math.max(0,t.top-l.bottom)})),a.detach(),h.detach(),g.detach())}else n(!1)}function q(a){a===e&&g()}var l=e.getOdtDocument(),r=l.getRootNode().parentNode.parentNode,t=l.getDOM(),w=t.createElement("div"),v=t.createElement("div"),
+y=t.createElement("div"),x=new odf.OdfUtils,u=new core.DomUtils,s=!0,C=t.createRange(),B=gui.SelectionMover.createPositionIterator(l.getRootNode()),A=u.areRangeRectanglesTransformed(t),I=NodeFilter.FILTER_ACCEPT,z=NodeFilter.FILTER_REJECT;this.show=this.rerender=g;this.hide=function(){n(!1)};this.visible=function(){return s};this.destroy=function(a){r.removeChild(w);r.removeChild(v);r.removeChild(y);e.getOdtDocument().unsubscribe(ops.OdtDocument.signalCursorMoved,q);a()};(function(){var a=e.getMemberId();
+r.appendChild(w);r.appendChild(v);r.appendChild(y);w.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",a);v.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",a);y.setAttributeNS("urn:webodf:names:editinfo","editinfo:memberid",a);w.className=v.className=y.className="selectionOverlay";e.getOdtDocument().subscribe(ops.OdtDocument.signalCursorMoved,q)})()};
+// Input 91
+/*
+
+ Copyright (C) 2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("gui.SelectionView");
+gui.SelectionViewManager=function(){function e(){return Object.keys(h).map(function(e){return h[e]})}var h={};this.getSelectionView=function(e){return h.hasOwnProperty(e)?h[e]:null};this.getSelectionViews=e;this.removeSelectionView=function(e){h.hasOwnProperty(e)&&(h[e].destroy(function(){}),delete h[e])};this.hideSelectionView=function(e){h.hasOwnProperty(e)&&h[e].hide()};this.showSelectionView=function(e){h.hasOwnProperty(e)&&h[e].show()};this.rerenderSelectionViews=function(){Object.keys(h).forEach(function(e){h[e].visible()&&
+h[e].rerender()})};this.registerCursor=function(e,n){var m=e.getMemberId(),p=new gui.SelectionView(e);n?p.show():p.hide();return h[m]=p};this.destroy=function(f){var h=e();(function p(c,b){b?f(b):c<h.length?h[c].destroy(function(a){p(c+1,a)}):f()})(0,void 0)}};
+// Input 92
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
+*/
+runtime.loadClass("core.EventNotifier");runtime.loadClass("core.DomUtils");runtime.loadClass("odf.OdfUtils");runtime.loadClass("odf.Namespaces");runtime.loadClass("gui.SelectionMover");runtime.loadClass("core.PositionFilterChain");
+ops.OdtDocument=function(e){function h(){var a=e.odfContainer().getContentElement(),b=a&&a.localName;runtime.assert("text"===b,"Unsupported content element type '"+b+"'for OdtDocument");return a}function f(a){function b(a){for(;a&&!(a.namespaceURI===odf.Namespaces.officens&&"text"===a.localName||a.namespaceURI===odf.Namespaces.officens&&"annotation"===a.localName);)a=a.parentNode;return a}this.acceptPosition=function(c){c=c.container();var d;d="string"===typeof a?k[a].getNode():a;return b(c)===b(d)?
+q:l}}function n(a){var b=gui.SelectionMover.createPositionIterator(h());for(a+=1;0<a&&b.nextPosition();)r.acceptPosition(b)===q&&(a-=1);return b}function m(b){return a.getParagraphElement(b)}function p(a,b){return e.getFormatting().getStyleElement(a,b)}function c(a){return p(a,"paragraph")}var b=this,a,d,k={},g=new core.EventNotifier([ops.OdtDocument.signalCursorAdded,ops.OdtDocument.signalCursorRemoved,ops.OdtDocument.signalCursorMoved,ops.OdtDocument.signalParagraphChanged,ops.OdtDocument.signalParagraphStyleModified,
+ops.OdtDocument.signalCommonStyleCreated,ops.OdtDocument.signalCommonStyleDeleted,ops.OdtDocument.signalTableAdded,ops.OdtDocument.signalOperationExecuted,ops.OdtDocument.signalUndoStackChanged]),q=core.PositionFilter.FilterResult.FILTER_ACCEPT,l=core.PositionFilter.FilterResult.FILTER_REJECT,r;this.getIteratorAtPosition=n;this.getStyleElement=p;this.upgradeWhitespacesAtPosition=function(b){b=n(b);var c,d,e;b.previousPosition();b.previousPosition();for(e=-1;1>=e;e+=1){c=b.container();d=b.unfilteredDomOffset();
+if(c.nodeType===Node.TEXT_NODE&&" "===c.data[d]&&a.isSignificantWhitespace(c,d)){runtime.assert(" "===c.data[d],"upgradeWhitespaceToElement: textNode.data[offset] should be a literal space");var f=c.ownerDocument.createElementNS(odf.Namespaces.textns,"text:s");f.appendChild(c.ownerDocument.createTextNode(" "));c.deleteData(d,1);0<d&&(c=c.splitText(d));c.parentNode.insertBefore(f,c);c=f;b.moveToEndOfNode(c)}b.nextPosition()}};this.downgradeWhitespacesAtPosition=function(b){var c=n(b),e;b=c.container();
+for(c=c.unfilteredDomOffset();!a.isCharacterElement(b)&&b.childNodes[c];)b=b.childNodes[c],c=0;b.nodeType===Node.TEXT_NODE&&(b=b.parentNode);a.isDowngradableSpaceElement(b)&&(c=b.firstChild,e=b.lastChild,d.mergeIntoParent(b),e!==c&&d.normalizeTextNodes(e),d.normalizeTextNodes(c))};this.getParagraphStyleElement=c;this.getParagraphElement=m;this.getParagraphStyleAttributes=function(a){return(a=c(a))?e.getFormatting().getInheritedStyleAttributes(a):null};this.getPositionInTextNode=function(a,c){var d=
+gui.SelectionMover.createPositionIterator(h()),e=null,f,g=0,l=null,l=a;runtime.assert(0<=a,"position must be >= 0");r.acceptPosition(d)===q?(f=d.container(),f.nodeType===Node.TEXT_NODE&&(e=f,g=0)):a+=1;for(;0<a||null===e;){if(!d.nextPosition())return null;if(r.acceptPosition(d)===q)if(a-=1,f=d.container(),f.nodeType===Node.TEXT_NODE)f!==e?(e=f,g=d.unfilteredDomOffset()):g+=1;else if(null!==e){if(0===a){g=e.length;break}e=null}else if(0===a){e=h().ownerDocument.createTextNode("");f.insertBefore(e,
+d.rightNode());g=0;break}}if(null===e)return null;if(c&&k[c]&&b.getCursorPosition(c)===l){for(l=k[c].getNode();0===g&&l.nextSibling&&"cursor"===l.nextSibling.localName;)l.parentNode.insertBefore(l,l.nextSibling.nextSibling);0<e.length&&(e=h().ownerDocument.createTextNode(""),g=0,l.parentNode.insertBefore(e,l.nextSibling));for(;0===g&&e.previousSibling&&"cursor"===e.previousSibling.localName&&(f=e.previousSibling,0<e.length&&(e=h().ownerDocument.createTextNode("")),f.parentNode.insertBefore(e,f),l!==
+f););}for(;e.previousSibling&&e.previousSibling.nodeType===Node.TEXT_NODE;)e.previousSibling.appendData(e.data),g=e.previousSibling.length,e=e.previousSibling,e.parentNode.removeChild(e.nextSibling);return{textNode:e,offset:g}};this.fixCursorPositions=function(){var a=new core.PositionFilterChain;a.addFilter("BaseFilter",r);Object.keys(k).forEach(function(c){var d=k[c],e=d.getStepCounter(),f,g,h=!1;a.addFilter("RootFilter",b.createRootFilter(c));c=e.countStepsToPosition(d.getAnchorNode(),0,a);e.isPositionWalkable(a)?
+0===c&&(h=!0,d.move(0)):(h=!0,f=e.countPositionsToNearestStep(d.getNode(),0,a),g=e.countPositionsToNearestStep(d.getAnchorNode(),0,a),d.move(f),0!==c&&(0<g&&(c+=1),0<f&&(c-=1),e=e.countSteps(c,a),d.move(e),d.move(-e,!0)));h&&b.emit(ops.OdtDocument.signalCursorMoved,d);a.removeFilter("RootFilter")})};this.getWalkableParagraphLength=function(a){var b=n(0),c=0;b.setUnfilteredPosition(a,0);do{if(m(b.container())!==a)break;r.acceptPosition(b)===q&&(c+=1)}while(b.nextPosition());return c};this.getDistanceFromCursor=
+function(a,b,c){a=k[a];var d=0;runtime.assert(null!==b&&void 0!==b,"OdtDocument.getDistanceFromCursor called without node");a&&(a=a.getStepCounter().countStepsToPosition,d=a(b,c,r));return d};this.getCursorPosition=function(a){return-b.getDistanceFromCursor(a,h(),0)};this.getCursorSelection=function(a){var b;a=k[a];var c=0;b=0;a&&(b=a.getStepCounter().countStepsToPosition,c=-b(h(),0,r),b=b(a.getAnchorNode(),0,r));return{position:c+b,length:-b}};this.getPositionFilter=function(){return r};this.getOdfCanvas=
+function(){return e};this.getRootNode=h;this.getDOM=function(){return h().ownerDocument};this.getCursor=function(a){return k[a]};this.getCursors=function(){var a=[],b;for(b in k)k.hasOwnProperty(b)&&a.push(k[b]);return a};this.addCursor=function(a){runtime.assert(Boolean(a),"OdtDocument::addCursor without cursor");var b=a.getStepCounter().countSteps(1,r),c=a.getMemberId();runtime.assert("string"===typeof c,"OdtDocument::addCursor has cursor without memberid");runtime.assert(!k[c],"OdtDocument::addCursor is adding a duplicate cursor with memberid "+
+c);a.move(b);k[c]=a};this.removeCursor=function(a){var c=k[a];return c?(c.removeFromOdtDocument(),delete k[a],b.emit(ops.OdtDocument.signalCursorRemoved,a),!0):!1};this.getMetaData=function(a){for(var b=e.odfContainer().rootElement.firstChild;b&&"meta"!==b.localName;)b=b.nextSibling;for(b=b&&b.firstChild;b&&b.localName!==a;)b=b.nextSibling;for(b=b&&b.firstChild;b&&b.nodeType!==Node.TEXT_NODE;)b=b.nextSibling;return b?b.data:null};this.getFormatting=function(){return e.getFormatting()};this.emit=function(a,
+b){g.emit(a,b)};this.subscribe=function(a,b){g.subscribe(a,b)};this.unsubscribe=function(a,b){g.unsubscribe(a,b)};this.createRootFilter=function(a){return new f(a)};this.close=function(a){a()};this.destroy=function(a){a()};r=new function(){function b(c,d,e){var f,g;if(d&&(f=a.lookLeftForCharacter(d),1===f||2===f&&(a.scanRightForAnyCharacter(e)||a.scanRightForAnyCharacter(a.nextNode(c)))))return q;f=null===d&&a.isParagraph(c);g=a.lookRightForCharacter(e);if(f)return g?q:a.scanRightForAnyCharacter(e)?
+l:q;if(!g)return l;d=d||a.previousNode(c);return a.scanLeftForAnyCharacter(d)?l:q}this.acceptPosition=function(c){var d=c.container(),e=d.nodeType,f,g,k;if(e!==Node.ELEMENT_NODE&&e!==Node.TEXT_NODE)return l;if(e===Node.TEXT_NODE){if(!a.isGroupingElement(d.parentNode)||a.isWithinTrackedChanges(d.parentNode,h()))return l;e=c.unfilteredDomOffset();f=d.data;runtime.assert(e!==f.length,"Unexpected offset.");if(0<e){c=f.substr(e-1,1);if(!a.isODFWhitespace(c))return q;if(1<e)if(c=f.substr(e-2,1),!a.isODFWhitespace(c))g=
+q;else{if(!a.isODFWhitespace(f.substr(0,e)))return l}else k=a.previousNode(d),a.scanLeftForNonWhitespace(k)&&(g=q);if(g===q)return a.isTrailingWhitespace(d,e)?l:q;g=f.substr(e,1);return a.isODFWhitespace(g)?l:a.scanLeftForAnyCharacter(a.previousNode(d))?l:q}k=c.leftNode();g=d;d=d.parentNode;g=b(d,k,g)}else!a.isGroupingElement(d)||a.isWithinTrackedChanges(d,h())?g=l:(k=c.leftNode(),g=c.rightNode(),g=b(d,k,g));return g}};a=new odf.OdfUtils;d=new core.DomUtils};ops.OdtDocument.signalCursorAdded="cursor/added";
+ops.OdtDocument.signalCursorRemoved="cursor/removed";ops.OdtDocument.signalCursorMoved="cursor/moved";ops.OdtDocument.signalParagraphChanged="paragraph/changed";ops.OdtDocument.signalTableAdded="table/added";ops.OdtDocument.signalCommonStyleCreated="style/created";ops.OdtDocument.signalCommonStyleDeleted="style/deleted";ops.OdtDocument.signalParagraphStyleModified="paragraphstyle/modified";ops.OdtDocument.signalOperationExecuted="operation/executed";ops.OdtDocument.signalUndoStackChanged="undo/changed";
+(function(){return ops.OdtDocument})();
+// Input 93
+/*
+
+ Copyright (C) 2012-2013 KO GmbH <copyright@kogmbh.com>
+
+ @licstart
+ The JavaScript code in this page is free software: you can redistribute it
+ and/or modify it under the terms of the GNU Affero General Public License
+ (GNU AGPL) as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.  The code is distributed
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU AGPL for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this code.  If not, see <http://www.gnu.org/licenses/>.
+
+ As additional permission under GNU AGPL version 3 section 7, you
+ may distribute non-source (e.g., minimized or compacted) forms of
+ that code without the copy of the GNU GPL normally required by
+ section 4, provided you include this license notice and a URL
+ through which recipients can access the Corresponding Source.
+
+ As a special exception to the AGPL, any HTML file which merely makes function
+ calls to this code, and for that purpose includes it by reference shall be
+ deemed a separate work for copyright law purposes. In addition, the copyright
+ holders of this code give you permission to combine this code with free
+ software libraries that are released under the GNU LGPL. You may copy and
+ distribute such a system following the terms of the GNU AGPL for this code
+ and the LGPL for the libraries. If you modify this code, you may extend this
+ exception to your version of the code, but you are not obligated to do so.
+ If you do not wish to do so, delete this exception statement from your
+ version.
+
+ This license applies to this entire compilation.
+ @licend
+ @source: http://www.webodf.org/
+ @source: https://github.com/kogmbh/WebODF/
 */
 runtime.loadClass("ops.TrivialMemberModel");runtime.loadClass("ops.TrivialOperationRouter");runtime.loadClass("ops.OperationFactory");runtime.loadClass("ops.OdtDocument");
-ops.Session=function(h){var m=new ops.OperationFactory,f=new ops.OdtDocument(h),a=new ops.TrivialMemberModel,c=null;this.setMemberModel=function(c){a=c};this.setOperationFactory=function(a){m=a;c&&c.setOperationFactory(m)};this.setOperationRouter=function(a){c=a;a.setPlaybackFunction(function(a){a.execute(f);f.emit(ops.OdtDocument.signalOperationExecuted,a)});a.setOperationFactory(m)};this.getMemberModel=function(){return a};this.getOperationFactory=function(){return m};this.getOdtDocument=function(){return f};
-this.enqueue=function(a){c.push(a)};this.close=function(d){c.close(function(b){b?d(b):a.close(function(a){a?d(a):f.close(d)})})};this.destroy=function(a){f.destroy(a)};this.setOperationRouter(new ops.TrivialOperationRouter)};
-// Input 84
-var webodf_css="@namespace draw url(urn:oasis:names:tc:opendocument:xmlns:drawing:1.0);\n@namespace fo url(urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0);\n@namespace office url(urn:oasis:names:tc:opendocument:xmlns:office:1.0);\n@namespace presentation url(urn:oasis:names:tc:opendocument:xmlns:presentation:1.0);\n@namespace style url(urn:oasis:names:tc:opendocument:xmlns:style:1.0);\n@namespace svg url(urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0);\n@namespace table url(urn:oasis:names:tc:opendocument:xmlns:table:1.0);\n@namespace text url(urn:oasis:names:tc:opendocument:xmlns:text:1.0);\n@namespace runtimens url(urn:webodf); /* namespace for runtime only */\n@namespace cursor url(urn:webodf:names:cursor);\n@namespace editinfo url(urn:webodf:names:editinfo);\n@namespace annotation url(urn:webodf:names:annotation);\n@namespace dc url(http://purl.org/dc/elements/1.1/);\n\noffice|document > *, office|document-content > * {\n  display: none;\n}\noffice|body, office|document {\n  display: inline-block;\n  position: relative;\n}\n\ntext|p, text|h {\n  display: block;\n  padding: 0;\n  margin: 0;\n  line-height: normal;\n  position: relative;\n  min-height: 1.3em; /* prevent empty paragraphs and headings from collapsing if they are empty */\n}\n*[runtimens|containsparagraphanchor] {\n  position: relative;\n}\ntext|s {\n    white-space: pre;\n}\ntext|tab {\n  display: inline;\n  white-space: pre;\n}\ntext|line-break {\n  content: \" \";\n  display: block;\n}\ntext|tracked-changes {\n  /*Consumers that do not support change tracking, should ignore changes.*/\n  display: none;\n}\noffice|binary-data {\n  display: none;\n}\noffice|text {\n  display: block;\n  text-align: left;\n  overflow: visible;\n  word-wrap: break-word;\n}\n\noffice|text::selection {\n    /** Let's not draw selection highlight that overflows into the office|text\n     * node when selecting content across several paragraphs\n     */\n    background: transparent;\n}\noffice|text * draw|text-box {\n    /** only for text documents */\n    display: block;\n    border: 1px solid #d3d3d3;\n}\noffice|spreadsheet {\n  display: block;\n  border-collapse: collapse;\n  empty-cells: show;\n  font-family: sans-serif;\n  font-size: 10pt;\n  text-align: left;\n  page-break-inside: avoid;\n  overflow: hidden;\n}\noffice|presentation {\n  display: inline-block;\n  text-align: left;\n}\n#shadowContent {\n  display: inline-block;\n  text-align: left;\n}\ndraw|page {\n  display: block;\n  position: relative;\n  overflow: hidden;\n}\npresentation|notes, presentation|footer-decl, presentation|date-time-decl {\n    display: none;\n}\n@media print {\n  draw|page {\n    border: 1pt solid black;\n    page-break-inside: avoid;\n  }\n  presentation|notes {\n    /*TODO*/\n  }\n}\noffice|spreadsheet text|p {\n  border: 0px;\n  padding: 1px;\n  margin: 0px;\n}\noffice|spreadsheet table|table {\n  margin: 3px;\n}\noffice|spreadsheet table|table:after {\n  /* show sheet name the end of the sheet */\n  /*content: attr(table|name);*/ /* gives parsing error in opera */\n}\noffice|spreadsheet table|table-row {\n  counter-increment: row;\n}\noffice|spreadsheet table|table-row:before {\n  width: 3em;\n  background: #cccccc;\n  border: 1px solid black;\n  text-align: center;\n  content: counter(row);\n  display: table-cell;\n}\noffice|spreadsheet table|table-cell {\n  border: 1px solid #cccccc;\n}\ntable|table {\n  display: table;\n}\ndraw|frame table|table {\n  width: 100%;\n  height: 100%;\n  background: white;\n}\ntable|table-header-rows {\n  display: table-header-group;\n}\ntable|table-row {\n  display: table-row;\n}\ntable|table-column {\n  display: table-column;\n}\ntable|table-cell {\n  width: 0.889in;\n  display: table-cell;\n  word-break: break-all; /* prevent long words from extending out the table cell */\n}\ndraw|frame {\n  display: block;\n}\ndraw|image {\n  display: block;\n  width: 100%;\n  height: 100%;\n  top: 0px;\n  left: 0px;\n  background-repeat: no-repeat;\n  background-size: 100% 100%;\n  -moz-background-size: 100% 100%;\n}\n/* only show the first image in frame */\ndraw|frame > draw|image:nth-of-type(n+2) {\n  display: none;\n}\ntext|list:before {\n    display: none;\n    content:\"\";\n}\ntext|list {\n    counter-reset: list;\n}\ntext|list-item {\n    display: block;\n}\ntext|number {\n    display:none;\n}\n\ntext|a {\n    color: blue;\n    text-decoration: underline;\n    cursor: pointer;\n}\ntext|note-citation {\n    vertical-align: super;\n    font-size: smaller;\n}\ntext|note-body {\n    display: none;\n}\ntext|note:hover text|note-citation {\n    background: #dddddd;\n}\ntext|note:hover text|note-body {\n    display: block;\n    left:1em;\n    max-width: 80%;\n    position: absolute;\n    background: #ffffaa;\n}\nsvg|title, svg|desc {\n    display: none;\n}\nvideo {\n    width: 100%;\n    height: 100%\n}\n\n/* below set up the cursor */\ncursor|cursor {\n    display: inline;\n    width: 0px;\n    height: 1em;\n    /* making the position relative enables the avatar to use\n       the cursor as reference for its absolute position */\n    position: relative;\n    z-index: 1;\n}\ncursor|cursor > span {\n    display: inline;\n    position: absolute;\n    top: 5%; /* push down the caret; 0px can do the job, 5% looks better, 10% is a bit over */\n    height: 1em;\n    border-left: 2px solid black;\n    outline: none;\n}\n\ncursor|cursor > div {\n    padding: 3px;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    border: none !important;\n    border-radius: 5px;\n    opacity: 0.3;\n}\n\ncursor|cursor > div > img {\n    border-radius: 5px;\n}\n\ncursor|cursor > div.active {\n    opacity: 0.8;\n}\n\ncursor|cursor > div:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 43%;\n}\n\n\n.editInfoMarker {\n    position: absolute;\n    width: 10px;\n    height: 100%;\n    left: -20px;\n    opacity: 0.8;\n    top: 0;\n    border-radius: 5px;\n    background-color: transparent;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n}\n.editInfoMarker:hover {\n    box-shadow: 0px 0px 8px rgba(0, 0, 0, 1);\n}\n\n.editInfoHandle {\n    position: absolute;\n    background-color: black;\n    padding: 5px;\n    border-radius: 5px;\n    opacity: 0.8;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    bottom: 100%;\n    margin-bottom: 10px;\n    z-index: 3;\n    left: -25px;\n}\n.editInfoHandle:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 5px;\n}\n.editInfo {\n    font-family: sans-serif;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    color: white;\n    width: 100%;\n    height: 12pt;\n}\n.editInfoColor {\n    float: left;\n    width: 10pt;\n    height: 10pt;\n    border: 1px solid white;\n}\n.editInfoAuthor {\n    float: left;\n    margin-left: 5pt;\n    font-size: 10pt;\n    text-align: left;\n    height: 12pt;\n    line-height: 12pt;\n}\n.editInfoTime {\n    float: right;\n    margin-left: 30pt;\n    font-size: 8pt;\n    font-style: italic;\n    color: yellow;\n    height: 12pt;\n    line-height: 12pt;\n}\n\n.annotationWrapper {\n    display: inline;\n    position: relative;\n}\n\n.annotationRemoveButton:before {\n    content: '\u00d7';\n    color: white;\n    padding: 5px;\n    line-height: 1em;\n}\n\n.annotationRemoveButton {\n    width: 20px;\n    height: 20px;\n    border-radius: 10px;\n    background-color: black;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    position: absolute;\n    top: -10px;\n    left: -10px;\n    z-index: 3;\n    text-align: center;\n    font-family: sans-serif;\n    font-style: normal;\n    font-weight: normal;\n    text-decoration: none;\n    font-size: 15px;\n}\n.annotationRemoveButton:hover {\n    cursor: pointer;\n    box-shadow: 0px 0px 5px rgba(0, 0, 0, 1);\n}\n\n.annotationNote {\n    width: 4cm;\n    position: absolute;\n    display: inline;\n    z-index: 10;\n}\n.annotationNote > office|annotation {\n    display: block;\n    text-align: left;\n}\n\n.annotationConnector {\n    position: absolute;\n    display: inline;\n    z-index: 2;\n    border-top: 1px dashed brown;\n}\n.annotationConnector.angular {\n    -moz-transform-origin: left top;\n    -webkit-transform-origin: left top;\n    -ms-transform-origin: left top;\n    transform-origin: left top;\n}\n.annotationConnector.horizontal {\n    left: 0;\n}\n.annotationConnector.horizontal:before {\n    content: '';\n    display: inline;\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: brown transparent transparent transparent;\n    top: -1px;\n    left: -5px;\n}\n\noffice|annotation {\n    width: 100%;\n    height: 100%;\n    display: none;\n    background: rgb(198, 238, 184);\n    background: -moz-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -webkit-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -o-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -ms-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: linear-gradient(180deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    box-shadow: 0 3px 4px -3px #ccc;\n}\n\noffice|annotation > dc|creator {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    color: white;\n    background-color: brown;\n    padding: 4px;\n}\noffice|annotation > dc|date {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    border: 4px solid transparent;\n}\noffice|annotation > text|list {\n    display: block;\n    padding: 5px;\n}\n\n/* This is very temporary CSS. This must go once\n * we start bundling webodf-default ODF styles for annotations.\n */\noffice|annotation text|p {\n    font-size: 10pt;\n    color: black;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    font-family: sans-serif;\n}\n\ndc|*::selection {\n    background: transparent;\n}\ndc|*::-moz-selection {\n    background: transparent;\n}\n\n#annotationsPane {\n    background-color: #EAEAEA;\n    width: 4cm;\n    height: 100%;\n    display: none;\n    position: absolute;\n    outline: 1px solid #ccc;\n}\n\n.annotationHighlight {\n    background-color: yellow;\n    position: relative;\n}\n";
+ops.Session=function(e){var h=new ops.OperationFactory,f=new ops.OdtDocument(e),n=new ops.TrivialMemberModel,m=null;this.setMemberModel=function(e){n=e};this.setOperationFactory=function(e){h=e;m&&m.setOperationFactory(h)};this.setOperationRouter=function(e){m=e;e.setPlaybackFunction(function(c){c.execute(f);f.emit(ops.OdtDocument.signalOperationExecuted,c)});e.setOperationFactory(h)};this.getMemberModel=function(){return n};this.getOperationFactory=function(){return h};this.getOdtDocument=function(){return f};
+this.enqueue=function(e){m.push(e)};this.close=function(e){m.close(function(c){c?e(c):n.close(function(b){b?e(b):f.close(e)})})};this.destroy=function(e){f.destroy(e)};this.setOperationRouter(new ops.TrivialOperationRouter)};
+// Input 94
+var webodf_css="@namespace draw url(urn:oasis:names:tc:opendocument:xmlns:drawing:1.0);\n@namespace fo url(urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0);\n@namespace office url(urn:oasis:names:tc:opendocument:xmlns:office:1.0);\n@namespace presentation url(urn:oasis:names:tc:opendocument:xmlns:presentation:1.0);\n@namespace style url(urn:oasis:names:tc:opendocument:xmlns:style:1.0);\n@namespace svg url(urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0);\n@namespace table url(urn:oasis:names:tc:opendocument:xmlns:table:1.0);\n@namespace text url(urn:oasis:names:tc:opendocument:xmlns:text:1.0);\n@namespace webodfhelper url(urn:webodf:names:helper);\n@namespace cursor url(urn:webodf:names:cursor);\n@namespace editinfo url(urn:webodf:names:editinfo);\n@namespace annotation url(urn:webodf:names:annotation);\n@namespace dc url(http://purl.org/dc/elements/1.1/);\n\noffice|document > *, office|document-content > * {\n  display: none;\n}\noffice|body, office|document {\n  display: inline-block;\n  position: relative;\n}\n\ntext|p, text|h {\n  display: block;\n  padding: 0;\n  margin: 0;\n  line-height: normal;\n  position: relative;\n  min-height: 1.3em; /* prevent empty paragraphs and headings from collapsing if they are empty */\n}\n*[webodfhelper|containsparagraphanchor] {\n  position: relative;\n}\ntext|s {\n    white-space: pre;\n}\ntext|tab {\n  display: inline;\n  white-space: pre;\n}\ntext|tracked-changes {\n  /*Consumers that do not support change tracking, should ignore changes.*/\n  display: none;\n}\noffice|binary-data {\n  display: none;\n}\noffice|text {\n  display: block;\n  text-align: left;\n  overflow: visible;\n  word-wrap: break-word;\n}\n\noffice|text::selection {\n  /** Let's not draw selection highlight that overflows into the office|text\n   * node when selecting content across several paragraphs\n   */\n  background: transparent;\n}\n\n.virtualSelections office|document *::selection {\n  background: transparent;\n}\n.virtualSelections office|document *::-moz-selection {\n  background: transparent;\n}\n\noffice|text * draw|text-box {\n/** only for text documents */\n    display: block;\n    border: 1px solid #d3d3d3;\n}\noffice|spreadsheet {\n  display: block;\n  border-collapse: collapse;\n  empty-cells: show;\n  font-family: sans-serif;\n  font-size: 10pt;\n  text-align: left;\n  page-break-inside: avoid;\n  overflow: hidden;\n}\noffice|presentation {\n  display: inline-block;\n  text-align: left;\n}\n#shadowContent {\n  display: inline-block;\n  text-align: left;\n}\ndraw|page {\n  display: block;\n  position: relative;\n  overflow: hidden;\n}\npresentation|notes, presentation|footer-decl, presentation|date-time-decl {\n    display: none;\n}\n@media print {\n  draw|page {\n    border: 1pt solid black;\n    page-break-inside: avoid;\n  }\n  presentation|notes {\n    /*TODO*/\n  }\n}\noffice|spreadsheet text|p {\n  border: 0px;\n  padding: 1px;\n  margin: 0px;\n}\noffice|spreadsheet table|table {\n  margin: 3px;\n}\noffice|spreadsheet table|table:after {\n  /* show sheet name the end of the sheet */\n  /*content: attr(table|name);*/ /* gives parsing error in opera */\n}\noffice|spreadsheet table|table-row {\n  counter-increment: row;\n}\noffice|spreadsheet table|table-row:before {\n  width: 3em;\n  background: #cccccc;\n  border: 1px solid black;\n  text-align: center;\n  content: counter(row);\n  display: table-cell;\n}\noffice|spreadsheet table|table-cell {\n  border: 1px solid #cccccc;\n}\ntable|table {\n  display: table;\n}\ndraw|frame table|table {\n  width: 100%;\n  height: 100%;\n  background: white;\n}\ntable|table-header-rows {\n  display: table-header-group;\n}\ntable|table-row {\n  display: table-row;\n}\ntable|table-column {\n  display: table-column;\n}\ntable|table-cell {\n  width: 0.889in;\n  display: table-cell;\n  word-break: break-all; /* prevent long words from extending out the table cell */\n}\ndraw|frame {\n  display: block;\n}\ndraw|image {\n  display: block;\n  width: 100%;\n  height: 100%;\n  top: 0px;\n  left: 0px;\n  background-repeat: no-repeat;\n  background-size: 100% 100%;\n  -moz-background-size: 100% 100%;\n}\n/* only show the first image in frame */\ndraw|frame > draw|image:nth-of-type(n+2) {\n  display: none;\n}\ntext|list:before {\n    display: none;\n    content:\"\";\n}\ntext|list {\n    counter-reset: list;\n}\ntext|list-item {\n    display: block;\n}\ntext|number {\n    display:none;\n}\n\ntext|a {\n    color: blue;\n    text-decoration: underline;\n    cursor: pointer;\n}\ntext|note-citation {\n    vertical-align: super;\n    font-size: smaller;\n}\ntext|note-body {\n    display: none;\n}\ntext|note:hover text|note-citation {\n    background: #dddddd;\n}\ntext|note:hover text|note-body {\n    display: block;\n    left:1em;\n    max-width: 80%;\n    position: absolute;\n    background: #ffffaa;\n}\nsvg|title, svg|desc {\n    display: none;\n}\nvideo {\n    width: 100%;\n    height: 100%\n}\n\n/* below set up the cursor */\ncursor|cursor {\n    display: inline;\n    width: 0px;\n    height: 1em;\n    /* making the position relative enables the avatar to use\n       the cursor as reference for its absolute position */\n    position: relative;\n    z-index: 1;\n}\ncursor|cursor > span {\n    /* IMPORTANT: when changing these values ensure DEFAULT_CARET_TOP and DEFAULT_CARET_HEIGHT\n        in Caret.js remain in sync */\n    display: inline;\n    position: absolute;\n    top: 5%; /* push down the caret; 0px can do the job, 5% looks better, 10% is a bit over */\n    height: 1em;\n    border-left: 2px solid black;\n    outline: none;\n}\n\ncursor|cursor > div {\n    padding: 3px;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    border: none !important;\n    border-radius: 5px;\n    opacity: 0.3;\n}\n\ncursor|cursor > div > img {\n    border-radius: 5px;\n}\n\ncursor|cursor > div.active {\n    opacity: 0.8;\n}\n\ncursor|cursor > div:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 43%;\n}\n\n\n.editInfoMarker {\n    position: absolute;\n    width: 10px;\n    height: 100%;\n    left: -20px;\n    opacity: 0.8;\n    top: 0;\n    border-radius: 5px;\n    background-color: transparent;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n}\n.editInfoMarker:hover {\n    box-shadow: 0px 0px 8px rgba(0, 0, 0, 1);\n}\n\n.editInfoHandle {\n    position: absolute;\n    background-color: black;\n    padding: 5px;\n    border-radius: 5px;\n    opacity: 0.8;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    bottom: 100%;\n    margin-bottom: 10px;\n    z-index: 3;\n    left: -25px;\n}\n.editInfoHandle:after {\n    content: ' ';\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: black transparent transparent transparent;\n\n    top: 100%;\n    left: 5px;\n}\n.editInfo {\n    font-family: sans-serif;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    color: white;\n    width: 100%;\n    height: 12pt;\n}\n.editInfoColor {\n    float: left;\n    width: 10pt;\n    height: 10pt;\n    border: 1px solid white;\n}\n.editInfoAuthor {\n    float: left;\n    margin-left: 5pt;\n    font-size: 10pt;\n    text-align: left;\n    height: 12pt;\n    line-height: 12pt;\n}\n.editInfoTime {\n    float: right;\n    margin-left: 30pt;\n    font-size: 8pt;\n    font-style: italic;\n    color: yellow;\n    height: 12pt;\n    line-height: 12pt;\n}\n\n.annotationWrapper {\n    display: inline;\n    position: relative;\n}\n\n.annotationRemoveButton:before {\n    content: '\u00d7';\n    color: white;\n    padding: 5px;\n    line-height: 1em;\n}\n\n.annotationRemoveButton {\n    width: 20px;\n    height: 20px;\n    border-radius: 10px;\n    background-color: black;\n    box-shadow: 0px 0px 5px rgba(50, 50, 50, 0.75);\n    position: absolute;\n    top: -10px;\n    left: -10px;\n    z-index: 3;\n    text-align: center;\n    font-family: sans-serif;\n    font-style: normal;\n    font-weight: normal;\n    text-decoration: none;\n    font-size: 15px;\n}\n.annotationRemoveButton:hover {\n    cursor: pointer;\n    box-shadow: 0px 0px 5px rgba(0, 0, 0, 1);\n}\n\n.annotationNote {\n    width: 4cm;\n    position: absolute;\n    display: inline;\n    z-index: 10;\n}\n.annotationNote > office|annotation {\n    display: block;\n    text-align: left;\n}\n\n.annotationConnector {\n    position: absolute;\n    display: inline;\n    z-index: 2;\n    border-top: 1px dashed brown;\n}\n.annotationConnector.angular {\n    -moz-transform-origin: left top;\n    -webkit-transform-origin: left top;\n    -ms-transform-origin: left top;\n    transform-origin: left top;\n}\n.annotationConnector.horizontal {\n    left: 0;\n}\n.annotationConnector.horizontal:before {\n    content: '';\n    display: inline;\n    position: absolute;\n    width: 0px;\n    height: 0px;\n    border-style: solid;\n    border-width: 8.7px 5px 0 5px;\n    border-color: brown transparent transparent transparent;\n    top: -1px;\n    left: -5px;\n}\n\noffice|annotation {\n    width: 100%;\n    height: 100%;\n    display: none;\n    background: rgb(198, 238, 184);\n    background: -moz-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -webkit-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -o-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: -ms-linear-gradient(90deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    background: linear-gradient(180deg, rgb(198, 238, 184) 30%, rgb(180, 196, 159) 100%);\n    box-shadow: 0 3px 4px -3px #ccc;\n}\n\noffice|annotation > dc|creator {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    color: white;\n    background-color: brown;\n    padding: 4px;\n}\noffice|annotation > dc|date {\n    display: block;\n    font-size: 10pt;\n    font-weight: normal;\n    font-style: normal;\n    font-family: sans-serif;\n    border: 4px solid transparent;\n}\noffice|annotation > text|list {\n    display: block;\n    padding: 5px;\n}\n\n/* This is very temporary CSS. This must go once\n * we start bundling webodf-default ODF styles for annotations.\n */\noffice|annotation text|p {\n    font-size: 10pt;\n    color: black;\n    font-weight: normal;\n    font-style: normal;\n    text-decoration: none;\n    font-family: sans-serif;\n}\n\ndc|*::selection {\n    background: transparent;\n}\ndc|*::-moz-selection {\n    background: transparent;\n}\n\n#annotationsPane {\n    background-color: #EAEAEA;\n    width: 4cm;\n    height: 100%;\n    display: none;\n    position: absolute;\n    outline: 1px solid #ccc;\n}\n\n.annotationHighlight {\n    background-color: yellow;\n    position: relative;\n}\n\n.selectionOverlay {\n    position: absolute;\n    z-index: 15;\n    opacity: 0.2;\n    pointer-events: none;\n    top: 0;\n    left: 0;\n    width: 0;\n    height: 0;\n}\n\n#imageSelector {\n    display: none;\n    position: absolute;\n    border-style: solid;\n    border-color: black;\n}\n\n#imageSelector > div {\n    width: 5px;\n    height: 5px;\n    display: block;\n    position: absolute;\n    border: 1px solid black;\n    background-color: #ffffff;\n}\n\n#imageSelector > .topLeft {\n    top: -4px;\n    left: -4px;\n}\n\n#imageSelector > .topRight {\n    top: -4px;\n    right: -4px;\n}\n\n#imageSelector > .bottomRight {\n    right: -4px;\n    bottom: -4px;\n}\n\n#imageSelector > .bottomLeft {\n    bottom: -4px;\n    left: -4px;\n}\n\n#imageSelector > .topMiddle {\n    top: -4px;\n    left: 50%;\n    margin-left: -2.5px; /* half of the width defined in #imageSelector > div */\n}\n\n#imageSelector > .rightMiddle {\n    top: 50%;\n    right: -4px;\n    margin-top: -2.5px; /* half of the height defined in #imageSelector > div */\n}\n\n#imageSelector > .bottomMiddle {\n    bottom: -4px;\n    left: 50%;\n    margin-left: -2.5px; /* half of the width defined in #imageSelector > div */\n}\n\n#imageSelector > .leftMiddle {\n    top: 50%;\n    left: -4px;\n    margin-top: -2.5px; /* half of the height defined in #imageSelector > div */\n}\n";

--- a/js/documents.js
+++ b/js/documents.js
@@ -167,7 +167,9 @@ var documentsMain = {
 				var serverFactory = new ServerFactory();
 				documentsMain.esId = response.es_id;
 				documentsMain.memberId = response.member_id;
-				
+
+				// TODO: set webodf translation system, by passing a proper function translate(!string):!string in "runtime.setTranslator(translate);"
+
 				documentsMain.webodfServerInstance = serverFactory.createServer();
 				documentsMain.webodfServerInstance.setToken(oc_requesttoken);
 				documentsMain.webodfEditorInstance = new Editor({unstableFeaturesEnabled: documentsMain.useUnstable}, documentsMain.webodfServerInstance, serverFactory);


### PR DESCRIPTION
- enables initial support for integrating into OC-Docs translation system
- fixes broken paragraphstyle dialog on 2nd and later editor start with the same OC-App page-life-cycle
- showing selections of other users, not just the cursor
- lots of small fixes with cursor/selection

For hooking up the translation systems there is now a call in the global (yes, ideally would be namespaced with "webodf.", that will come soon, but that needs some more work) runtime object, by which for now a lookup-method can be registered that will then be used inside the webodf code.
The method needs to have the signature "function translate(!string):!string", getting in the engineer/default english term and returning the proper translation. Simple, but works for now (tm).

Question is how to hook-up with transiflex given that method, but that discussion needs to be continued in the proper issue #14
