### PR TITLE
let the core CSS handle the toolbar stuff

### DIFF
--- a/css/viewer/odfviewer.css
+++ b/css/viewer/odfviewer.css
@@ -8,13 +8,3 @@
   -moz-box-shadow: 0px 4px 10px #000;
   -webkit-box-shadow: 0px 4px 10px #000;
 }
-
-#odf_close{
-	top: 0px;
-	position: absolute;
-	left: 10px;
-}
-
-#odf-toolbar{
-    padding: 0 0 0 1em
-}


### PR DESCRIPTION
cc @jancborchardt @VicDeo 

occured while debugging owncloud/core#5946

Are these rules used anywhere else? Just in the preview from the file app, right?
