### PR TITLE
Don't display read-only docs

### DIFF
--- a/lib/storage.php
+++ b/lib/storage.php
@@ -34,6 +34,9 @@ class Storage {
 					if (strpos($item['path'], '_trashbin')===0){
 						return false;
 					}
+					if (!\OC\Files\Filesystem::isUpdatable($item['path'])) {
+						return false;
+					}
 					return true;
 				}
 		);


### PR DESCRIPTION
Half-PR for #62 

The first commit will hide the non-writable docs from the view.

But for security purposes I'd also like to forbid opening it if you know the correct URL.
Any pointers @VicDeo  ?
