### PR TITLE
Fixed file not found issue

### DIFF
--- a/lib/file.php
+++ b/lib/file.php
@@ -177,17 +177,18 @@ class File {
 		/* to emit hooks properly, view root should contain /user/files */
 		
 		if (strpos($this->path, 'files') === 0){
-			$this->path = preg_replace('|^files|', '', $this->path);
+			$path = preg_replace('|^files|', '', $this->path);
 			$view = new View('/' . $this->owner . '/files');
 		} else {
+			$path = $this->path;
 			$view = new View('/' . $this->owner);
 		}
 		
-		if (!$view->file_exists($this->path)){
+		if (!$view->file_exists($path)){
 			throw new \Exception($this->path . ' doesn\'t exist');
 		}
 		
-		return array($view, $this->path);
+		return array($view, $path);
 	}
 
 	public function getOwner(){


### PR DESCRIPTION
This fixes an issue where the second call would miss the "/files" part.

The path attribute must keep "files" so that the next call to the File
instance will still have the correct one.

Fixes #135 

Please review @VicDeo 

I'm still testing this and there are some issues with sharing, I'm not sure whether they are related to my fix.
I'll report them separately.
