### PR TITLE
remove unneeded extra icon class

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -13,7 +13,7 @@ var documentsMain = {
 	
 	UI : {
 		/* Overlay HTML */
-		overlay : '<div id="documents-overlay" class="icon icon-loading-dark"></div> <div id="documents-overlay-below" class="icon icon-loading-dark"></div>',
+		overlay : '<div id="documents-overlay" class="icon-loading-dark"></div> <div id="documents-overlay-below" class="icon-loading-dark"></div>',
 				
 		/* Toolbar HTML */
 		toolbar : '<div id="odf-toolbar" class="dijitToolbar">' +
@@ -599,12 +599,12 @@ $(document).ready(function() {
 	var file_upload_start = $('#file_upload_start');
 	if (supportAjaxUploadWithProgress()) {
 		file_upload_start.on('fileuploadstart', function(e, data) {
-			$('#upload').addClass('icon icon-loading');
+			$('#upload').addClass('icon-loading');
 			$('.add-document .upload').css({opacity:0})
 		});
 	}
 	file_upload_start.on('fileuploaddone', function(){
-		$('#upload').removeClass('icon icon-loading');
+		$('#upload').removeClass('icon-loading');
 		$('.add-document .upload').css({opacity:0.7})
 		documentsMain.show();
 	});

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -1,7 +1,7 @@
 <div id="documents-content">
 	<ul class="documentslist">
 		<li class="add-document">
-			<a class="icon icon-add add svg" target="_blank" href="">
+			<a class="icon-add add svg" target="_blank" href="">
 				<label><?php p($l->t('New document')) ?></label>
 			</a> 
 			<div id="upload" title="<?php p($l->t('Upload') . ' max. '.$_['uploadMaxHumanFilesize']) ?>">
@@ -23,12 +23,12 @@
 						   value="(max <?php p($_['uploadMaxHumanFilesize']); ?>)" />
 					<input type="hidden" name="dir" value="<?php p($_['savePath']) ?>" id="dir" />
 					<input type="file" id="file_upload_start" name='files[]' />
-					<a href="#" class="icon icon-upload upload svg">
+					<a href="#" class="icon-upload upload svg">
 					<label><?php p($l->t('Upload')) ?></label></a>
 				</form>
 			</div>
 		</li>
-		<li class="progress icon icon-loading"><div><?php p($l->t('Loading documents...')); ?></div></li>
+		<li class="progress icon-loading"><div><?php p($l->t('Loading documents...')); ?></div></li>
 		<li class="document template" data-id="" style="display:none;">
 			<a target="_blank" href=""><label></label></a>
 		</li>


### PR DESCRIPTION
As per the change by @jbtbnl in https://github.com/owncloud/core/pull/7382 the extra icon class is not needed anymore.

Please review @owncloud/designers @VicDeo 
