### PR TITLE
Show preview images larger

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,12 @@
+/* IE 8 fixes */
+.ie8 .document label {
+	background-color: #fff;
+}
+.ie8 .add-document .upload {
+	margin-top: 5px;
+}
+/* end IE 8 fixes */
+
 #editor ::-webkit-scrollbar-thumb {
 	background-color: #fff;
 }
@@ -11,13 +20,14 @@
 	height: 200px;
 	width: 200px;
 	float: left;
-	background-color: #e8e8e8;
 	margin: 14px;
 	vertical-align: top;
-	border-radius: 5px;
 }
 
 .add-document a {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 	display: inline-block;
 	position: relative;
 	height: 100px;
@@ -33,12 +43,17 @@
 .add-document .add,
 .add-document .upload {
 	opacity: .7;
+	border: 1px solid #e8e8e8;
+}
+.add-document .upload {
+	margin-top: 4px;
 }
 .add-document .add:hover,
 .add-document .add:focus,
 .add-document #upload:hover .upload,
 .add-document .upload:focus {
 	opacity: 1;
+	border: 1px solid #818181;
 }
 
 .add-document label {
@@ -50,10 +65,7 @@
 }
 
 .documentslist .progress{
-	position:absolute;
-	left:232px;
-	z-index:5;
-	background-color: #e8e8e8;
+	border: 1px solid #e8e8e8;
 }
 
 .documentslist .progress div{
@@ -73,18 +85,19 @@
 	width: 32px;
 }
 .document a {
-	border-radius: 5px;
 	display: block;
 	position: relative;
 	height: 200px;
 	width: 200px;
 	background-repeat: no-repeat;
 	background-size: 200px;
-	border: 1px solid grey;
+	border: 1px solid #e8e8e8;
+}
+.document a:hover {
+	border: 1px solid #818181;
 }
 .document label {
-	background: lightgray;
-	opacity: 0.6;
+	background: rgba(255, 255, 255, 0.7);
 	position: absolute;
 	bottom: 0px;
 	width: 100%;

--- a/js/documents.js
+++ b/js/documents.js
@@ -649,7 +649,7 @@ var documentsMain = {
 /*globals navigator,dojoConfig */
 var usedLocale = "C";
 
-if (navigator && navigator.language.match(/^(de)/)) {
+if (navigator && navigator.language && navigator.language.match(/^(de)/)) {
 	usedLocale = navigator.language.substr(0,2);
 }
 


### PR DESCRIPTION
I actually dislike that the previews are currently shown so little. This offers not really any advantage to the user.

This PR adjust the app to show preview images a little bit larger:

**Before:**
![screenshot 2014-04-16 18 56 39](https://cloud.githubusercontent.com/assets/878997/2722445/1bc9575e-c588-11e3-8bab-4dc2faf06c02.png)

**After:**
![screenshot 2014-04-16 18 53 04](https://cloud.githubusercontent.com/assets/878997/2722403/a40d6f70-c587-11e3-90b5-02f6bcbf7183.png)

I'm not a CSS nor design guru, feel free to adjust anything in this PR ;-)

@jancborchardt @VicDeo 
