### PR TITLE
fixing http range requests

### DIFF
--- a/lib/download/range.php
+++ b/lib/download/range.php
@@ -48,13 +48,17 @@ class Download_Range extends \OCA\Documents\Download {
 		foreach ($ranges as $range){
 			$parts = explode('-', $range);
 
-			if ($parts[0]==='' && $parts[1]=='') {$this->sendNotSatisfiable();}
+			if ($parts[0]==='' && $parts[1]=='') {
+				$this->sendNotSatisfiable();
+			}
 			if ($parts[0]==='') {
 				$start = $size - $parts[1];
-				$end = $size - 1;}
+				$end = $size - 1;
+			}
 			else {
 				$start = $parts[0];
-				$end = ($parts[1]==='') ? $size - 1 : $parts[1];}
+				$end = ($parts[1]==='') ? $size - 1 : $parts[1];
+			}
 
 			if ($start > $end){
 				$this->sendNotSatisfiable();


### PR DESCRIPTION
Range support is broken. The test isset always returns true because the
explode function will return empty strings if nothin is specified. As a
result if parts[0] is an empty string no start is set; same for the
endpoint. This is fixed here. Furthermore if the start is not
specified, the range must be applied to the end of the file as
specified in the the http 1.1 standard. Finally I added brackets to
avoid malformed headers.
