### PR TITLE
Register actions via brand new API

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -83,6 +83,7 @@ var odfViewer = {
 				$(attachToolbarTo).prepend(odfToolbarHtml);
 				$('#odf-toolbar').css({position:'fixed'});
 			} else {
+				$('#controls').css({left:'0px'});
 				$(attachToolbarTo).append(odfToolbarHtml);
 			}
 
@@ -101,6 +102,9 @@ var odfViewer = {
 		FileList.setViewerMode(false);
 		$('#odf-toolbar').remove();
 		$('#odf-canvas').remove();
+		if (!odfViewer.isDocuments){
+			$('#controls').css({left:'auto'});
+		}
 	}
 };
 


### PR DESCRIPTION
`FileActions.register` is improperly deprecated in master so it does nothing but emits a deprecation warning now.
