### PR TITLE
Fix invisible document content when viewing

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -56,7 +56,7 @@ var odfViewer = {
 			
 	onView: function(filename) {
 		var webodfSource = (oc_debug === true) ? 'webodf-debug' : 'webodf',
-		attachTo = odfViewer.isDocuments ? '#documents-content' : '#app-content-files',
+		attachTo = odfViewer.isDocuments ? '#documents-content' : '#controls',
 		attachToolbarTo = odfViewer.isDocuments ? '#content-wrapper' : '#controls';
 
 		if (odfViewer.isDocuments){


### PR DESCRIPTION
# app-content-files takes the whole page size so the document content should be displayed inside it  (not below).
