### PR TITLE
Removed call to FileActions.display()

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -34,9 +34,6 @@ var odfViewer = {
 					odfViewer.onEdit
 			);
 		}
-		$('#fileList tr').each(function () {
-			OCA.Files.fileActions.display($(this).children('td.filename'));
-		});
 	},
 	
 	dispatch : function(filename){


### PR DESCRIPTION
Let the file lists automatically update themselves from the previous
calls to FileActions.register().

Note: https://github.com/owncloud/core/pull/9254 must be merged first into core for this to work.

Fixes #275

@VicDeo please review
