### PR TITLE
Use context instead of static access

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -46,8 +46,8 @@ var odfViewer = {
 		}
 	},
 	
-	onEdit : function(){
-		var fileId = OCA.Files.fileActions.currentFile.parent().attr('data-id');
+	onEdit : function(fileName, context){
+		var fileId = context.$file.attr('data-id');
 		window.location = OC.linkTo('documents', 'index.php') + '#' + fileId;
 	},
 			


### PR DESCRIPTION
@VicDeo this fix will be required soon as I'm fixing FileActions stuff.

We should avoid static access to attributes of fileActions in the future.
