### PR TITLE
Set home directory for libreoffice conversion

### DIFF
--- a/lib/converter.php
+++ b/lib/converter.php
@@ -49,6 +49,7 @@ class Converter {
 		$params = ' --headless --convert-to ' . $targetFilter . ' --outdir ' 
 				. escapeshellarg($outdir) 
 				. ' --writer '. escapeshellarg($infile)
+				. ' -env:UserInstallation=file://' . get_temp_dir()
 		;
 		
 		file_put_contents($infile, $input);


### PR DESCRIPTION
Fixes https://github.com/owncloud/documents/issues/291#issuecomment-48953083

I use owncloud's get_temp_dir() because \OCP\Files::tmpFolder(); would change every call. This would be alot of wasted IO + CPU because the 1MB+ user directory would need to be created repeatedly.
