### PR TITLE
Remove unused argument

### DIFF
--- a/ajax/sessionController.php
+++ b/ajax/sessionController.php
@@ -23,7 +23,7 @@ class SessionController extends Controller{
 		try {
 			$token = Helper::getArrayValueByKey($args, 'token');
 			$file = File::getByShareToken($token);
-			$session = Db\Session::start($uid, $file, true);
+			$session = Db\Session::start($uid, $file);
 			\OCP\JSON::success($session);
 		} catch (\Exception $e){
 			Helper::warnLog('Starting a session failed. Reason: ' . $e->getMessage());


### PR DESCRIPTION
This `true` is a leftover. 
`Db\Session::start` takes two parameters only for a long time.
