### PR TITLE
Do not localize the internal (javascript) name of action "Edit"

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -28,10 +28,11 @@ var odfViewer = {
 			var mime = odfViewer.supportedMimesUpdate[i];
 			OCA.Files.fileActions.register(
 					mime, 
-					t('documents', 'Edit'), 
+					'Edit',
 					OC.PERMISSION_UPDATE, 
 					OC.imagePath('core', 'actions/rename'), 
-					odfViewer.onEdit
+					odfViewer.onEdit,
+					t('documents', 'Edit')
 			);
 		}
 	},


### PR DESCRIPTION
When installing file actions, the viewer currently passes the name of the "Edit" action through t() and inserts the localized/translated string in the generated HTML code (instead of the original action name). This prevents the action from working on systems that use a non-english locale. I have moved the t() call into the displayName argument, where it belongs.
