### PR TITLE
Connection lost notice was invisible and misplaced

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -222,7 +222,10 @@
 }
 
 #warning-connection-lost{
-	padding: 6px 0;
+	position: relative;
+	z-index: 2000;
+	margin-top: 35px;
+	padding: 8px 0;
 	text-align: center;
 	color: #ffffff;
 	background-color: #CE7070;


### PR DESCRIPTION
Before: dimmed toolbar and nothing on it:
![broken](https://cloud.githubusercontent.com/assets/991300/4534271/c9856aa6-4da3-11e4-88c7-7db132eec1de.png)

After:
![fixed](https://cloud.githubusercontent.com/assets/991300/4534281/e095215a-4da3-11e4-82f5-ebeb17f23fb4.png)
