### PR TITLE
fix target format for external format-filter-server

### DIFF
--- a/lib/converter.php
+++ b/lib/converter.php
@@ -30,7 +30,7 @@ class Converter {
 	
 	public static function checkConnection(){
 		$expected = file_get_contents(__DIR__ . '/response.odt');
-		$converted = self::convertExternal('', 'application/vnd.oasis.opendocument.text');
+		$converted = self::convertExternal('', 'odt');
 		
 		return $converted === $expected;
 	}


### PR DESCRIPTION
According to https://github.com/owncloud/format-filter-server/blob/cc435eac37fb6e67f73fb47d404281c59aa49bd7/code/conversion.js#L17 the target_format should be "odt".

The format-filter-server returns an empty response otherwise.
