### PR TITLE
Show active sessions in bold.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,11 +82,8 @@
 	background-color: #ddd;
 }
 
-.documentslist .session-active {
-	position: relative;
-	margin-left: 128px;
-	margin-top: 128px;
-	width: 32px;
+.documentslist .session label {
+	font-weight: bold;
 }
 .document a {
 	display: block;

--- a/js/documents.js
+++ b/js/documents.js
@@ -109,7 +109,6 @@ $.widget('oc.documentGrid', {
 				var docElem = $(that.options.context + ' .document[data-id="'+session.file_id+'"]');
 				if (docElem.length > 0) {
 					docElem.attr('data-esid', session.es_id);
-					docElem.find('label').after('<img class="svg session-active" src="'+OC.imagePath('core','places/contacts-dark')+'">');
 					docElem.addClass('session');
 				} else {
 					console.log('Could not find file '+session.file_id+' for session '+session.es_id);


### PR DESCRIPTION
Before 
![session-active1](https://cloud.githubusercontent.com/assets/991300/4664454/11bceca2-5544-11e4-8aab-35bb8b549e96.png)

After
![session-active](https://cloud.githubusercontent.com/assets/991300/4664456/177080f0-5544-11e4-9566-27059eee5936.png)

 Fixes #84
