### PR TITLE
Previews improvements

### DIFF
--- a/index.php
+++ b/index.php
@@ -41,11 +41,12 @@ namespace OCA\Documents;
 
 $tmpl = new \OCP\Template('documents', 'documents', 'user');
 
+$previewsEnabled = \OC::$server->getConfig()->getSystemValue('enable_previews', false);
 $unstable = \OCP\Config::getAppValue('documents', 'unstable', 'false');
 $maxUploadFilesize = \OCP\Util::maxUploadFilesize("/");
 $savePath = \OCP\Config::getUserValue(\OCP\User::getUser(), 'documents', 'save_path', '/');
 
-
+$tmpl->assign('enable_previews', $previewsEnabled);
 $tmpl->assign('useUnstable', $unstable);
 $tmpl->assign('uploadMaxFilesize', $maxUploadFilesize);
 $tmpl->assign('uploadMaxHumanFilesize', \OCP\Util::humanFileSize($maxUploadFilesize));

--- a/js/documents.js
+++ b/js/documents.js
@@ -70,7 +70,9 @@ $.widget('oc.documentGrid', {
 			}(a);
 			ready(previewURL);
 		};
-		img.src = previewURL;
+		if ( $('#previews_enabled').length ) {
+			img.src = previewURL;
+		}
 	},
 	
 	_load : function (){

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -35,4 +35,7 @@
 	</ul>
 </div>
 <input type="hidden" id="webodf-unstable" value="<?php p($_['useUnstable']) ?>" />
+<?php if ($_['enable_previews']): ?>
+<input type="hidden" id="previews_enabled" value="<?php p($_['enable_previews']) ?>" />
+<?php endif; ?>
 <input type="hidden" name="allowShareWithLink" id="allowShareWithLink" value="<?php p($_['allowShareWithLink']) ?>" />


### PR DESCRIPTION
Do not load previews when `enable_previews` is disabled in config.
Ref https://github.com/owncloud/documents/issues/425