### PR TITLE
Enable previews by default. Skip loading if disabled

### DIFF
--- a/index.php
+++ b/index.php
@@ -41,7 +41,7 @@ namespace OCA\Documents;
 
 $tmpl = new \OCP\Template('documents', 'documents', 'user');
 
-$previewsEnabled = \OC::$server->getConfig()->getSystemValue('enable_previews', false);
+$previewsEnabled = \OC::$server->getConfig()->getSystemValue('enable_previews', true);
 $unstable = \OCP\Config::getAppValue('documents', 'unstable', 'false');
 $maxUploadFilesize = \OCP\Util::maxUploadFilesize("/");
 $savePath = \OCP\Config::getUserValue(\OCP\User::getUser(), 'documents', 'save_path', '/');

--- a/js/documents.js
+++ b/js/documents.js
@@ -60,17 +60,17 @@ $.widget('oc.documentGrid', {
 
 		previewURL = OC.generateUrl('/core/preview.png?') + $.param(urlSpec);
 		previewURL = previewURL.replace('(', '%28').replace(')', '%29');
-
-		var img = new Image();
-		img.onload = function(){
-			var ready = function (node){
-				return function(path){
-					node.css('background-image', 'url("'+ path +'")');
-				}; 
-			}(a);
-			ready(previewURL);
-		};
+		
 		if ( $('#previews_enabled').length ) {
+			var img = new Image();
+			img.onload = function(){
+				var ready = function (node){
+					return function(path){
+						node.css('background-image', 'url("'+ path +'")');
+					}; 
+				}(a);
+				ready(previewURL);
+			};
 			img.src = previewURL;
 		}
 	},


### PR DESCRIPTION
Enable previews in documents by default. (Like Files app does)
Fixes https://github.com/owncloud/documents/issues/451 
