### PR TITLE
Encode token in viewer

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -63,7 +63,7 @@ var odfViewer = {
 			//Public page, files app, etc
 			var dirName = $('#dir').val()!='/' ? $('#dir').val() + '/' : '/';
 			var location = OC.filePath('documents', 'ajax', 'download.php') + '?path=' + encodeURIComponent(dirName) + encodeURIComponent(filename)
-			 + '&requesttoken=' + oc_requesttoken;
+			 + '&requesttoken=' + encodeURIComponent(oc_requesttoken);
 			OC.addStyle('documents', '3rdparty/webodf/editor');
 		}
 		


### PR DESCRIPTION
Fixes broken viewer when request token has unsafe characters
Ref https://github.com/owncloud/documents/issues/463