### PR TITLE
Make sure the users storages are setup

### DIFF
--- a/lib/downloadresponse.php
+++ b/lib/downloadresponse.php
@@ -11,6 +11,7 @@
 
 namespace OCA\Documents;
 
+use OC\Files\Filesystem;
 use \OCP\AppFramework\Http;
 use \OCP\IRequest;
 use \OC\Files\View;
@@ -29,7 +30,8 @@ class DownloadResponse extends \OCP\AppFramework\Http\Response {
 		$this->request = $request;
 		$this->user = $user;
 		$this->path = $path;
-		
+
+		Filesystem::initMountPoints($user);
 		$this->view = new View('/' . $user);
 		if (!$this->view->file_exists($path)){
 			$this->setStatus(Http::STATUS_NOT_FOUND);

--- a/tests/controller/documentcontrollertest.php
+++ b/tests/controller/documentcontrollertest.php
@@ -51,6 +51,9 @@ class DocumentControllerTest extends \PHPUnit_Framework_TestCase {
 		\OC_Util::setupFS();
 	}
 	
+	/**
+	 * @expectedException \OCP\Files\NotFoundException
+	 */
 	public function testRename(){
 		$result = array(
 			'status' => 'error',
@@ -61,7 +64,6 @@ class DocumentControllerTest extends \PHPUnit_Framework_TestCase {
 			'name' => 'newname.ext'
 		);
 		$response = $this->controller->rename(500);
-		$this->assertEquals($result, $response);
 	}
 	
 	public function testCreate(){


### PR DESCRIPTION
Tested by manually changing the `getHome` implementation to make the home folder not be the same as `$uid.

Replaces #568