### PR TITLE
Fix user value set (fix #600)

### DIFF
--- a/lib/appconfig.php
+++ b/lib/appconfig.php
@@ -80,7 +80,6 @@ use \OCP\IConfig;
 	 * @return string
 	 */
 	public function setUserValue($userId, $key, $value) {
-		return $this->config->setAppValue($userId, $this->appName, $key, $value);
+		return $this->config->setUserValue($userId, $this->appName, $key, $value);
 	}
  }
- 


### PR DESCRIPTION
Also, should it not be useful to catch exception as it was done before in [Config](https://github.com/owncloud/core/blob/master/lib/public/config.php#L156-L161) but not anymore in [IConfig](https://github.com/owncloud/core/blob/master/lib/private/allconfig.php#L257) - if I understand well - [here](https://github.com/owncloud/documents/blob/master/lib/appconfig.php#L83)?
That way, a boolean could be returned and it could be used to know if the value has been set or not...